### PR TITLE
 refactor(ButtonGroup): check child.type.displayName instead of child.displayName

### DIFF
--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -110,4 +110,8 @@ Button.defaultProps = {
   type: 'button',
 };
 
-export default styled(Button)``;
+const styledButton = styled(Button)``;
+
+styledButton.displayName = 'Button';
+
+export default styledButton;

--- a/src/ButtonGroup/index.js
+++ b/src/ButtonGroup/index.js
@@ -79,7 +79,7 @@ class ButtonGroup extends PureComponent {
           if (child.props.disabled) {
             return child;
           }
-          if (child.type !== Button) {
+          if (child.type.displayName !== 'Button') {
             return child;
           }
           if (!child.props.name) {

--- a/src/Date/DatePicker/__tests__/__snapshots__/DatePicker.test.js.snap
+++ b/src/Date/DatePicker/__tests__/__snapshots__/DatePicker.test.js.snap
@@ -291,7 +291,7 @@ exports[`<DatePicker /> should handle date hover 1`] = `
         <div
           className="c1"
         >
-          <Styled(Button)
+          <Button
             appearance="secondary"
             disabled={false}
             onClick={[Function]}
@@ -378,7 +378,7 @@ exports[`<DatePicker /> should handle date hover 1`] = `
                 </button>
               </styled.button>
             </Button>
-          </Styled(Button)>
+          </Button>
           <styled.div>
             <div
               className="c4"
@@ -386,7 +386,7 @@ exports[`<DatePicker /> should handle date hover 1`] = `
               July 2018
             </div>
           </styled.div>
-          <Styled(Button)
+          <Button
             appearance="secondary"
             disabled={false}
             onClick={[Function]}
@@ -473,7 +473,7 @@ exports[`<DatePicker /> should handle date hover 1`] = `
                 </button>
               </styled.button>
             </Button>
-          </Styled(Button)>
+          </Button>
         </div>
       </styled.div>
       <Styled(WeekdayNames)
@@ -2837,7 +2837,7 @@ exports[`<DatePicker /> should handle date hover 2`] = `
         <div
           className="c1"
         >
-          <Styled(Button)
+          <Button
             appearance="secondary"
             disabled={false}
             onClick={[Function]}
@@ -2924,7 +2924,7 @@ exports[`<DatePicker /> should handle date hover 2`] = `
                 </button>
               </styled.button>
             </Button>
-          </Styled(Button)>
+          </Button>
           <styled.div>
             <div
               className="c4"
@@ -2932,7 +2932,7 @@ exports[`<DatePicker /> should handle date hover 2`] = `
               July 2018
             </div>
           </styled.div>
-          <Styled(Button)
+          <Button
             appearance="secondary"
             disabled={false}
             onClick={[Function]}
@@ -3019,7 +3019,7 @@ exports[`<DatePicker /> should handle date hover 2`] = `
                 </button>
               </styled.button>
             </Button>
-          </Styled(Button)>
+          </Button>
         </div>
       </styled.div>
       <Styled(WeekdayNames)
@@ -5389,7 +5389,7 @@ exports[`<DatePicker /> should handle date hover 3`] = `
         <div
           className="c1"
         >
-          <Styled(Button)
+          <Button
             appearance="secondary"
             disabled={false}
             onClick={[Function]}
@@ -5476,7 +5476,7 @@ exports[`<DatePicker /> should handle date hover 3`] = `
                 </button>
               </styled.button>
             </Button>
-          </Styled(Button)>
+          </Button>
           <styled.div>
             <div
               className="c4"
@@ -5484,7 +5484,7 @@ exports[`<DatePicker /> should handle date hover 3`] = `
               July 2018
             </div>
           </styled.div>
-          <Styled(Button)
+          <Button
             appearance="secondary"
             disabled={false}
             onClick={[Function]}
@@ -5571,7 +5571,7 @@ exports[`<DatePicker /> should handle date hover 3`] = `
                 </button>
               </styled.button>
             </Button>
-          </Styled(Button)>
+          </Button>
         </div>
       </styled.div>
       <Styled(WeekdayNames)
@@ -7925,7 +7925,7 @@ exports[`<DatePicker /> should handle date selection 1`] = `
         <div
           className="c1"
         >
-          <Styled(Button)
+          <Button
             appearance="secondary"
             disabled={false}
             onClick={[Function]}
@@ -8012,7 +8012,7 @@ exports[`<DatePicker /> should handle date selection 1`] = `
                 </button>
               </styled.button>
             </Button>
-          </Styled(Button)>
+          </Button>
           <styled.div>
             <div
               className="c4"
@@ -8020,7 +8020,7 @@ exports[`<DatePicker /> should handle date selection 1`] = `
               July 2018
             </div>
           </styled.div>
-          <Styled(Button)
+          <Button
             appearance="secondary"
             disabled={false}
             onClick={[Function]}
@@ -8107,7 +8107,7 @@ exports[`<DatePicker /> should handle date selection 1`] = `
                 </button>
               </styled.button>
             </Button>
-          </Styled(Button)>
+          </Button>
         </div>
       </styled.div>
       <Styled(WeekdayNames)
@@ -10461,7 +10461,7 @@ exports[`<DatePicker /> should handle date selection 2`] = `
         <div
           className="c1"
         >
-          <Styled(Button)
+          <Button
             appearance="secondary"
             disabled={false}
             onClick={[Function]}
@@ -10548,7 +10548,7 @@ exports[`<DatePicker /> should handle date selection 2`] = `
                 </button>
               </styled.button>
             </Button>
-          </Styled(Button)>
+          </Button>
           <styled.div>
             <div
               className="c4"
@@ -10556,7 +10556,7 @@ exports[`<DatePicker /> should handle date selection 2`] = `
               July 2018
             </div>
           </styled.div>
-          <Styled(Button)
+          <Button
             appearance="secondary"
             disabled={false}
             onClick={[Function]}
@@ -10643,7 +10643,7 @@ exports[`<DatePicker /> should handle date selection 2`] = `
                 </button>
               </styled.button>
             </Button>
-          </Styled(Button)>
+          </Button>
         </div>
       </styled.div>
       <Styled(WeekdayNames)
@@ -12967,7 +12967,7 @@ exports[`<DatePicker /> should handle next month 1`] = `
         <div
           className="c1"
         >
-          <Styled(Button)
+          <Button
             appearance="secondary"
             disabled={false}
             onClick={[Function]}
@@ -13054,7 +13054,7 @@ exports[`<DatePicker /> should handle next month 1`] = `
                 </button>
               </styled.button>
             </Button>
-          </Styled(Button)>
+          </Button>
           <styled.div>
             <div
               className="c4"
@@ -13062,7 +13062,7 @@ exports[`<DatePicker /> should handle next month 1`] = `
               June 2018
             </div>
           </styled.div>
-          <Styled(Button)
+          <Button
             appearance="secondary"
             disabled={false}
             onClick={[Function]}
@@ -13149,7 +13149,7 @@ exports[`<DatePicker /> should handle next month 1`] = `
                 </button>
               </styled.button>
             </Button>
-          </Styled(Button)>
+          </Button>
         </div>
       </styled.div>
       <Styled(WeekdayNames)
@@ -15173,7 +15173,7 @@ exports[`<DatePicker /> should handle next month 2`] = `
         <div
           className="c1"
         >
-          <Styled(Button)
+          <Button
             appearance="secondary"
             disabled={false}
             onClick={[Function]}
@@ -15260,7 +15260,7 @@ exports[`<DatePicker /> should handle next month 2`] = `
                 </button>
               </styled.button>
             </Button>
-          </Styled(Button)>
+          </Button>
           <styled.div>
             <div
               className="c4"
@@ -15268,7 +15268,7 @@ exports[`<DatePicker /> should handle next month 2`] = `
               July 2018
             </div>
           </styled.div>
-          <Styled(Button)
+          <Button
             appearance="secondary"
             disabled={false}
             onClick={[Function]}
@@ -15355,7 +15355,7 @@ exports[`<DatePicker /> should handle next month 2`] = `
                 </button>
               </styled.button>
             </Button>
-          </Styled(Button)>
+          </Button>
         </div>
       </styled.div>
       <Styled(WeekdayNames)
@@ -17679,7 +17679,7 @@ exports[`<DatePicker /> should handle previous month 1`] = `
         <div
           className="c1"
         >
-          <Styled(Button)
+          <Button
             appearance="secondary"
             disabled={false}
             onClick={[Function]}
@@ -17766,7 +17766,7 @@ exports[`<DatePicker /> should handle previous month 1`] = `
                 </button>
               </styled.button>
             </Button>
-          </Styled(Button)>
+          </Button>
           <styled.div>
             <div
               className="c4"
@@ -17774,7 +17774,7 @@ exports[`<DatePicker /> should handle previous month 1`] = `
               June 2018
             </div>
           </styled.div>
-          <Styled(Button)
+          <Button
             appearance="secondary"
             disabled={false}
             onClick={[Function]}
@@ -17861,7 +17861,7 @@ exports[`<DatePicker /> should handle previous month 1`] = `
                 </button>
               </styled.button>
             </Button>
-          </Styled(Button)>
+          </Button>
         </div>
       </styled.div>
       <Styled(WeekdayNames)
@@ -19903,7 +19903,7 @@ exports[`<DatePicker /> should render withouth a problem 1`] = `
         <div
           className="c1"
         >
-          <Styled(Button)
+          <Button
             appearance="secondary"
             disabled={false}
             onClick={[Function]}
@@ -19990,7 +19990,7 @@ exports[`<DatePicker /> should render withouth a problem 1`] = `
                 </button>
               </styled.button>
             </Button>
-          </Styled(Button)>
+          </Button>
           <styled.div>
             <div
               className="c4"
@@ -19998,7 +19998,7 @@ exports[`<DatePicker /> should render withouth a problem 1`] = `
               July 2018
             </div>
           </styled.div>
-          <Styled(Button)
+          <Button
             appearance="secondary"
             disabled={false}
             onClick={[Function]}
@@ -20085,7 +20085,7 @@ exports[`<DatePicker /> should render withouth a problem 1`] = `
                 </button>
               </styled.button>
             </Button>
-          </Styled(Button)>
+          </Button>
         </div>
       </styled.div>
       <Styled(WeekdayNames)

--- a/src/Date/DateRangePicker/__tests__/__snapshots__/DateRangePicker.test.js.snap
+++ b/src/Date/DateRangePicker/__tests__/__snapshots__/DateRangePicker.test.js.snap
@@ -296,7 +296,7 @@ exports[`<DatePicker /> should handle date hover 1`] = `
             <div
               className="c1"
             >
-              <Styled(Button)
+              <Button
                 appearance="secondary"
                 disabled={false}
                 onClick={[Function]}
@@ -383,7 +383,7 @@ exports[`<DatePicker /> should handle date hover 1`] = `
                     </button>
                   </styled.button>
                 </Button>
-              </Styled(Button)>
+              </Button>
               <styled.div>
                 <div
                   className="c4"
@@ -2156,7 +2156,7 @@ exports[`<DatePicker /> should handle date hover 1`] = `
                   July 2018
                 </div>
               </styled.div>
-              <Styled(Button)
+              <Button
                 appearance="secondary"
                 disabled={false}
                 onClick={[Function]}
@@ -2243,7 +2243,7 @@ exports[`<DatePicker /> should handle date hover 1`] = `
                     </button>
                   </styled.button>
                 </Button>
-              </Styled(Button)>
+              </Button>
             </div>
           </styled.div>
           <Styled(WeekdayNames)
@@ -4612,7 +4612,7 @@ exports[`<DatePicker /> should handle date hover 2`] = `
             <div
               className="c1"
             >
-              <Styled(Button)
+              <Button
                 appearance="secondary"
                 disabled={false}
                 onClick={[Function]}
@@ -4699,7 +4699,7 @@ exports[`<DatePicker /> should handle date hover 2`] = `
                     </button>
                   </styled.button>
                 </Button>
-              </Styled(Button)>
+              </Button>
               <styled.div>
                 <div
                   className="c4"
@@ -6472,7 +6472,7 @@ exports[`<DatePicker /> should handle date hover 2`] = `
                   June 2018
                 </div>
               </styled.div>
-              <Styled(Button)
+              <Button
                 appearance="secondary"
                 disabled={false}
                 onClick={[Function]}
@@ -6559,7 +6559,7 @@ exports[`<DatePicker /> should handle date hover 2`] = `
                     </button>
                   </styled.button>
                 </Button>
-              </Styled(Button)>
+              </Button>
             </div>
           </styled.div>
           <Styled(WeekdayNames)
@@ -8613,7 +8613,7 @@ exports[`<DatePicker /> should handle date hover 3`] = `
             <div
               className="c1"
             >
-              <Styled(Button)
+              <Button
                 appearance="secondary"
                 disabled={false}
                 onClick={[Function]}
@@ -8700,7 +8700,7 @@ exports[`<DatePicker /> should handle date hover 3`] = `
                     </button>
                   </styled.button>
                 </Button>
-              </Styled(Button)>
+              </Button>
               <styled.div>
                 <div
                   className="c4"
@@ -10473,7 +10473,7 @@ exports[`<DatePicker /> should handle date hover 3`] = `
                   June 2018
                 </div>
               </styled.div>
-              <Styled(Button)
+              <Button
                 appearance="secondary"
                 disabled={false}
                 onClick={[Function]}
@@ -10560,7 +10560,7 @@ exports[`<DatePicker /> should handle date hover 3`] = `
                     </button>
                   </styled.button>
                 </Button>
-              </Styled(Button)>
+              </Button>
             </div>
           </styled.div>
           <Styled(WeekdayNames)
@@ -12592,7 +12592,7 @@ exports[`<DatePicker /> should handle date selection 1`] = `
             <div
               className="c1"
             >
-              <Styled(Button)
+              <Button
                 appearance="secondary"
                 disabled={false}
                 onClick={[Function]}
@@ -12679,7 +12679,7 @@ exports[`<DatePicker /> should handle date selection 1`] = `
                     </button>
                   </styled.button>
                 </Button>
-              </Styled(Button)>
+              </Button>
               <styled.div>
                 <div
                   className="c4"
@@ -14452,7 +14452,7 @@ exports[`<DatePicker /> should handle date selection 1`] = `
                   June 2018
                 </div>
               </styled.div>
-              <Styled(Button)
+              <Button
                 appearance="secondary"
                 disabled={false}
                 onClick={[Function]}
@@ -14539,7 +14539,7 @@ exports[`<DatePicker /> should handle date selection 1`] = `
                     </button>
                   </styled.button>
                 </Button>
-              </Styled(Button)>
+              </Button>
             </div>
           </styled.div>
           <Styled(WeekdayNames)
@@ -16562,7 +16562,7 @@ exports[`<DatePicker /> should handle date selection 2`] = `
             <div
               className="c1"
             >
-              <Styled(Button)
+              <Button
                 appearance="secondary"
                 disabled={false}
                 onClick={[Function]}
@@ -16649,7 +16649,7 @@ exports[`<DatePicker /> should handle date selection 2`] = `
                     </button>
                   </styled.button>
                 </Button>
-              </Styled(Button)>
+              </Button>
               <styled.div>
                 <div
                   className="c4"
@@ -18422,7 +18422,7 @@ exports[`<DatePicker /> should handle date selection 2`] = `
                   June 2018
                 </div>
               </styled.div>
-              <Styled(Button)
+              <Button
                 appearance="secondary"
                 disabled={false}
                 onClick={[Function]}
@@ -18509,7 +18509,7 @@ exports[`<DatePicker /> should handle date selection 2`] = `
                     </button>
                   </styled.button>
                 </Button>
-              </Styled(Button)>
+              </Button>
             </div>
           </styled.div>
           <Styled(WeekdayNames)
@@ -20551,7 +20551,7 @@ exports[`<DatePicker /> should handle date selection 3`] = `
             <div
               className="c1"
             >
-              <Styled(Button)
+              <Button
                 appearance="secondary"
                 disabled={false}
                 onClick={[Function]}
@@ -20638,7 +20638,7 @@ exports[`<DatePicker /> should handle date selection 3`] = `
                     </button>
                   </styled.button>
                 </Button>
-              </Styled(Button)>
+              </Button>
               <styled.div>
                 <div
                   className="c4"
@@ -22738,7 +22738,7 @@ exports[`<DatePicker /> should handle date selection 3`] = `
                   May 2018
                 </div>
               </styled.div>
-              <Styled(Button)
+              <Button
                 appearance="secondary"
                 disabled={false}
                 onClick={[Function]}
@@ -22825,7 +22825,7 @@ exports[`<DatePicker /> should handle date selection 3`] = `
                     </button>
                   </styled.button>
                 </Button>
-              </Styled(Button)>
+              </Button>
             </div>
           </styled.div>
           <Styled(WeekdayNames)
@@ -24837,7 +24837,7 @@ exports[`<DatePicker /> should handle next month 1`] = `
             <div
               className="c1"
             >
-              <Styled(Button)
+              <Button
                 appearance="secondary"
                 disabled={false}
                 onClick={[Function]}
@@ -24924,7 +24924,7 @@ exports[`<DatePicker /> should handle next month 1`] = `
                     </button>
                   </styled.button>
                 </Button>
-              </Styled(Button)>
+              </Button>
               <styled.div>
                 <div
                   className="c4"
@@ -26697,7 +26697,7 @@ exports[`<DatePicker /> should handle next month 1`] = `
                   June 2018
                 </div>
               </styled.div>
-              <Styled(Button)
+              <Button
                 appearance="secondary"
                 disabled={false}
                 onClick={[Function]}
@@ -26784,7 +26784,7 @@ exports[`<DatePicker /> should handle next month 1`] = `
                     </button>
                   </styled.button>
                 </Button>
-              </Styled(Button)>
+              </Button>
             </div>
           </styled.div>
           <Styled(WeekdayNames)
@@ -28815,7 +28815,7 @@ exports[`<DatePicker /> should handle next month 2`] = `
             <div
               className="c1"
             >
-              <Styled(Button)
+              <Button
                 appearance="secondary"
                 disabled={false}
                 onClick={[Function]}
@@ -28902,7 +28902,7 @@ exports[`<DatePicker /> should handle next month 2`] = `
                     </button>
                   </styled.button>
                 </Button>
-              </Styled(Button)>
+              </Button>
               <styled.div>
                 <div
                   className="c4"
@@ -30675,7 +30675,7 @@ exports[`<DatePicker /> should handle next month 2`] = `
                   July 2018
                 </div>
               </styled.div>
-              <Styled(Button)
+              <Button
                 appearance="secondary"
                 disabled={false}
                 onClick={[Function]}
@@ -30762,7 +30762,7 @@ exports[`<DatePicker /> should handle next month 2`] = `
                     </button>
                   </styled.button>
                 </Button>
-              </Styled(Button)>
+              </Button>
             </div>
           </styled.div>
           <Styled(WeekdayNames)
@@ -33101,7 +33101,7 @@ exports[`<DatePicker /> should handle previous month 1`] = `
             <div
               className="c1"
             >
-              <Styled(Button)
+              <Button
                 appearance="secondary"
                 disabled={false}
                 onClick={[Function]}
@@ -33188,7 +33188,7 @@ exports[`<DatePicker /> should handle previous month 1`] = `
                     </button>
                   </styled.button>
                 </Button>
-              </Styled(Button)>
+              </Button>
               <styled.div>
                 <div
                   className="c4"
@@ -34961,7 +34961,7 @@ exports[`<DatePicker /> should handle previous month 1`] = `
                   June 2018
                 </div>
               </styled.div>
-              <Styled(Button)
+              <Button
                 appearance="secondary"
                 disabled={false}
                 onClick={[Function]}
@@ -35048,7 +35048,7 @@ exports[`<DatePicker /> should handle previous month 1`] = `
                     </button>
                   </styled.button>
                 </Button>
-              </Styled(Button)>
+              </Button>
             </div>
           </styled.div>
           <Styled(WeekdayNames)
@@ -37168,7 +37168,7 @@ exports[`<DatePicker /> should render withouth a problem 1`] = `
             <div
               className="c1"
             >
-              <Styled(Button)
+              <Button
                 appearance="secondary"
                 disabled={true}
                 onClick={[Function]}
@@ -37255,7 +37255,7 @@ exports[`<DatePicker /> should render withouth a problem 1`] = `
                     </button>
                   </styled.button>
                 </Button>
-              </Styled(Button)>
+              </Button>
               <styled.div>
                 <div
                   className="c4"
@@ -39028,7 +39028,7 @@ exports[`<DatePicker /> should render withouth a problem 1`] = `
                   July 2018
                 </div>
               </styled.div>
-              <Styled(Button)
+              <Button
                 appearance="secondary"
                 disabled={false}
                 onClick={[Function]}
@@ -39115,7 +39115,7 @@ exports[`<DatePicker /> should render withouth a problem 1`] = `
                     </button>
                   </styled.button>
                 </Button>
-              </Styled(Button)>
+              </Button>
             </div>
           </styled.div>
           <Styled(WeekdayNames)

--- a/src/Form/__tests__/__snapshots__/Form.test.js.snap
+++ b/src/Form/__tests__/__snapshots__/Form.test.js.snap
@@ -4358,11 +4358,12 @@ exports[`<Form /> should render withouth a problem 1`] = `
                             <div
                               className=""
                             >
-                              <Styled(Button)
+                              <Button
                                 _onBlur={[Function]}
                                 _onFocus={[Function]}
                                 key=".0"
                                 primary={true}
+                                type="submit"
                               >
                                 <Button
                                   _onBlur={[Function]}
@@ -4376,7 +4377,7 @@ exports[`<Form /> should render withouth a problem 1`] = `
                                   onClick={[Function]}
                                   primary={true}
                                   size="default"
-                                  type="button"
+                                  type="submit"
                                 >
                                   <styled.button
                                     _onBlur={[Function]}
@@ -4390,7 +4391,7 @@ exports[`<Form /> should render withouth a problem 1`] = `
                                     onClick={[Function]}
                                     primary={true}
                                     size="default"
-                                    type="button"
+                                    type="submit"
                                   >
                                     <button
                                       className="c8"
@@ -4398,13 +4399,13 @@ exports[`<Form /> should render withouth a problem 1`] = `
                                       icon={null}
                                       onClick={[Function]}
                                       size="default"
-                                      type="button"
+                                      type="submit"
                                     >
                                       Hello
                                     </button>
                                   </styled.button>
                                 </Button>
-                              </Styled(Button)>
+                              </Button>
                             </div>
                           </styled.div>
                         </div>

--- a/src/KpiChart/__tests__/__snapshots__/KpiChart.test.js.snap
+++ b/src/KpiChart/__tests__/__snapshots__/KpiChart.test.js.snap
@@ -135,7 +135,7 @@ exports[`<KpiChart /> should render with render props 1`] = `
         <div
           className="c4"
         >
-          <Styled(Button)
+          <Button
             ghost={true}
           >
             <Button
@@ -174,7 +174,7 @@ exports[`<KpiChart /> should render with render props 1`] = `
                 </button>
               </styled.button>
             </Button>
-          </Styled(Button)>
+          </Button>
         </div>
       </styled.div>
     </div>
@@ -312,7 +312,7 @@ exports[`<KpiChart /> should render withouth a problem 1`] = `
         <div
           className="c4"
         >
-          <Styled(Button)
+          <Button
             ghost={true}
           >
             <Button
@@ -351,7 +351,7 @@ exports[`<KpiChart /> should render withouth a problem 1`] = `
                 </button>
               </styled.button>
             </Button>
-          </Styled(Button)>
+          </Button>
         </div>
       </styled.div>
     </div>


### PR DESCRIPTION
- [ ] Feature
- [ ] Fix
- [x] Enhancement

## Description
In `<ButtonGroup />` we  check `child.type.displayName` instead of just `child.displayName` beacause od styled-components

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
