### PR TITLE
fix(DatePicker): allow interval in defaultValue

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "initials": "^3.0.0",
-    "luxon": "^1.3.3",
+    "luxon": "^1.11.4",
     "polished": "3.0.3",
     "react-onclickoutside": "^6.7.1",
     "react-portal": "^4.1.5",

--- a/src/DatePicker/Header/__tests__/__snapshots__/Header.test.js.snap
+++ b/src/DatePicker/Header/__tests__/__snapshots__/Header.test.js.snap
@@ -84,6 +84,7 @@ exports[`Header should render without a problem 1`] = `
   -ms-flex-align: center;
   align-items: center;
   color: hsl(213,17%,20%);
+  text-align: center;
   font-size: 1.2rem;
   line-height: 1.4rem;
 }

--- a/src/DatePicker/Header/index.js
+++ b/src/DatePicker/Header/index.js
@@ -95,6 +95,7 @@ const styledHeader = styled(Header)`
   align-items: center;
 
   color: ${({ theme: { palette } }) => palette.darkBlue};
+  text-align: center;
   font-size: ${({
     theme: {
       fonts: { size },

--- a/src/DatePicker/Weeks/index.js
+++ b/src/DatePicker/Weeks/index.js
@@ -47,7 +47,6 @@ const Weeks = ({
           (!minDate || dateNormalized >= minDate.startOf('day')) &&
           (!maxDate || dateNormalized <= maxDate.startOf('day'));
 
-        // Check if calendar date is same day as selected
         const isSelected = isInMonth && isInRange && isSameDay(dateNormalized, selected);
 
         const startOfDay = dateNormalized.startOf('day');

--- a/src/DatePicker/__stories__/DatePicker.stories.js
+++ b/src/DatePicker/__stories__/DatePicker.stories.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { withKnobs, select, date, boolean, number } from '@storybook/addon-knobs';
 import { State, Store } from '@sambego/storybook-state';
 import { action } from '@storybook/addon-actions';
-import { DateTime } from 'luxon';
+import { DateTime, Interval } from 'luxon';
 
 import DatePicker from '..';
 
@@ -58,8 +58,8 @@ storiesOf('DatePicker', module)
     const localeValue = select(
       'Locale',
       {
-        en: 'English',
-        fr: 'French',
+        English: 'en',
+        French: 'fr',
       },
       'English',
       'Locale',
@@ -94,6 +94,50 @@ storiesOf('DatePicker', module)
             />
           )}
         </State>
+      </div>
+    );
+  })
+  .add('controlled with an interval', () => {
+    const localeValue = select(
+      'Locale',
+      {
+        English: 'en',
+        French: 'fr',
+      },
+      'English',
+      'Locale',
+    );
+
+    const withMinDate = boolean('With minimum date', false, 'Bounds');
+    const minDateValue = date('Minimum date', today, 'Bounds');
+    const withMaxDate = boolean('With maximum date', false, 'Bounds');
+    const maxDateValue = date('Maximum date', today, 'Bounds');
+
+    const numberOfMonthsToDisplay = number(
+      'Number of month to display',
+      2,
+      { range: true, min: 1, max: 2, step: 1 },
+      'Bounds',
+    );
+
+    const isRange = boolean('Range date picker', true, 'Type');
+
+    const interval = Interval.fromDateTimes(
+      DateTime.fromObject({ year: 1982, month: 5, day: 25 }).startOf('day'),
+      DateTime.fromObject({ year: 1982, month: 5, day: 27 }).endOf('day'),
+    );
+
+    return (
+      <div style={{ background: 'white', padding: '16px', borderRadius: '4px' }}>
+        <DatePicker
+          numberOfMonthsToDisplay={numberOfMonthsToDisplay}
+          rangePicker={isRange}
+          locale={localeValue}
+          defaultValue={interval}
+          minDate={withMinDate ? DateTime.fromMillis(minDateValue) : null}
+          maxDate={withMaxDate ? DateTime.fromMillis(maxDateValue) : null}
+          onDateChanged={date => onChangeAction(date)}
+        />
       </div>
     );
   });

--- a/src/DatePicker/__tests__/__snapshots__/DatePicker.test.js.snap
+++ b/src/DatePicker/__tests__/__snapshots__/DatePicker.test.js.snap
@@ -238,13 +238,16 @@ exports[`<DatePicker /> Range should render without a problem 1`] = `
 }
 
 .c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   width: 24.4rem;
   font-weight: 500;
 }
 
 <div
   class="c0"
-  style="display: flex;"
 >
   <div
     class="c1"
@@ -977,13 +980,16 @@ exports[`<DatePicker /> Simple should render without a problem 1`] = `
 }
 
 .c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   width: 24.4rem;
   font-weight: 500;
 }
 
 <div
   class="c0"
-  style="display: flex;"
 >
   <div
     class="c1"

--- a/src/DatePicker/__tests__/__snapshots__/DatePicker.test.js.snap
+++ b/src/DatePicker/__tests__/__snapshots__/DatePicker.test.js.snap
@@ -548,7 +548,7 @@ exports[`<DatePicker /> Range should render without a problem 1`] = `
         class="c10"
       >
         <div
-          class="c13"
+          class="c12"
         >
           18
         </div>
@@ -557,7 +557,7 @@ exports[`<DatePicker /> Range should render without a problem 1`] = `
         class="c10"
       >
         <div
-          class="c12"
+          class="c13"
         >
           19
         </div>
@@ -1286,7 +1286,7 @@ exports[`<DatePicker /> Simple should render without a problem 1`] = `
         class="c10"
       >
         <div
-          class="c13"
+          class="c12"
         >
           18
         </div>
@@ -1295,7 +1295,7 @@ exports[`<DatePicker /> Simple should render without a problem 1`] = `
         class="c10"
       >
         <div
-          class="c12"
+          class="c13"
         >
           19
         </div>

--- a/src/DatePicker/__tests__/__snapshots__/DatePicker.test.js.snap
+++ b/src/DatePicker/__tests__/__snapshots__/DatePicker.test.js.snap
@@ -557,7 +557,7 @@ exports[`<DatePicker /> Range should render without a problem 1`] = `
         class="c10"
       >
         <div
-          class="c13"
+          class="c12"
         >
           19
         </div>
@@ -566,7 +566,7 @@ exports[`<DatePicker /> Range should render without a problem 1`] = `
         class="c10"
       >
         <div
-          class="c12"
+          class="c13"
         >
           20
         </div>
@@ -1295,7 +1295,7 @@ exports[`<DatePicker /> Simple should render without a problem 1`] = `
         class="c10"
       >
         <div
-          class="c13"
+          class="c12"
         >
           19
         </div>
@@ -1304,7 +1304,7 @@ exports[`<DatePicker /> Simple should render without a problem 1`] = `
         class="c10"
       >
         <div
-          class="c12"
+          class="c13"
         >
           20
         </div>

--- a/src/DatePicker/__tests__/__snapshots__/DatePicker.test.js.snap
+++ b/src/DatePicker/__tests__/__snapshots__/DatePicker.test.js.snap
@@ -228,6 +228,7 @@ exports[`<DatePicker /> Range should render without a problem 1`] = `
   -ms-flex-align: center;
   align-items: center;
   color: hsl(213,17%,20%);
+  text-align: center;
   font-size: 1.2rem;
   line-height: 1.4rem;
 }
@@ -566,7 +567,7 @@ exports[`<DatePicker /> Range should render without a problem 1`] = `
         class="c10"
       >
         <div
-          class="c13"
+          class="c12"
         >
           20
         </div>
@@ -575,7 +576,7 @@ exports[`<DatePicker /> Range should render without a problem 1`] = `
         class="c10"
       >
         <div
-          class="c12"
+          class="c13"
         >
           21
         </div>
@@ -966,6 +967,7 @@ exports[`<DatePicker /> Simple should render without a problem 1`] = `
   -ms-flex-align: center;
   align-items: center;
   color: hsl(213,17%,20%);
+  text-align: center;
   font-size: 1.2rem;
   line-height: 1.4rem;
 }
@@ -1304,7 +1306,7 @@ exports[`<DatePicker /> Simple should render without a problem 1`] = `
         class="c10"
       >
         <div
-          class="c13"
+          class="c12"
         >
           20
         </div>
@@ -1313,7 +1315,7 @@ exports[`<DatePicker /> Simple should render without a problem 1`] = `
         class="c10"
       >
         <div
-          class="c12"
+          class="c13"
         >
           21
         </div>

--- a/src/DatePicker/__tests__/__snapshots__/helpers.test.js.snap
+++ b/src/DatePicker/__tests__/__snapshots__/helpers.test.js.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Helpers should return an array of the calendar dates) 1`] = `
+exports[`Helpers should check if an object is an Interval 1`] = `false`;
+
+exports[`Helpers should check if an object is an Interval 2`] = `true`;
+
+exports[`Helpers should return an array of the calendar dates 1`] = `
 Array [
   Object {
     "day": 26,

--- a/src/DatePicker/__tests__/helpers.test.js
+++ b/src/DatePicker/__tests__/helpers.test.js
@@ -1,4 +1,4 @@
-import { DateTime, Settings } from 'luxon';
+import { DateTime, Settings, Interval } from 'luxon';
 import Mockdate from 'mockdate';
 
 import {
@@ -8,6 +8,7 @@ import {
   isSameMonth,
   isInNextMonth,
   isInLastMonth,
+  isInterval,
   getCalendarDates,
 } from '../helpers';
 
@@ -82,9 +83,19 @@ describe('Helpers', () => {
     expect(isInLastMonth(anotherSelectedDate, date)).toBeFalsy();
   });
 
-  test('should return an array of the calendar dates)', () => {
+  test('should return an array of the calendar dates', () => {
     const date = DateTime.fromObject({ year: 1982, month: 5, day: 1 });
 
     expect(getCalendarDates(date)).toMatchSnapshot();
+  });
+
+  test('should check if an object is an Interval', () => {
+    const from = DateTime.fromObject({ year: 1982, month: 5, day: 1 });
+    const to = DateTime.fromObject({ year: 1982, month: 5, day: 3 });
+    const notAnIntervalObject = from;
+    const intervalObject = Interval.fromDateTimes(from, to);
+
+    expect(isInterval(notAnIntervalObject)).toMatchSnapshot();
+    expect(isInterval(intervalObject)).toMatchSnapshot();
   });
 });

--- a/src/DatePicker/helpers.js
+++ b/src/DatePicker/helpers.js
@@ -1,4 +1,4 @@
-import { DateTime } from 'luxon';
+import { DateTime, Interval } from 'luxon';
 
 const CALENDAR_WEEKS = 6; // Weeks displayed on calendar
 
@@ -72,6 +72,16 @@ export const isInLastMonth = (date, currentDate) => {
   const monthEnd = date.endOf('month');
   return monthEnd.hasSame(currentDate.minus({ month: 1 }), 'month');
 };
+
+/**
+ * Is interval
+ * Check if an object is an Interval
+ *
+ * @param {object} value
+ *
+ * @return {boolean}
+ */
+export const isInterval = value => Interval.isInterval(value);
 
 /**
  * Calendar builder for a month in the specified year

--- a/src/Input/DatePickerInput/__tests__/DatePickerInput.test.js
+++ b/src/Input/DatePickerInput/__tests__/DatePickerInput.test.js
@@ -62,10 +62,10 @@ describe('<DatePickerInput />', () => {
     fireEvent.change(inputNode, { target: { value: inputValue } });
 
     const newSelectedDay = getByText('10');
-    const previouSelectedDay = getByText('15');
+    const previousSelectedDay = selectedDay;
 
-    expect(previouSelectedDay).not.toHaveStyleRule('color', Theme.palette.white);
-    expect(previouSelectedDay).not.toHaveStyleRule('background', Theme.palette.primary.default);
+    expect(previousSelectedDay).not.toHaveStyleRule('color');
+    expect(previousSelectedDay).not.toHaveStyleRule('background');
     expect(newSelectedDay).toHaveStyleRule('color', Theme.palette.white);
     expect(newSelectedDay).toHaveStyleRule('background', Theme.palette.primary.default);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7846,9 +7846,10 @@ lru-cache@^4.1.3, lru-cache@^4.1.5:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-luxon@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.3.3.tgz#e66e8537a62c9b351ba69b766d7fb70b07ab5e57"
+luxon@^1.11.4:
+  version "1.11.4"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.11.4.tgz#c5d8c1f795cee26c162e95a4686632abcec50442"
+  integrity sha512-zTQ1DCShOGHIdNpa56yjDpUCowKDsBqeFVuEG2XBcrAM2udxN0g3N5RTZzbw94OkDiBgECsuDgLNnQTo73yghw==
 
 make-dir@^1.0.0, make-dir@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description

Fix a bug who `<DatePicker />` did not allow interval (Luxon.Interval) in defaultValue

## Requirements
:warning: Requires running `yarn` command.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
