### PR TITLE
fix(Input/InputText): allow custom styles to override the style on focused input

### DIFF
--- a/src/Form/__tests__/__snapshots__/Form.test.js.snap
+++ b/src/Form/__tests__/__snapshots__/Form.test.js.snap
@@ -137,6 +137,7 @@ exports[`<Form /> should render form with highlighted label when has focus 1`] =
   -ms-flex: 1;
   flex: 1;
   height: 100%;
+  width: 100%;
   background-color: hsl(0,100%,100%);
   margin: 0 0.7rem;
   border-radius: 0.4rem;
@@ -251,7 +252,7 @@ exports[`<Form /> should render form with highlighted label when has focus 2`] =
               width="25rem"
             >
               <input
-                class="sc-eHgmQL gGHbTY"
+                class="sc-eHgmQL bEMfzu"
                 data-testid="input"
                 id=""
                 placeholder="tape inside me"
@@ -379,6 +380,7 @@ exports[`<Form /> should render form without label without a problem 1`] = `
   -ms-flex: 1;
   flex: 1;
   height: 100%;
+  width: 100%;
   background-color: hsl(0,100%,100%);
   margin: 0 0.7rem;
   border-radius: 0.4rem;
@@ -624,6 +626,7 @@ exports[`<Form /> should render row form with inline labels without a problem 1`
   -ms-flex: 1;
   flex: 1;
   height: 100%;
+  width: 100%;
   background-color: hsl(0,100%,100%);
   margin: 0 0.7rem;
   border-radius: 0.4rem;
@@ -908,6 +911,7 @@ exports[`<Form /> should render without a problem 1`] = `
   -ms-flex: 1;
   flex: 1;
   height: 100%;
+  width: 100%;
   background-color: hsl(0,100%,100%);
   margin: 0 0.7rem;
   border-radius: 0.4rem;

--- a/src/Input/DatePickerInput/__tests__/__snapshots__/DatePickerInput.test.js.snap
+++ b/src/Input/DatePickerInput/__tests__/__snapshots__/DatePickerInput.test.js.snap
@@ -26,6 +26,7 @@ exports[`<DatePickerInput /> should render without a problem 1`] = `
   -ms-flex: 1;
   flex: 1;
   height: 100%;
+  width: 100%;
   background-color: hsl(0,100%,100%);
   margin: 0 0.7rem;
   border-radius: 0.4rem;

--- a/src/Input/NumberInput/__tests__/__snapshots__/NumberInput.test.js.snap
+++ b/src/Input/NumberInput/__tests__/__snapshots__/NumberInput.test.js.snap
@@ -45,6 +45,7 @@ exports[`<NumberInput /> should have a text label 1`] = `
   -ms-flex: 1;
   flex: 1;
   height: 100%;
+  width: 100%;
   background-color: hsl(0,100%,100%);
   margin: 0 0.7rem;
   border-radius: 0.4rem;
@@ -143,6 +144,7 @@ exports[`<NumberInput /> should have an icon icon label and label position 1`] =
   -ms-flex: 1;
   flex: 1;
   height: 100%;
+  width: 100%;
   background-color: hsl(0,100%,100%);
   margin: 0 0.7rem;
   border-radius: 0.4rem;
@@ -269,6 +271,7 @@ exports[`<NumberInput /> should have an icon label 1`] = `
   -ms-flex: 1;
   flex: 1;
   height: 100%;
+  width: 100%;
   background-color: hsl(0,100%,100%);
   margin: 0 0.7rem;
   border-radius: 0.4rem;
@@ -376,6 +379,7 @@ exports[`<NumberInput /> should render without a problem 1`] = `
   -ms-flex: 1;
   flex: 1;
   height: 100%;
+  width: 100%;
   background-color: hsl(0,100%,100%);
   margin: 0 0.7rem;
   border-radius: 0.4rem;
@@ -449,6 +453,7 @@ exports[`<NumberInput /> should render without a problem when focused and unfocu
   -ms-flex: 1;
   flex: 1;
   height: 100%;
+  width: 100%;
   background-color: hsl(0,100%,100%);
   margin: 0 0.7rem;
   border-radius: 0.4rem;
@@ -501,7 +506,7 @@ exports[`<NumberInput /> should render without a problem when focused and unfocu
   width="25rem"
 >
   <input
-    class="sc-jKJlTe bFNfrE"
+    class="sc-jKJlTe cWhkTx"
     data-testid="input"
     id=""
     placeholder=""

--- a/src/Input/TextInput/__stories__/TextInput.stories.js
+++ b/src/Input/TextInput/__stories__/TextInput.stories.js
@@ -33,6 +33,7 @@ storiesOf('Input - TextInput', module)
     const disabledValue = boolean('Disabled', false, 'General');
 
     const loadingValue = boolean('Loading', false, 'Status');
+    const ghostValue = boolean('Ghost', false, 'Status');
     const infoValue = boolean('Info', false, 'Status');
     const successValue = boolean('Success', false, 'Status');
     const warningValue = boolean('Warning', false, 'Status');
@@ -49,6 +50,7 @@ storiesOf('Input - TextInput', module)
         onBlur={onBlurAction}
         loading={loadingValue}
         info={infoValue}
+        ghost={ghostValue}
         success={successValue}
         warning={warningValue}
         error={errorValue}

--- a/src/Input/TextInput/__tests__/TextInput.test.js
+++ b/src/Input/TextInput/__tests__/TextInput.test.js
@@ -146,7 +146,7 @@ describe('<TextInput />', () => {
   test('should render ghost input without problem', () => {
     const { container } = render(<TextInput ghost value="" />);
 
-    expect(container.firstChild).toHaveStyleRule('border', '0');
+    expect(container.firstChild).toHaveStyleRule('border-color', 'transparent');
   });
 
   test('should have a search status', () => {

--- a/src/Input/TextInput/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/Input/TextInput/__tests__/__snapshots__/TextInput.test.js.snap
@@ -47,6 +47,7 @@ exports[`<TextInput /> should have a text label 1`] = `
   -ms-flex: 1;
   flex: 1;
   height: 100%;
+  width: 100%;
   background-color: hsl(0,100%,100%);
   margin: 0 0.7rem;
   border-radius: 0.4rem;
@@ -154,6 +155,7 @@ exports[`<TextInput /> should have an icon icon label and label position 1`] = `
   -ms-flex: 1;
   flex: 1;
   height: 100%;
+  width: 100%;
   background-color: hsl(0,100%,100%);
   margin: 0 0.7rem;
   border-radius: 0.4rem;
@@ -280,6 +282,7 @@ exports[`<TextInput /> should have an icon label 1`] = `
   -ms-flex: 1;
   flex: 1;
   height: 100%;
+  width: 100%;
   background-color: hsl(0,100%,100%);
   margin: 0 0.7rem;
   border-radius: 0.4rem;
@@ -407,6 +410,7 @@ exports[`<TextInput /> should render search status input without problem when fo
   -ms-flex: 1;
   flex: 1;
   height: 100%;
+  width: 100%;
   background-color: hsl(0,100%,100%);
   margin: 0 0.7rem;
   border-radius: 0.4rem;
@@ -506,6 +510,7 @@ exports[`<TextInput /> should render without a problem 1`] = `
   -ms-flex: 1;
   flex: 1;
   height: 100%;
+  width: 100%;
   background-color: hsl(0,100%,100%);
   margin: 0 0.7rem;
   border-radius: 0.4rem;

--- a/src/Input/TextInput/elements.js
+++ b/src/Input/TextInput/elements.js
@@ -61,6 +61,7 @@ export const Container = styled.div`
 export const InputElement = styled.input`
   flex: 1;
   height: 100%;
+  width: 100%;
   background-color: ${({ theme: { palette } }) => palette.white};
 
   margin: 0 ${({ theme: { dimensions } }) => dimensions.small};

--- a/src/Input/TextInput/elements.js
+++ b/src/Input/TextInput/elements.js
@@ -17,7 +17,13 @@ export const Container = styled.div`
   ${({ ghost }) =>
     ghost &&
     css`
-      border: 0;
+      border-color: transparent;
+    `};
+
+  ${({ hasFocus }) =>
+    hasFocus &&
+    css`
+      border-color: ${({ theme: { palette } }) => palette.primary.default};
     `};
 
   ${({ error }) =>
@@ -40,12 +46,6 @@ export const Container = styled.div`
 
   ${({ info }) =>
     info &&
-    css`
-      border-color: ${({ theme: { palette } }) => palette.primary.default};
-    `};
-
-  ${({ hasFocus }) =>
-    hasFocus &&
     css`
       border-color: ${({ theme: { palette } }) => palette.primary.default};
     `};

--- a/src/Input/TextInput/index.js
+++ b/src/Input/TextInput/index.js
@@ -42,6 +42,7 @@ const getStatus = (loading, info, success, warning, error, search) => {
  * @param {boolean} loading - Whether to display an input that is loading or not.
  * @param {boolean} success - Whether to display an input that is successful or not.
  * @param {boolean} warning - Whether to display an input that is warning or not.
+ * @param {boolean} info - Whether to display an input that is an info or not.
  * @param {boolean} error - Whether to display an input that has failed or not.
  * @param {boolean} ghost - Whether to display an input with no border.
  * @param {boolean} search - Whether to display an input that meant for search or not.


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Brief
Fix style for custom props on InputText.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
