### PR TITLE
test(Loader): use react-testing-library instead of enzyme

### DIFF
--- a/src/Loader/__tests__/Loader.test.js
+++ b/src/Loader/__tests__/Loader.test.js
@@ -1,25 +1,27 @@
-import 'jest-styled-components';
 import React from 'react';
 
 import Loader from '..';
 import Theme from '../../Theme';
 
 describe('<Loader />', () => {
-  it('should render without a problem ', () => {
-    const render = shallow(<Loader />);
+  test('should render without a problem ', () => {
+    const { container } = render(<Loader />);
 
-    expect(render.dive()).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('should render with another size ', () => {
-    const render = shallow(<Loader width="4rem" height="4rem" />);
+  test('should render with another size ', () => {
+    const size = '4rem';
+    const { container } = render(<Loader width={size} height={size} />);
 
-    expect(render.dive()).toMatchSnapshot();
+    expect(container.firstChild).toHaveAttribute('width', size);
+    expect(container.firstChild).toHaveAttribute('height', size);
   });
 
-  it('should render with another color ', () => {
-    const render = shallow(<Loader color={Theme.palette.failure.default} />);
+  test('should render with another color ', () => {
+    const { getByTestId } = render(<Loader color={Theme.palette.failure.default} />);
+    const circleShapeNode = getByTestId('circleShape');
 
-    expect(render.dive()).toMatchSnapshot();
+    expect(circleShapeNode).toHaveAttribute('stroke', Theme.palette.failure.default);
   });
 });

--- a/src/Loader/__tests__/__snapshots__/Loader.test.js.snap
+++ b/src/Loader/__tests__/__snapshots__/Loader.test.js.snap
@@ -1,69 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Loader /> should render with another color  1`] = `
-.c0 {
-  -webkit-animation: rotate 1.4s linear infinite;
-  animation: rotate 1.4s linear infinite;
-  display: block;
-}
-
-.c0 .path {
-  stroke-linecap: round;
-  -webkit-animation: dash 1.4s ease-in-out infinite;
-  animation: dash 1.4s ease-in-out infinite;
-}
-
-<svg
-  aria-hidden="true"
-  className="c0"
-  height="2rem"
-  viewBox="0 0 50 50"
-  width="2rem"
->
-  <circle
-    className="path"
-    cx="25"
-    cy="25"
-    fill="none"
-    r="20"
-    stroke="hsl(6, 79%, 65%)"
-    strokeWidth="4"
-  />
-</svg>
-`;
-
-exports[`<Loader /> should render with another size  1`] = `
-.c0 {
-  -webkit-animation: rotate 1.4s linear infinite;
-  animation: rotate 1.4s linear infinite;
-  display: block;
-}
-
-.c0 .path {
-  stroke-linecap: round;
-  -webkit-animation: dash 1.4s ease-in-out infinite;
-  animation: dash 1.4s ease-in-out infinite;
-}
-
-<svg
-  aria-hidden="true"
-  className="c0"
-  height="4rem"
-  viewBox="0 0 50 50"
-  width="4rem"
->
-  <circle
-    className="path"
-    cx="25"
-    cy="25"
-    fill="none"
-    r="20"
-    stroke="hsl(200, 74%, 46%)"
-    strokeWidth="4"
-  />
-</svg>
-`;
-
 exports[`<Loader /> should render without a problem  1`] = `
 .c0 {
   -webkit-animation: rotate 1.4s linear infinite;
@@ -79,19 +15,20 @@ exports[`<Loader /> should render without a problem  1`] = `
 
 <svg
   aria-hidden="true"
-  className="c0"
+  class="c0"
   height="2rem"
   viewBox="0 0 50 50"
   width="2rem"
 >
   <circle
-    className="path"
+    class="path"
     cx="25"
     cy="25"
+    data-testid="circleShape"
     fill="none"
     r="20"
     stroke="hsl(200, 74%, 46%)"
-    strokeWidth="4"
+    stroke-width="4"
   />
 </svg>
 `;

--- a/src/Loader/index.js
+++ b/src/Loader/index.js
@@ -20,7 +20,16 @@ import Theme from '../Theme';
 
 const Loader = ({ className, color, width, height }) => (
   <svg className={className} viewBox="0 0 50 50" width={width} height={height} aria-hidden="true">
-    <circle className="path" cx="25" cy="25" r="20" fill="none" stroke={color} strokeWidth="4" />
+    <circle
+      className="path"
+      cx="25"
+      cy="25"
+      r="20"
+      fill="none"
+      stroke={color}
+      strokeWidth="4"
+      data-testid="circleShape"
+    />
   </svg>
 );
 


### PR DESCRIPTION
- [ ] Feature
- [ ] Fix
- [x] Enhancement

## Description
Refactor`<Loader /> unit test with [react-testing-library](https://github.com/kentcdodds/react-testing-library) instead of [Enzyme](https://github.com/airbnb/enzyme/). 

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.

close #263