### PR TITLE
fix(Tooltip): Add a border to the pseudo-element ::before

### DIFF
--- a/src/Tooltip/__tests__/Tooltip.test.js
+++ b/src/Tooltip/__tests__/Tooltip.test.js
@@ -36,9 +36,20 @@ describe('<Tooltip />', () => {
       'box-shadow',
       `0 0 0 1px ${Theme.palette.lightGrey},0 2px 16px 0 rgba(0,0,0,0.1)`,
     );
-    expect(tooltipNode).toHaveStyleRule('background', Theme.palette.white, {
-      modifier: '::before',
-    });
+    expect(tooltipNode).toHaveStyleRule(
+      'border-color',
+      `${Theme.palette.white} transparent ${Theme.palette.white} transparent`,
+      {
+        modifier: '::before',
+      },
+    );
+    expect(tooltipNode).toHaveStyleRule(
+      'border-color',
+      `${Theme.palette.lightGrey} transparent ${Theme.palette.lightGrey} transparent`,
+      {
+        modifier: '::after',
+      },
+    );
   });
 
   test('should render an active tooltip without a problem', () => {

--- a/src/Tooltip/elements.js
+++ b/src/Tooltip/elements.js
@@ -30,26 +30,52 @@ export const Container = styled.div`
     css`
       bottom: 100%;
       top: auto;
-    `} &::before {
+    `}
+
+  &::before,
+  &::after {
     content: '';
 
     display: block;
 
     position: absolute;
-    top: 0;
+    bottom: 100%;
+    top: auto;
     left: ${({ arrowPositionX }) => arrowPositionX};
     z-index: -1;
 
-    height: 0.7rem;
-    width: 0.7rem;
+    width: 0;
+    height: 0;
 
-    transform: translate3d(0, -50%, 0) rotate(135deg);
+    border-style: solid;
+    background-color: transparent;
     ${({ top }) =>
       top &&
       css`
-        bottom: 0;
-        top: auto;
-        transform: translate3d(0, 50%, 0) rotate(135deg);
+        bottom: auto;
+        top: 100%;
+        border-width: 5px 5px 0 5px;
+      `};
+  }
+
+  &::before {
+    z-index: 1;
+    border-width: 0 5px 5px 5px;
+    ${({ top }) =>
+      top &&
+      css`
+        border-width: 5px 5px 0 5px;
+      `};
+  }
+
+  &::after {
+    z-index: -1;
+    border-width: 0 6px 6px 6px;
+    transform: translateX(-1px);
+    ${({ top }) =>
+      top &&
+      css`
+        border-width: 6px 6px 0 6px;
       `};
   }
 `;

--- a/src/Tooltip/helpers.js
+++ b/src/Tooltip/helpers.js
@@ -16,8 +16,9 @@ export const getAppearance = ({ palette }, appearance) => {
       color: ${palette.white};
       background: ${palette.darkBlue};
       box-shadow: none;
-      &::before {
-        background: ${palette.darkBlue};
+      &::before,
+      &::after {
+        border-color: ${palette.darkBlue} transparent ${palette.darkBlue} transparent;
       }
     `,
     light: css`
@@ -25,7 +26,11 @@ export const getAppearance = ({ palette }, appearance) => {
       background: ${palette.white};
       box-shadow: 0 0 0 1px ${palette.lightGrey}, 0 2px 16px 0 rgba(0, 0, 0, 0.1);
       &::before {
-        background: ${palette.white};
+        border-color: ${palette.white} transparent ${palette.white} transparent;
+      }
+
+      &::after {
+        border-color: ${palette.lightGrey} transparent ${palette.lightGrey} transparent;
       }
     `,
   }[appearance];


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description
@leopoldhoudin noticed there missing a border on the pseudo-element `::before`. So I open this PR to fix that issue.

## Related / Associated Jira Cards :
> [leopoldhoudin comment](https://github.com/tillersystems/tiller-sonar/pull/435#issuecomment-457522507)

## Todo - Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
