### PR TITLE
fix(Input): fix placeholder style

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "initials": "^3.0.0",
     "luxon": "^1.3.3",
-    "polished": "^2.0.0",
+    "polished": "3.0.0",
     "react-onclickoutside": "^6.7.1",
     "react-portal": "^4.1.5",
     "styled-components-breakpoint": "^2.1.0"

--- a/src/Form/__tests__/__snapshots__/Form.test.js.snap
+++ b/src/Form/__tests__/__snapshots__/Form.test.js.snap
@@ -151,15 +151,15 @@ exports[`<Form /> should render form with highlighted label when has focus 1`] =
   font-size: 1.4rem;
 }
 
-.c8:-moz-placeholder {
-  font-size: 1.4rem;
-}
-
 .c8::-moz-placeholder {
   font-size: 1.4rem;
 }
 
 .c8:-ms-input-placeholder {
+  font-size: 1.4rem;
+}
+
+.c8::placeholder {
   font-size: 1.4rem;
 }
 
@@ -252,7 +252,7 @@ exports[`<Form /> should render form with highlighted label when has focus 2`] =
               width="25rem"
             >
               <input
-                class="sc-eHgmQL bEMfzu"
+                class="sc-eHgmQL ekoJZv"
                 data-testid="input"
                 id=""
                 placeholder="tape inside me"
@@ -394,15 +394,15 @@ exports[`<Form /> should render form without label without a problem 1`] = `
   font-size: 1.4rem;
 }
 
-.c7:-moz-placeholder {
-  font-size: 1.4rem;
-}
-
 .c7::-moz-placeholder {
   font-size: 1.4rem;
 }
 
 .c7:-ms-input-placeholder {
+  font-size: 1.4rem;
+}
+
+.c7::placeholder {
   font-size: 1.4rem;
 }
 
@@ -640,15 +640,15 @@ exports[`<Form /> should render row form with inline labels without a problem 1`
   font-size: 1.4rem;
 }
 
-.c8:-moz-placeholder {
-  font-size: 1.4rem;
-}
-
 .c8::-moz-placeholder {
   font-size: 1.4rem;
 }
 
 .c8:-ms-input-placeholder {
+  font-size: 1.4rem;
+}
+
+.c8::placeholder {
   font-size: 1.4rem;
 }
 
@@ -925,15 +925,15 @@ exports[`<Form /> should render without a problem 1`] = `
   font-size: 1.4rem;
 }
 
-.c8:-moz-placeholder {
-  font-size: 1.4rem;
-}
-
 .c8::-moz-placeholder {
   font-size: 1.4rem;
 }
 
 .c8:-ms-input-placeholder {
+  font-size: 1.4rem;
+}
+
+.c8::placeholder {
   font-size: 1.4rem;
 }
 

--- a/src/Input/DatePickerInput/__tests__/__snapshots__/DatePickerInput.test.js.snap
+++ b/src/Input/DatePickerInput/__tests__/__snapshots__/DatePickerInput.test.js.snap
@@ -40,15 +40,15 @@ exports[`<DatePickerInput /> should render without a problem 1`] = `
   font-size: 1.4rem;
 }
 
-.c2:-moz-placeholder {
-  font-size: 1.4rem;
-}
-
 .c2::-moz-placeholder {
   font-size: 1.4rem;
 }
 
 .c2:-ms-input-placeholder {
+  font-size: 1.4rem;
+}
+
+.c2::placeholder {
   font-size: 1.4rem;
 }
 

--- a/src/Input/NumberInput/__tests__/__snapshots__/NumberInput.test.js.snap
+++ b/src/Input/NumberInput/__tests__/__snapshots__/NumberInput.test.js.snap
@@ -59,15 +59,15 @@ exports[`<NumberInput /> should have a text label 1`] = `
   font-size: 1.4rem;
 }
 
-.c2:-moz-placeholder {
-  font-size: 1.4rem;
-}
-
 .c2::-moz-placeholder {
   font-size: 1.4rem;
 }
 
 .c2:-ms-input-placeholder {
+  font-size: 1.4rem;
+}
+
+.c2::placeholder {
   font-size: 1.4rem;
 }
 
@@ -158,15 +158,15 @@ exports[`<NumberInput /> should have an icon icon label and label position 1`] =
   font-size: 1.4rem;
 }
 
-.c1:-moz-placeholder {
-  font-size: 1.4rem;
-}
-
 .c1::-moz-placeholder {
   font-size: 1.4rem;
 }
 
 .c1:-ms-input-placeholder {
+  font-size: 1.4rem;
+}
+
+.c1::placeholder {
   font-size: 1.4rem;
 }
 
@@ -285,15 +285,15 @@ exports[`<NumberInput /> should have an icon label 1`] = `
   font-size: 1.4rem;
 }
 
-.c3:-moz-placeholder {
-  font-size: 1.4rem;
-}
-
 .c3::-moz-placeholder {
   font-size: 1.4rem;
 }
 
 .c3:-ms-input-placeholder {
+  font-size: 1.4rem;
+}
+
+.c3::placeholder {
   font-size: 1.4rem;
 }
 
@@ -393,15 +393,15 @@ exports[`<NumberInput /> should render without a problem 1`] = `
   font-size: 1.4rem;
 }
 
-.c1:-moz-placeholder {
-  font-size: 1.4rem;
-}
-
 .c1::-moz-placeholder {
   font-size: 1.4rem;
 }
 
 .c1:-ms-input-placeholder {
+  font-size: 1.4rem;
+}
+
+.c1::placeholder {
   font-size: 1.4rem;
 }
 
@@ -467,15 +467,15 @@ exports[`<NumberInput /> should render without a problem when focused and unfocu
   font-size: 1.4rem;
 }
 
-.c1:-moz-placeholder {
-  font-size: 1.4rem;
-}
-
 .c1::-moz-placeholder {
   font-size: 1.4rem;
 }
 
 .c1:-ms-input-placeholder {
+  font-size: 1.4rem;
+}
+
+.c1::placeholder {
   font-size: 1.4rem;
 }
 
@@ -506,7 +506,7 @@ exports[`<NumberInput /> should render without a problem when focused and unfocu
   width="25rem"
 >
   <input
-    class="sc-jKJlTe cWhkTx"
+    class="sc-jKJlTe jQmZNI"
     data-testid="input"
     id=""
     placeholder=""

--- a/src/Input/TextInput/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/Input/TextInput/__tests__/__snapshots__/TextInput.test.js.snap
@@ -61,15 +61,15 @@ exports[`<TextInput /> should have a text label 1`] = `
   font-size: 1.4rem;
 }
 
-.c2:-moz-placeholder {
-  font-size: 1.4rem;
-}
-
 .c2::-moz-placeholder {
   font-size: 1.4rem;
 }
 
 .c2:-ms-input-placeholder {
+  font-size: 1.4rem;
+}
+
+.c2::placeholder {
   font-size: 1.4rem;
 }
 
@@ -169,15 +169,15 @@ exports[`<TextInput /> should have an icon icon label and label position 1`] = `
   font-size: 1.4rem;
 }
 
-.c1:-moz-placeholder {
-  font-size: 1.4rem;
-}
-
 .c1::-moz-placeholder {
   font-size: 1.4rem;
 }
 
 .c1:-ms-input-placeholder {
+  font-size: 1.4rem;
+}
+
+.c1::placeholder {
   font-size: 1.4rem;
 }
 
@@ -296,15 +296,15 @@ exports[`<TextInput /> should have an icon label 1`] = `
   font-size: 1.4rem;
 }
 
-.c3:-moz-placeholder {
-  font-size: 1.4rem;
-}
-
 .c3::-moz-placeholder {
   font-size: 1.4rem;
 }
 
 .c3:-ms-input-placeholder {
+  font-size: 1.4rem;
+}
+
+.c3::placeholder {
   font-size: 1.4rem;
 }
 
@@ -424,15 +424,15 @@ exports[`<TextInput /> should render search status input without problem when fo
   font-size: 1.4rem;
 }
 
-.c1:-moz-placeholder {
-  font-size: 1.4rem;
-}
-
 .c1::-moz-placeholder {
   font-size: 1.4rem;
 }
 
 .c1:-ms-input-placeholder {
+  font-size: 1.4rem;
+}
+
+.c1::placeholder {
   font-size: 1.4rem;
 }
 
@@ -524,15 +524,15 @@ exports[`<TextInput /> should render without a problem 1`] = `
   font-size: 1.4rem;
 }
 
-.c1:-moz-placeholder {
-  font-size: 1.4rem;
-}
-
 .c1::-moz-placeholder {
   font-size: 1.4rem;
 }
 
 .c1:-ms-input-placeholder {
+  font-size: 1.4rem;
+}
+
+.c1::placeholder {
   font-size: 1.4rem;
 }
 

--- a/src/Input/TextInput/elements.js
+++ b/src/Input/TextInput/elements.js
@@ -1,5 +1,4 @@
 import styled, { css } from 'styled-components';
-import { placeholder } from 'polished';
 
 export const Container = styled.div`
   display: flex;
@@ -67,8 +66,10 @@ export const InputElement = styled.input`
   margin: 0 ${({ theme: { dimensions } }) => dimensions.small};
   border-radius: ${({ theme: { dimensions } }) => dimensions.radius};
 
-  ${({ theme: { palette } }) => placeholder({ color: palette.darGrey })}
-  ${({ theme: { fonts } }) => placeholder({ 'font-size': fonts.size.medium })}
+  &::placeholder {
+    color: ${({ theme: { palette } }) => palette.darGrey};
+    font-size: ${({ theme: { fonts } }) => fonts.size.medium};
+  }
 
   font-size: ${({ theme: { fonts } }) => fonts.size.medium};
   border: none;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2744,6 +2744,14 @@ babel-plugin-macros@2.4.2, babel-plugin-macros@^2.4.2:
     cosmiconfig "^5.0.5"
     resolve "^1.8.1"
 
+babel-plugin-macros@^2.2.2:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.5.0.tgz#01f4d3b50ed567a67b80a30b9da066e94f4097b6"
+  integrity sha512-BWw0lD0kVZAXRD3Od1kMrdmfudqzDzYv2qrN3l2ISR1HVp1EgLKfbOrYV9xmY5k3qx3RIu5uPAUZZZHpo0o5Iw==
+  dependencies:
+    cosmiconfig "^5.0.5"
+    resolve "^1.8.1"
+
 babel-plugin-minify-builtins@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.5.0.tgz#31eb82ed1a0d0efdc31312f93b6e4741ce82c36b"
@@ -2810,6 +2818,14 @@ babel-plugin-minify-type-constructors@^0.4.3:
 babel-plugin-named-asset-import@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.2.3.tgz#b40ed50a848e7bb0a2a7e34d990d1f9d46fe9b38"
+
+babel-plugin-preval@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-preval/-/babel-plugin-preval-3.0.1.tgz#a26f9690114a864a54a5cbdf865496ebf541a9c3"
+  integrity sha512-s8hmTlRSmzcL7cHSIi0s6WxmpOAxfIlWqSVQwBIt7V5bNBaac+8JMZ6kJXLOazMJ8gCIcb5AJgQUgPHvbSYUzw==
+  dependencies:
+    babel-plugin-macros "^2.2.2"
+    require-from-string "^2.0.2"
 
 babel-plugin-react-docgen@^2.0.0:
   version "2.0.0"
@@ -8508,9 +8524,13 @@ pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
 
-polished@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/polished/-/polished-2.0.0.tgz#f9f34a6efe1dd66eca540bb41a6b7058ae9b4fa7"
+polished@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-3.0.0.tgz#72a61e9729f8cfbcf2d6968441dc1f6f723a9fd6"
+  integrity sha512-qgxFjrkdnOrcHm/ulPjvK4jwzFv2zOdwY7JmaOX2iqTkLw2tA8U+YqYd5EDo5plPOZ2xpsGXeWWwj/C+/3nL5g==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    babel-plugin-preval "3.0.1"
 
 popmotion-pose@^3.4.0:
   version "3.4.0"
@@ -9511,9 +9531,10 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
 
-require-from-string@^2.0.1:
+require-from-string@^2.0.1, require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 require-main-filename@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Brief
Use placeholder pseudo-element instead of deprecated method from polished lib.

## Description
Polished dependency [deprecated](https://github.com/styled-components/polished/commit/8792e1ffefecb55bc8fad393cb9111477f2d7f12) its `placeholder()` method, so we need to remove it from our lib.
Stardust is broken because of that in captain-client (weirdly it broke on update of polished dependency in captain-client, I would have thought that inner dependency in Stardust would not be impacted?). Either way this PR is fixing it.

## Requirements :
<!--- Eventually remove the following. -->
:warning: Requires running `yarn` command.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
