### PR TITLE
feat(KpiBlock): update component design for mobile

### DIFF
--- a/src/KpiBlock/README.md
+++ b/src/KpiBlock/README.md
@@ -15,12 +15,12 @@ import { KpiBlock } from '@tillersystems/stardust';
 - `value` - KpiBlock value.
 - `variation` - KpiBlock variation (negative or positive).
 
-| propName    |        propType         | defaultValue | isRequired |
-| ----------- | :---------------------: | :----------: | :--------: |
-| `className` |        `string`         |     `''`     |     -      |
-| `title`     |        `string`         |              |     \*     |
-| `value`     | `string` / `node | | \* |
-| `variation` |    `number` / `bool`    |              |     -      |
+| propName    |     propType      | defaultValue | isRequired |
+| ----------- | :---------------: | :----------: | :--------: |
+| `className` |     `string`      |     `''`     |     -      |
+| `title`     |     `string`      |              |     \*     |
+| `value`     | `string` / `node` |              |     \*     |
+| `variation` | `number` / `bool` |              |     -      |
 
 ### Example
 

--- a/src/KpiBlock/__stories__/KpiBlock.stories.js
+++ b/src/KpiBlock/__stories__/KpiBlock.stories.js
@@ -12,16 +12,18 @@ storiesOf('KpiBlock', module)
       max: 100,
       step: 10,
     };
-    const Variation = number('Variation', 50, options, 'Variation');
-    const Title = text('Title', 'Commandes', 'Title');
-    const Value = text('Value', '621', 'Value');
-    const hasVariation = boolean('HasVariation', true, 'Variation');
-    const withCustomValue = boolean('withCustomValue', false, 'Value');
+    const Variation = number('Variation', 50, options, 'ALL');
+    const Title = text('Title', 'Commandes', 'ALL');
+    const Value = text('Value', '621', 'ALL');
+    const hasVariation = boolean('HasVariation', true, 'ALL');
+    const withCustomValue = boolean('withCustomValue', false, 'ALL');
+    const isCompactedValue = boolean('isCompactedValue', false, 'ALL');
     return (
       <KpiBlock
         value={withCustomValue ? <div>19</div> : Value}
         title={Title}
         variation={hasVariation ? Variation : false}
+        isCompacted={isCompactedValue}
       />
     );
   });

--- a/src/KpiBlock/__tests__/KpiBlock.test.js
+++ b/src/KpiBlock/__tests__/KpiBlock.test.js
@@ -22,10 +22,25 @@ describe('<KpiBlock />', () => {
   });
 
   test('should render with a custom a value', () => {
-    const Custom = () => <div data-testid="customeValue">custom</div>;
+    const Custom = () => <div data-testid="customValue">custom</div>;
     const { getByTestId } = render(<KpiBlock title="title" value={<Custom />} variation={-100} />);
-    const customeValueNode = getByTestId('customeValue');
+    const customValueNode = getByTestId('customValue');
 
-    expect(customeValueNode).toBeInTheDocument();
+    expect(customValueNode).toBeInTheDocument();
+  });
+
+  test('should render with compacted style', () => {
+    const { container, getByText } = render(
+      <KpiBlock title="title" value="value" variation={-100} isCompacted />,
+    );
+    const titleNode = getByText('title');
+    const valueNode = getByText('value');
+
+    expect(titleNode).toHaveStyleRule('font-size', '1.2rem');
+    expect(valueNode).toHaveStyleRule('font-size', '2.6rem');
+    expect(container.firstChild).toHaveStyleRule(
+      'grid-template-areas',
+      "'title' 'value' 'variation'",
+    );
   });
 });

--- a/src/KpiBlock/__tests__/__snapshots__/KpiBlock.test.js.snap
+++ b/src/KpiBlock/__tests__/__snapshots__/KpiBlock.test.js.snap
@@ -10,13 +10,22 @@ exports[`<KpiBlock /> should render with a negative variation value 1`] = `
   line-height: 20;
 }
 
+.c4 {
+  grid-area: title;
+  color: hsl(207,13%,45%);
+  font-size: 1.4rem;
+  margin-top: 0.3rem;
+}
+
 .c3 {
+  grid-area: value;
   color: hsl(213,17%,20%);
   font-size: 3rem;
   font-weight: 500;
 }
 
 .c1 {
+  grid-area: variation;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -26,16 +35,10 @@ exports[`<KpiBlock /> should render with a negative variation value 1`] = `
   display: -ms-flexbox;
   display: flex;
   font-size: 1.2rem;
-  position: absolute;
   right: 1rem;
   top: 1rem;
+  justify-self: end;
   color: hsl(6,79%,65%);
-}
-
-.c4 {
-  color: hsl(207,13%,45%);
-  font-size: 1.4rem;
-  margin-top: 0.5rem;
 }
 
 .c0 {
@@ -48,15 +51,11 @@ exports[`<KpiBlock /> should render with a negative variation value 1`] = `
   border-radius: 0.4rem;
   box-shadow: 0 1px 3px 0 rgba(0,0,0,0.04);
   box-sizing: content-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  height: 6.6rem;
-  padding: 3rem 1rem;
+  display: grid;
+  grid-template-areas: 'variation' 'value' 'title';
+  height: 10rem;
+  grid-template-rows: max-content max-content max-content;
+  padding: 1rem;
   position: relative;
 }
 
@@ -114,13 +113,22 @@ exports[`<KpiBlock /> should render with a positive variation value 1`] = `
   line-height: 20;
 }
 
+.c4 {
+  grid-area: title;
+  color: hsl(207,13%,45%);
+  font-size: 1.4rem;
+  margin-top: 0.3rem;
+}
+
 .c3 {
+  grid-area: value;
   color: hsl(213,17%,20%);
   font-size: 3rem;
   font-weight: 500;
 }
 
 .c1 {
+  grid-area: variation;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -130,16 +138,10 @@ exports[`<KpiBlock /> should render with a positive variation value 1`] = `
   display: -ms-flexbox;
   display: flex;
   font-size: 1.2rem;
-  position: absolute;
   right: 1rem;
   top: 1rem;
+  justify-self: end;
   color: hsl(89,53%,52%);
-}
-
-.c4 {
-  color: hsl(207,13%,45%);
-  font-size: 1.4rem;
-  margin-top: 0.5rem;
 }
 
 .c0 {
@@ -152,15 +154,11 @@ exports[`<KpiBlock /> should render with a positive variation value 1`] = `
   border-radius: 0.4rem;
   box-shadow: 0 1px 3px 0 rgba(0,0,0,0.04);
   box-sizing: content-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  height: 6.6rem;
-  padding: 3rem 1rem;
+  display: grid;
+  grid-template-areas: 'variation' 'value' 'title';
+  height: 10rem;
+  grid-template-rows: max-content max-content max-content;
+  padding: 1rem;
   position: relative;
 }
 
@@ -210,16 +208,18 @@ exports[`<KpiBlock /> should render with a positive variation value 1`] = `
 `;
 
 exports[`<KpiBlock /> should render without a problem 1`] = `
+.c2 {
+  grid-area: title;
+  color: hsl(207,13%,45%);
+  font-size: 1.4rem;
+  margin-top: 0.3rem;
+}
+
 .c1 {
+  grid-area: value;
   color: hsl(213,17%,20%);
   font-size: 3rem;
   font-weight: 500;
-}
-
-.c2 {
-  color: hsl(207,13%,45%);
-  font-size: 1.4rem;
-  margin-top: 0.5rem;
 }
 
 .c0 {
@@ -232,15 +232,11 @@ exports[`<KpiBlock /> should render without a problem 1`] = `
   border-radius: 0.4rem;
   box-shadow: 0 1px 3px 0 rgba(0,0,0,0.04);
   box-sizing: content-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  height: 6.6rem;
-  padding: 3rem 1rem;
+  display: grid;
+  grid-template-areas: 'variation' 'value' 'title';
+  height: 10rem;
+  grid-template-rows: max-content max-content max-content;
+  padding: 1rem;
   position: relative;
 }
 

--- a/src/KpiBlock/elements.js
+++ b/src/KpiBlock/elements.js
@@ -3,14 +3,16 @@ import styled, { css } from 'styled-components';
 export const Title = styled.div`
   grid-area: title;
   color: ${({ theme: { palette } }) => palette.spaceGrey};
-  font-size: ${({ theme: { fonts } }) => fonts.size.medium};
+  font-size: ${({ isCompacted, theme: { fonts } }) =>
+    isCompacted ? fonts.size.default : fonts.size.medium};
   margin-top: 0.3rem;
 `;
 
 export const Value = styled.div`
   grid-area: value;
   color: ${({ theme: { palette } }) => palette.darkBlue};
-  font-size: ${({ theme: { fonts } }) => fonts.size.h2};
+  font-size: ${({ isCompacted, theme: { fonts } }) =>
+    isCompacted ? fonts.size.h3 : fonts.size.h2};
   font-weight: ${({ theme: { fonts } }) => fonts.weight.thick};
 `;
 
@@ -21,7 +23,7 @@ export const Variation = styled.div`
   font-size: ${({ theme: { fonts } }) => fonts.size.default};
   right: 1rem;
   top: 1rem;
-  justify-self: end;
+  justify-self: ${({ isCompacted }) => (isCompacted ? 'center' : 'end')};
 
   /* Negative */
   ${({ negative }) =>

--- a/src/KpiBlock/elements.js
+++ b/src/KpiBlock/elements.js
@@ -1,18 +1,27 @@
 import styled, { css } from 'styled-components';
 
+export const Title = styled.div`
+  grid-area: title;
+  color: ${({ theme: { palette } }) => palette.spaceGrey};
+  font-size: ${({ theme: { fonts } }) => fonts.size.medium};
+  margin-top: 0.3rem;
+`;
+
 export const Value = styled.div`
+  grid-area: value;
   color: ${({ theme: { palette } }) => palette.darkBlue};
   font-size: ${({ theme: { fonts } }) => fonts.size.h2};
   font-weight: ${({ theme: { fonts } }) => fonts.weight.thick};
 `;
 
 export const Variation = styled.div`
+  grid-area: variation;
   align-items: center;
   display: flex;
   font-size: ${({ theme: { fonts } }) => fonts.size.default};
-  position: absolute;
   right: 1rem;
   top: 1rem;
+  justify-self: end;
 
   /* Negative */
   ${({ negative }) =>
@@ -27,10 +36,4 @@ export const Variation = styled.div`
     css`
       color: ${({ theme: { palette } }) => palette.success.default};
     `};
-`;
-
-export const Title = styled.div`
-  color: ${({ theme: { palette } }) => palette.spaceGrey};
-  font-size: ${({ theme: { fonts } }) => fonts.size.medium};
-  margin-top: 0.5rem;
 `;

--- a/src/KpiBlock/index.js
+++ b/src/KpiBlock/index.js
@@ -63,9 +63,10 @@ export default styled(KpiBlock)`
   border-radius: ${({ theme: { dimensions } }) => dimensions.radius};
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.04);
   box-sizing: content-box;
-  display: flex;
-  flex-direction: column;
-  height: 6.6rem;
-  padding: 3rem 1rem;
+  display: grid;
+  grid-template-areas: 'variation' 'value' 'title';
+  grid-template-rows: max-content max-content max-content;
+  height: 10rem;
+  padding: 1rem;
   position: relative;
 `;

--- a/src/KpiBlock/index.js
+++ b/src/KpiBlock/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { Icon, Theme } from '..';
 import { Title, Value, Variation } from './elements';
@@ -15,25 +15,26 @@ import { Title, Value, Variation } from './elements';
  * @param {string} title // KpiBlock title.
  * @param {string} value // KpiBlock value.
  * @param {number} variation // KpiBlock variation (negative or positive).
+ * @param {boolean} isCompacted // Display or not mobile version of the component
  *
  * @return {jsx}
  */
 
-const KpiBlock = ({ className, title, value, variation }) => (
+const KpiBlock = ({ className, title, value, variation, isCompacted }) => (
   <div className={className}>
     {variation !== false && variation < 0 && (
-      <Variation negative>
+      <Variation negative isCompacted={isCompacted}>
         {variation.toFixed(2)} % <Icon name="caret-down" color={Theme.palette.failure.default} />
       </Variation>
     )}
     {variation !== false && variation >= 0 && (
-      <Variation positive>
+      <Variation positive isCompacted={isCompacted}>
         +{variation.toFixed(2)} % <Icon name="caret-up" color={Theme.palette.success.default} />
       </Variation>
     )}
-    {typeof value === 'string' && <Value>{value}</Value>}
+    {typeof value === 'string' && <Value isCompacted={isCompacted}>{value}</Value>}
     {React.isValidElement(value) && value}
-    <Title>{title}</Title>
+    <Title isCompacted={isCompacted}>{title}</Title>
   </div>
 );
 
@@ -43,6 +44,7 @@ const KpiBlock = ({ className, title, value, variation }) => (
 const { bool, number, node, oneOfType, string } = PropTypes;
 KpiBlock.propTypes = {
   className: string,
+  isCompacted: bool,
   title: string.isRequired,
   value: oneOfType([string, node]).isRequired,
   variation: oneOfType([bool, number]),
@@ -53,6 +55,7 @@ KpiBlock.propTypes = {
  */
 KpiBlock.defaultProps = {
   className: '',
+  isCompacted: false,
   variation: false,
 };
 
@@ -64,9 +67,17 @@ export default styled(KpiBlock)`
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.04);
   box-sizing: content-box;
   display: grid;
-  grid-template-areas: 'variation' 'value' 'title';
-  grid-template-rows: max-content max-content max-content;
-  height: 10rem;
-  padding: 1rem;
+  grid-template-areas: ${({ isCompacted }) =>
+    isCompacted ? "'title' 'value' 'variation'" : "'variation' 'value' 'title'"};
+
+  height: ${({ isCompacted }) => (isCompacted ? '7.8rem' : '10rem')};
+
+  ${({ isCompacted }) =>
+    !isCompacted &&
+    css`
+      grid-template-rows: max-content max-content max-content;
+    `};
+
+  padding: ${({ isCompacted }) => (isCompacted ? '1.2rem' : '1rem')};
   position: relative;
 `;


### PR DESCRIPTION
- [ ] Feature
- [ ] Fix
- [x] Enhancement

## Brief
Update of KpiBlock for mobile.

## Description
Updated style of KpiBlock according to [design for Sonar](https://app.zeplin.io/project/5c08e7dab171cd2fd787d7d6/screen/5c9cd3fc66d66477528d2c6a)

Normal
<img width="429" alt="Screenshot 2019-04-01 at 18 48 22" src="https://user-images.githubusercontent.com/6019103/55345546-6d863500-54b0-11e9-9cb8-524883e313c9.png">

isCompacted
<img width="427" alt="Screenshot 2019-04-01 at 18 48 29" src="https://user-images.githubusercontent.com/6019103/55345547-6e1ecb80-54b0-11e9-8e46-36923ceaa544.png">

## Requirements :
<!--- Eventually remove the following. -->
:warning: Requires running `yarn` command.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
