### PR TITLE
test(ToggleButton): use react-testing-library instead of enzyme

### DIFF
--- a/src/ToggleButton/__tests__/ToggleButton.test.js
+++ b/src/ToggleButton/__tests__/ToggleButton.test.js
@@ -1,87 +1,56 @@
-import React, { PureComponent } from 'react';
-import 'jest-styled-components';
+import React from 'react';
+import { fireEvent } from 'react-testing-library';
 
 import ToggleButton from '..';
 
 describe('<ToggleButton />', () => {
-  it('should render without a problem', () => {
-    const render = shallowWithTheme(<ToggleButton />);
+  test('should render without a problem', () => {
+    const { container } = render(<ToggleButton />);
 
-    expect(render.dive()).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('should render without a problem when checked and disabled', () => {
-    const render = shallowWithTheme(<ToggleButton checked disabled />);
+  test('should render without a problem when checked', () => {
+    const { container } = render(<ToggleButton checked />);
 
-    expect(render.dive()).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('should render without a problem when unchecked and disabled', () => {
-    const render = shallowWithTheme(<ToggleButton checked={false} disabled />);
+  test('should render without a problem when disabled', () => {
+    const { container, getByTestId } = render(<ToggleButton disabled />);
+    const toggleNode = getByTestId('toggle-button');
 
-    expect(render.dive()).toMatchSnapshot();
+    expect(container.firstChild).toHaveStyleRule('cursor', 'not-allowed');
+    expect(toggleNode).toHaveStyleRule('opacity', '0.4');
   });
 
-  it('should render without a problem when checked and not disabled', () => {
-    const render = shallowWithTheme(<ToggleButton checked />);
+  test('should toggle', () => {
+    const { container } = render(<ToggleButton />);
 
-    expect(render.dive()).toMatchSnapshot();
-  });
+    fireEvent.click(container.firstChild);
 
-  it('should render without a problem when unchecked and not disabled', () => {
-    const render = shallowWithTheme(<ToggleButton checked={false} />);
+    expect(render).toMatchSnapshot();
 
-    expect(render.dive()).toMatchSnapshot();
-  });
-
-  it('should toggle', () => {
-    const render = mountWithTheme(<ToggleButton />);
-
-    render.find('ToggleButton').simulate('click');
+    fireEvent.click(container.firstChild);
 
     expect(render).toMatchSnapshot();
   });
 
-  it('should call change handler when enabled', () => {
+  test('should call change handler when enabled', () => {
     const handleToggleMock = jest.fn();
-    const render = mountWithTheme(<ToggleButton checked onToggle={handleToggleMock} />);
+    const { container } = render(<ToggleButton checked onToggle={handleToggleMock} />);
 
-    render.find('ToggleButton').simulate('click');
+    fireEvent.click(container.firstChild);
 
-    expect(handleToggleMock).toHaveBeenCalled();
+    expect(handleToggleMock).toHaveBeenCalledTimes(1);
   });
 
-  it('should not call change handler when disabled', () => {
+  test('should not call change handler when disabled', () => {
     const handleToggleMock = jest.fn();
-    const render = mountWithTheme(<ToggleButton checked disabled onToggle={handleToggleMock} />);
+    const { container } = render(<ToggleButton checked disabled onToggle={handleToggleMock} />);
 
-    render.find('ToggleButton').simulate('click');
+    fireEvent.click(container.firstChild);
 
     expect(handleToggleMock).not.toHaveBeenCalled();
-  });
-
-  it('should call componentDidUpdate and setState', () => {
-    class FakeComponent extends PureComponent {
-      state = {
-        checked: false,
-      };
-
-      handleToogle = () => {
-        const { checked } = this.state;
-        this.setState({ ...this.state, checked: !checked });
-      };
-
-      render() {
-        const { checked } = this.state;
-
-        return <ToggleButton checked={checked} onToggle={this.handleToogle} />;
-      }
-    }
-
-    const render = mountWithTheme(<FakeComponent />);
-
-    render.find('ToggleButton').simulate('click');
-
-    expect(render).toMatchSnapshot();
   });
 });

--- a/src/ToggleButton/__tests__/__snapshots__/ToggleButton.test.js.snap
+++ b/src/ToggleButton/__tests__/__snapshots__/ToggleButton.test.js.snap
@@ -1,102 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ToggleButton /> should call componentDidUpdate and setState 1`] = `
-.c1 {
-  position: absolute;
-  width: 0;
-  opacity: 0;
-}
-
-.c2 {
-  display: inline-block;
-  position: relative;
-  width: 3.8rem;
-  height: 2rem;
-  border-radius: 1rem;
-  background: hsl(200,74%,46%) linear-gradient( 0deg, hsla(0,100%,100%,0) 0%, hsla(0,100%,100%,0.1) 100% );
-  border: 1px solid hsl(200,74%,46%);
-  cursor: pointer;
-  pointer-events: none;
-}
-
-.c2:before {
-  content: '';
-  display: block;
-  position: absolute;
-  top: 0.1rem;
-  left: 0.2rem;
-  cursor: pointer;
-  height: 1.6rem;
-  width: 1.6rem;
-  border-radius: 1.6rem;
-  background: hsl(0,100%,100%);
-  box-shadow: 0 2px 4px 0 rgba(0,0,0,0.15);
-  -webkit-transition: -webkit-transform 250ms ease;
-  -webkit-transition: transform 250ms ease;
-  transition: transform 250ms ease;
-  -webkit-transform: translateX(1.7rem);
-  -ms-transform: translateX(1.7rem);
-  transform: translateX(1.7rem);
-  will-change: transform;
-}
-
-.c2:active:before {
-  width: 3rem;
-  left: 0;
-}
-
-.c0 {
-  display: inline-block;
-  position: relative;
-  height: 2rem;
-  vertical-align: middle;
-  cursor: pointer;
-}
-
-<FakeComponent>
-  <Styled(ToggleButton)
-    checked={true}
-    onToggle={[Function]}
-  >
-    <ToggleButton
-      checked={true}
-      className="c0"
-      disabled={false}
-      onToggle={[Function]}
-    >
-      <div
-        className="c0"
-        onClick={[Function]}
-      >
-        <styled.input
-          checked={true}
-          readOnly={true}
-          type="checkbox"
-        >
-          <input
-            checked={true}
-            className="c1"
-            readOnly={true}
-            type="checkbox"
-          />
-        </styled.input>
-        <styled.span
-          checked={true}
-          readOnly={false}
-        >
-          <span
-            checked={true}
-            className="c2"
-            readOnly={false}
-          />
-        </styled.span>
-      </div>
-    </ToggleButton>
-  </Styled(ToggleButton)>
-</FakeComponent>
-`;
-
 exports[`<ToggleButton /> should render without a problem 1`] = `
+.c1 {
+  position: absolute;
+  width: 0;
+  opacity: 0;
+}
+
+.c2 {
+  display: inline-block;
+  position: relative;
+  width: 3.8rem;
+  height: 2rem;
+  border-radius: 1rem;
+  background: hsl(207,22%,90%);
+  border: 1px solid hsl(207,22%,90%);
+  cursor: pointer;
+  pointer-events: none;
+}
+
+.c2:before {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0.1rem;
+  left: 0.2rem;
+  cursor: pointer;
+  height: 1.6rem;
+  width: 1.6rem;
+  border-radius: 1.6rem;
+  background: hsl(0,100%,100%);
+  box-shadow: 0 2px 4px 0 rgba(0,0,0,0.15);
+  -webkit-transition: -webkit-transform 250ms ease;
+  -webkit-transition: transform 250ms ease;
+  transition: transform 250ms ease;
+  -webkit-transform: translateX(0);
+  -ms-transform: translateX(0);
+  transform: translateX(0);
+  will-change: transform;
+}
+
+.c2:active:before {
+  width: 3rem;
+  left: 6px;
+}
+
 .c0 {
   display: inline-block;
   position: relative;
@@ -106,122 +54,21 @@ exports[`<ToggleButton /> should render without a problem 1`] = `
 }
 
 <div
-  className="c0"
-  onClick={[Function]}
+  class="c0"
 >
-  <styled.input
-    checked={false}
-    readOnly={true}
+  <input
+    class="c1"
+    readonly=""
     type="checkbox"
   />
-  <styled.span
-    checked={false}
-    readOnly={false}
+  <span
+    class="c2"
+    data-testid="toggle-button"
   />
 </div>
 `;
 
-exports[`<ToggleButton /> should render without a problem when checked and disabled 1`] = `
-.c0 {
-  display: inline-block;
-  position: relative;
-  height: 2rem;
-  vertical-align: middle;
-  cursor: not-allowed;
-}
-
-<div
-  className="c0"
-  onClick={[Function]}
->
-  <styled.input
-    checked={true}
-    readOnly={true}
-    type="checkbox"
-  />
-  <styled.span
-    checked={true}
-    readOnly={true}
-  />
-</div>
-`;
-
-exports[`<ToggleButton /> should render without a problem when checked and not disabled 1`] = `
-.c0 {
-  display: inline-block;
-  position: relative;
-  height: 2rem;
-  vertical-align: middle;
-  cursor: pointer;
-}
-
-<div
-  className="c0"
-  onClick={[Function]}
->
-  <styled.input
-    checked={true}
-    readOnly={true}
-    type="checkbox"
-  />
-  <styled.span
-    checked={true}
-    readOnly={false}
-  />
-</div>
-`;
-
-exports[`<ToggleButton /> should render without a problem when unchecked and disabled 1`] = `
-.c0 {
-  display: inline-block;
-  position: relative;
-  height: 2rem;
-  vertical-align: middle;
-  cursor: not-allowed;
-}
-
-<div
-  className="c0"
-  onClick={[Function]}
->
-  <styled.input
-    checked={false}
-    readOnly={true}
-    type="checkbox"
-  />
-  <styled.span
-    checked={false}
-    readOnly={true}
-  />
-</div>
-`;
-
-exports[`<ToggleButton /> should render without a problem when unchecked and not disabled 1`] = `
-.c0 {
-  display: inline-block;
-  position: relative;
-  height: 2rem;
-  vertical-align: middle;
-  cursor: pointer;
-}
-
-<div
-  className="c0"
-  onClick={[Function]}
->
-  <styled.input
-    checked={false}
-    readOnly={true}
-    type="checkbox"
-  />
-  <styled.span
-    checked={false}
-    readOnly={false}
-  />
-</div>
-`;
-
-exports[`<ToggleButton /> should toggle 1`] = `
+exports[`<ToggleButton /> should render without a problem when checked 1`] = `
 .c1 {
   position: absolute;
   width: 0;
@@ -274,40 +121,22 @@ exports[`<ToggleButton /> should toggle 1`] = `
   cursor: pointer;
 }
 
-<Styled(ToggleButton)>
-  <ToggleButton
-    checked={false}
-    className="c0"
-    disabled={false}
-    onToggle={null}
-  >
-    <div
-      className="c0"
-      onClick={[Function]}
-    >
-      <styled.input
-        checked={true}
-        readOnly={true}
-        type="checkbox"
-      >
-        <input
-          checked={true}
-          className="c1"
-          readOnly={true}
-          type="checkbox"
-        />
-      </styled.input>
-      <styled.span
-        checked={true}
-        readOnly={false}
-      >
-        <span
-          checked={true}
-          className="c2"
-          readOnly={false}
-        />
-      </styled.span>
-    </div>
-  </ToggleButton>
-</Styled(ToggleButton)>
+<div
+  class="c0"
+>
+  <input
+    checked=""
+    class="c1"
+    readonly=""
+    type="checkbox"
+  />
+  <span
+    class="c2"
+    data-testid="toggle-button"
+  />
+</div>
 `;
+
+exports[`<ToggleButton /> should toggle 1`] = `[Function]`;
+
+exports[`<ToggleButton /> should toggle 2`] = `[Function]`;

--- a/src/ToggleButton/index.js
+++ b/src/ToggleButton/index.js
@@ -77,7 +77,7 @@ class ToggleButton extends PureComponent {
     return (
       <div className={className} onClick={() => this.handleToogle(checked)}>
         <Checkbox type="checkbox" checked={checked} readOnly />
-        <Toggle checked={checked} readOnly={disabled} />
+        <Toggle checked={checked} readOnly={disabled} data-testid="toggle-button" />
       </div>
     );
   }


### PR DESCRIPTION
- [ ] Feature
- [ ] Fix
- [x] Enhancement

## Description
Refactor`<ToggleButton /> unit test with [react-testing-library](https://github.com/kentcdodds/react-testing-library) instead of [Enzyme](https://github.com/airbnb/enzyme/). 

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.

close #272