### PR TITLE
fix(Modal): fix size and mobile version of the component

### DIFF
--- a/src/Modal/elements.js
+++ b/src/Modal/elements.js
@@ -48,10 +48,10 @@ export const Dialog = styled.dialog`
   border-radius: ${({ theme: { dimensions } }) => dimensions.radius};
   background: ${({ theme: { palette } }) => palette.white};
 
-  /* For small devices */
+  /* For small mobile devices */
   ${breakpoint('xs', 'sm')`
-    width:90%;
-    margin-left: calc(-90% / 2)};
+    width: 100%;
+    margin: 0.4rem;
   `};
 `;
 

--- a/src/Modal/elements.js
+++ b/src/Modal/elements.js
@@ -1,43 +1,40 @@
 import styled from 'styled-components';
 import breakpoint from 'styled-components-breakpoint';
-import { stripUnit } from 'polished';
 
 export const Container = styled.div`
-  display: flex;
+  position: absolute;
+  display: grid;
   justify-content: center;
-  align-items: center;
+  align-content: center;
+  top: 0px;
+  bottom: 0px;
+  left: 0px;
+  right: 0px;
 
   width: 100%;
+
+  /* For small mobile devices */
+  ${breakpoint('xs', 'sm')`
+    display: flex;
+    align-items: flex-end;
+  `};
 `;
 
 export const Overlay = styled.div`
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 1;
-  height: 100%;
-  width: 100%;
   min-width: 100%;
   min-height: 100%;
   background-color: rgba(0, 0, 0, 0.5);
 `;
 
 export const Dialog = styled.dialog`
-  position: absolute;
+  position: relative;
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
 
   z-index: 999;
   display: flex;
   flex-direction: column;
-
-  height: ${({ height }) => height};
-  width: ${({ width }) => width};
-
-  ${({ width, height }) => `
-    left: calc(50% - ${stripUnit(width) / 2}rem);
-    top: calc(50% - ${stripUnit(height) / 2}rem);
-  `}
 
   padding: ${({ padding }) => padding};
 

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -66,16 +66,16 @@ class Modal extends PureComponent {
     const { active, width, height, padding, onOverlayClick, children } = this.props;
     return (
       <Portal>
-        <Container>
-          <PoseGroup>
-            {active && [
-              <OverlayAnimation onClick={onOverlayClick} key="Overlay" data-testid="overlay" />,
+        <PoseGroup>
+          {active && (
+            <ContainerAnimation key="Container">
+              <OverlayAnimation onClick={onOverlayClick} key="Overlay" data-testid="overlay" />
               <DialogAnimation width={width} height={height} padding={padding} key="Dialog">
                 {children}
-              </DialogAnimation>,
-            ]}
-          </PoseGroup>
-        </Container>
+              </DialogAnimation>
+            </ContainerAnimation>
+          )}
+        </PoseGroup>
       </Portal>
     );
   }
@@ -84,6 +84,14 @@ class Modal extends PureComponent {
 /**
  * Animation
  */
+const ContainerAnimation = posed(Container)({
+  enter: {
+    opacity: 1,
+  },
+  exit: {
+    opacity: 0,
+  },
+});
 const OverlayAnimation = posed(Overlay)({
   enter: {
     opacity: 1,


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description

The size of the modal needed to be specified without the modal resizing by itself according to the content. If translations values change, you need to update the height/width of the component, which is cumbersome. That PR aims to fix that.

The mobile version of the modal is also updated to fit design ([Sonar example of the datepicker](https://app.zeplin.io/project/5c08e7dab171cd2fd787d7d6/screen/5ca2107fb4da6a05e1c042e6))

![Untitled1](https://user-images.githubusercontent.com/6019103/55332420-a238c300-5495-11e9-8d61-8ddeac208772.gif)

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
