### PR TITLE
test(Tag): use react-testing-library instead of enzyme

### DIFF
--- a/src/Tag/__tests__/Tag.test.js
+++ b/src/Tag/__tests__/Tag.test.js
@@ -4,15 +4,15 @@ import 'jest-styled-components';
 import Tag from '..';
 
 describe('<Tag />', () => {
-  it('should render withouth a problem', () => {
-    const render = shallowWithTheme(<Tag />);
+  test('should render withouth a problem', () => {
+    const { container } = render(<Tag />);
 
-    expect(render.dive()).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('should have a color', () => {
-    const render = shallowWithTheme(<Tag color="red" />);
+  test('should have a color', () => {
+    const { getByTestId } = render(<Tag color="red" />);
 
-    expect(render.dive()).toMatchSnapshot();
+    expect(getByTestId('tag')).toHaveStyleRule('background', 'red');
   });
 });

--- a/src/Tag/__tests__/__snapshots__/Tag.test.js.snap
+++ b/src/Tag/__tests__/__snapshots__/Tag.test.js.snap
@@ -1,20 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Tag /> should have a color 1`] = `
-.c0 {
-  position: relative;
-  display: inline-block;
-  padding: 0.2rem 0.8rem 0.4rem;
-  border-radius: 0.5rem;
-  color: hsl(0,100%,100%);
-  background: red;
-}
-
-<div
-  className="c0"
-/>
-`;
-
 exports[`<Tag /> should render withouth a problem 1`] = `
 .c0 {
   position: relative;
@@ -25,6 +10,7 @@ exports[`<Tag /> should render withouth a problem 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
+  data-testid="tag"
 />
 `;

--- a/src/Tag/index.js
+++ b/src/Tag/index.js
@@ -16,7 +16,7 @@ import styled from 'styled-components';
  */
 
 const Tag = ({ children, className, color, ...rest }) => (
-  <div className={className} {...rest}>
+  <div className={className} {...rest} data-testid="tag">
     {children}
   </div>
 );


### PR DESCRIPTION
- [ ] Feature
- [ ] Fix
- [x] Enhancement

## Description
Refactor`<Tag /> unit test with [react-testing-library](https://github.com/kentcdodds/react-testing-library) instead of [Enzyme](https://github.com/airbnb/enzyme/). 

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.

close #271 