### PR TITLE
fix(Loader): use px instead of rem for Firefox support

### DIFF
--- a/src/DatePicker/__tests__/__snapshots__/DatePicker.test.js.snap
+++ b/src/DatePicker/__tests__/__snapshots__/DatePicker.test.js.snap
@@ -579,7 +579,7 @@ exports[`<DatePicker /> Range should render without a problem 1`] = `
         class="c10"
       >
         <div
-          class="c13"
+          class="c12"
         >
           21
         </div>
@@ -588,7 +588,7 @@ exports[`<DatePicker /> Range should render without a problem 1`] = `
         class="c10"
       >
         <div
-          class="c12"
+          class="c13"
         >
           22
         </div>
@@ -1321,7 +1321,7 @@ exports[`<DatePicker /> Simple should render without a problem 1`] = `
         class="c10"
       >
         <div
-          class="c13"
+          class="c12"
         >
           21
         </div>
@@ -1330,7 +1330,7 @@ exports[`<DatePicker /> Simple should render without a problem 1`] = `
         class="c10"
       >
         <div
-          class="c12"
+          class="c13"
         >
           22
         </div>

--- a/src/Loader/__tests__/__snapshots__/Loader.test.js.snap
+++ b/src/Loader/__tests__/__snapshots__/Loader.test.js.snap
@@ -16,9 +16,9 @@ exports[`<Loader /> should render without a problem  1`] = `
 <svg
   aria-hidden="true"
   class="c0"
-  height="2rem"
+  height="20px"
   viewBox="0 0 50 50"
-  width="2rem"
+  width="20px"
 >
   <circle
     class="path"

--- a/src/Loader/index.js
+++ b/src/Loader/index.js
@@ -50,8 +50,8 @@ Loader.propTypes = {
 Loader.defaultProps = {
   className: '',
   color: Theme.palette.primary.default,
-  height: '2rem',
-  width: '2rem',
+  height: '20px',
+  width: '20px',
 };
 
 export default styled(Loader)`


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Brief
Fix loader size for Firefox

## Description
The loader uses a svg and rem are not supported on Firefox 🦊 So instead we use pixels.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
