### PR TITLE
test(Logo) use react-testing-library instead of enzyme

### DIFF
--- a/src/Logo/__tests__/Logo.test.js
+++ b/src/Logo/__tests__/Logo.test.js
@@ -4,19 +4,19 @@ import 'jest-styled-components';
 import Logo from '..';
 
 describe('<Logo />', () => {
-  it('should render withouth a problem', () => {
+  test('should render withouth a problem', () => {
     const { container } = render(<Logo />);
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('should render with custom width & height', () => {
+  test('should render with custom width & height', () => {
     const { getByTestId } = render(<Logo width="300" height="80" />);
     const logoNode = getByTestId('logo');
     expect(logoNode).toHaveAttribute('width', '300');
     expect(logoNode).toHaveAttribute('height', '80');
   });
 
-  it('should render with custom color', () => {
+  test('should render with custom color', () => {
     const color = 'hsl(217, 89%, 61%)';
     const { getByTestId } = render(<Logo color={color} />);
     const logoPathNode = getByTestId('logoPath');


### PR DESCRIPTION
- [ ] Feature
- [ ] Fix
- [x] Enhancement

## Description
Refactor unit test with [react-testing-library](https://github.com/kentcdodds/react-testing-library) instead of [Enzyme](https://github.com/airbnb/enzyme/).

## Todo - Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.