### PR TITLE
feat(TabSwitcher): add new TabSwitcher component

### DIFF
--- a/src/TabSwitcher/Pane/index.js
+++ b/src/TabSwitcher/Pane/index.js
@@ -7,7 +7,7 @@ const { node, string } = PropTypes;
  * A pane wraps the content displayable by a tab
  *
  * @param {node} children // Anything that can be rendered: numbers, strings, elements or an array (or fragment)
- * @param {string} className /// className needed by styled components
+ * @param {string} className // className needed by styled components
  *
  * @return {jsx}
  */

--- a/src/TabSwitcher/Pane/index.js
+++ b/src/TabSwitcher/Pane/index.js
@@ -1,0 +1,29 @@
+import React, { memo } from 'react';
+import PropTypes from 'prop-types';
+
+const { node, string } = PropTypes;
+
+/**
+ * A pane wraps the content displayable by a tab
+ *
+ * @param {node} children // Anything that can be rendered: numbers, strings, elements or an array (or fragment)
+ * @param {string} className /// className needed by styled components
+ *
+ * @return {jsx}
+ */
+
+const Pane = ({ children, className }) => <div className={className}>{children}</div>;
+
+/** Prop types. */
+Pane.propTypes = {
+  children: node,
+  className: string,
+};
+
+/** Default props. */
+Pane.defaultProps = {
+  children: null,
+  className: '',
+};
+
+export default memo(Pane);

--- a/src/TabSwitcher/Panes/elements.js
+++ b/src/TabSwitcher/Panes/elements.js
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+`;

--- a/src/TabSwitcher/Panes/elements.js
+++ b/src/TabSwitcher/Panes/elements.js
@@ -4,4 +4,5 @@ export const Container = styled.div`
   width: 100%;
   height: 100%;
   display: flex;
+  padding: ${({ isCompacted }) => (isCompacted ? '1.2rem 1.6rem' : '2.4rem 3rem')};
 `;

--- a/src/TabSwitcher/Panes/index.js
+++ b/src/TabSwitcher/Panes/index.js
@@ -1,40 +1,42 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Container } from './elements';
 
-const { node, number, string } = PropTypes;
+const { bool, node, number, string } = PropTypes;
 
 /**
  * Panes hold the content of interactive tabs
  *
  * @param {number} activeIndex // index of the active tab
- * @param {string} className /// className needed by styled components
+ * @param {node} children // Anything that can be rendered: numbers, strings, elements or an array (or fragment)
+ * @param {string} className // className needed by styled components
+ * @param {boolean} isCompacted // if it should reduce its size by reducing padding and font-size
  *
  * @return {jsx}
  */
-class Panes extends PureComponent {
-  static displayName = 'Panes';
+const Panes = ({ activeIndex, children, className, isCompacted }) => (
+  <Container className={className} isCompacted={isCompacted}>
+    {children[activeIndex]}
+  </Container>
+);
 
-  /** Prop types. */
-  static propTypes = {
-    activeIndex: number,
-    children: node,
-    className: string,
-  };
+Panes.displayName = 'Panes';
 
-  /** Default props. */
-  static defaultProps = {
-    activeIndex: 0,
-    children: null,
-    className: '',
-  };
+/** Prop types. */
+Panes.propTypes = {
+  activeIndex: number,
+  children: node,
+  className: string,
+  isCompacted: bool,
+};
 
-  render() {
-    const { activeIndex, children, className } = this.props;
-
-    return <Container className={className}>{children[activeIndex]}</Container>;
-  }
-}
+/** Default props. */
+Panes.defaultProps = {
+  activeIndex: 0,
+  children: null,
+  className: '',
+  isCompacted: false,
+};
 
 export default Panes;

--- a/src/TabSwitcher/Panes/index.js
+++ b/src/TabSwitcher/Panes/index.js
@@ -1,0 +1,40 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+import { Container } from './elements';
+
+const { node, number, string } = PropTypes;
+
+/**
+ * Panes hold the content of interactive tabs
+ *
+ * @param {number} activeIndex // index of the active tab
+ * @param {string} className /// className needed by styled components
+ *
+ * @return {jsx}
+ */
+class Panes extends PureComponent {
+  static displayName = 'Panes';
+
+  /** Prop types. */
+  static propTypes = {
+    activeIndex: number,
+    children: node,
+    className: string,
+  };
+
+  /** Default props. */
+  static defaultProps = {
+    activeIndex: 0,
+    children: null,
+    className: '',
+  };
+
+  render() {
+    const { activeIndex, children, className } = this.props;
+
+    return <Container className={className}>{children[activeIndex]}</Container>;
+  }
+}
+
+export default Panes;

--- a/src/TabSwitcher/README.md
+++ b/src/TabSwitcher/README.md
@@ -1,0 +1,57 @@
+# TabSwitcher
+
+### Usage
+
+```jsx
+import { TabSwitcher } from '@tillersystems/stardust';
+```
+
+<!-- STORY -->
+
+### Properties
+
+- `children` - Class needed by styled components.
+
+| `propName` | propType | defaultValue | isRequired |
+| ---------- | :------: | :----------: | :--------: |
+| `children` |  `node`  |    `null`    |     -      |
+
+### Example
+
+```jsx
+import { TabSwitcher } from '@tillersystems/stardust';
+
+const panes = [
+  {
+    name: 'Tab 1',
+    content: 'Content 1',
+  },
+  {
+    name: 'Tab 2',
+    content: 'Content 2',
+  },
+  {
+    name: 'Tab 3',
+    content: 'Content 3',
+  },
+  {
+    name: 'Tab 4',
+    content: 'Content 4',
+  },
+];
+
+render() {
+  <TabSwitcher>
+    <TabSwitcher.Tabs>
+      {panes.map(({ name }) => (
+        <TabSwitcher.Tab key={name}>{name}</TabSwitcher.Tab>
+      ))}
+    </TabSwitcher.Tabs>
+    <TabSwitcher.Panes>
+      {panes.map(({ name, content }) => (
+        <TabSwitcher.Pane key={name}>{content}</TabSwitcher.Pane>
+      ))}
+    </TabSwitcher.Panes>
+  </TabSwitcher>
+}
+```

--- a/src/TabSwitcher/README.md
+++ b/src/TabSwitcher/README.md
@@ -10,11 +10,17 @@ import { TabSwitcher } from '@tillersystems/stardust';
 
 ### Properties
 
-- `children` - Class needed by styled components.
+- `activeIndex` - index of the active tab
+- `children` - tabs and panes to be displayed
+- `isCompacted` - if it should reduce its size by reducing padding and font-size
+- `onActiveTabChange` - onActiveTabChange - callback triggered when the active tab changes
 
-| `propName` | propType | defaultValue | isRequired |
-| ---------- | :------: | :----------: | :--------: |
-| `children` |  `node`  |    `null`    |     -      |
+| propName            | propType  | defaultValue | isRequired |
+| ------------------- | :-------: | :----------: | :--------: |
+| `activeIndex`       | `number`  |     `0`      |     -      |
+| `children`          |  `node`   |    `null`    |     -      |
+| `isCompacted`       | `boolean` |   `false`    |     -      |
+| `onActiveTabChange` |  `func`   |  `() => {}`  |     -      |
 
 ### Example
 

--- a/src/TabSwitcher/Tab/elements.js
+++ b/src/TabSwitcher/Tab/elements.js
@@ -1,0 +1,27 @@
+import styled, { css } from 'styled-components';
+
+export const Container = styled.div`
+  ${({ isActive }) =>
+    isActive &&
+    css`
+      border-bottom: 3px solid ${({ theme: { palette } }) => palette.primary.default};
+    `}
+  color: ${({ isActive, isDisabled, theme: { palette } }) =>
+    isActive ? palette.darkBlue : isDisabled ? palette.mediumGrey : palette.spaceGrey};
+  ${({ isActive, isDisabled }) =>
+    !isActive &&
+    !isDisabled &&
+    css`
+      cursor: pointer;
+    `}
+  font-size: ${({ isCompacted, theme: { fonts } }) =>
+    isCompacted ? fonts.size.medium : fonts.size.h6};
+  font-weight: ${({
+    isActive,
+    theme: {
+      fonts: { weight },
+    },
+  }) => (isActive ? weight.thick : weight.normal)};
+  margin-right: 1.5rem;
+  padding-bottom: ${({ isCompacted }) => (isCompacted ? '1.2rem' : '1.5rem')};
+`;

--- a/src/TabSwitcher/Tab/index.js
+++ b/src/TabSwitcher/Tab/index.js
@@ -1,0 +1,51 @@
+import React, { memo } from 'react';
+import PropTypes from 'prop-types';
+import { Container } from './elements';
+
+const { bool, func, node, string } = PropTypes;
+
+/**
+ * Tab are a link displaying the content of a pane
+ *
+ * @param {node} children // Anything that can be rendered: numbers, strings, elements or an array (or fragment)
+ * @param {string} className // className needed by styled components
+ * @param {boolean} isActive // if the tab is the current displayed content
+ * @param {boolean} isCompacted // if it should reduce its size by reducing padding and font-size
+ * @param {boolean} isDisabled // if this tab should be interactive or not
+ * @param {function} onActivate - callback triggered when the tab is clicked
+ *
+ * @return {jsx}
+ */
+const Tab = ({ children, className, isActive, isCompacted, isDisabled, onActivate }) => (
+  <Container
+    className={className}
+    onClick={isDisabled ? null : () => onActivate()}
+    isActive={isActive}
+    isDisabled={isDisabled}
+    isCompacted={isCompacted}
+  >
+    {children}
+  </Container>
+);
+
+/** Prop types. */
+Tab.propTypes = {
+  children: node,
+  onActivate: func,
+  isActive: bool,
+  isCompacted: bool,
+  isDisabled: bool,
+  className: string,
+};
+
+/** Default props. */
+Tab.defaultProps = {
+  children: null,
+  onActivate: () => {},
+  isActive: false,
+  isCompacted: false,
+  isDisabled: false,
+  className: '',
+};
+
+export default memo(Tab);

--- a/src/TabSwitcher/Tabs/elements.js
+++ b/src/TabSwitcher/Tabs/elements.js
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+`;

--- a/src/TabSwitcher/Tabs/elements.js
+++ b/src/TabSwitcher/Tabs/elements.js
@@ -2,4 +2,6 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
   display: flex;
+  border-bottom: 1px solid ${({ theme: { palette } }) => palette.lightGrey};
+  padding: ${({ isCompacted }) => (isCompacted ? '1.2rem 1.6rem 0 1.6rem' : '2.4rem 3rem 0 3rem')};
 `;

--- a/src/TabSwitcher/Tabs/index.js
+++ b/src/TabSwitcher/Tabs/index.js
@@ -19,6 +19,7 @@ const Tabs = ({ activeIndex, children, className, isCompacted, onActiveTab }) =>
   <Container className={className} isCompacted={isCompacted}>
     {Children.map(children, (child, index) =>
       cloneElement(child, {
+        isCompacted,
         isActive: index === activeIndex,
         onActivate: () => {
           onActiveTab(index);

--- a/src/TabSwitcher/Tabs/index.js
+++ b/src/TabSwitcher/Tabs/index.js
@@ -1,0 +1,51 @@
+import React, { Children, cloneElement } from 'react';
+import PropTypes from 'prop-types';
+import { Container } from './elements';
+
+const { bool, func, node, number, string } = PropTypes;
+
+/**
+ * Tabs are links displaying the content of a pane
+ *
+ * @param {number} activeIndex // index of the active tab
+ * @param {Array} children // interactive links displaying tabs on click
+ * @param {string} className // className needed by styled components
+ * @param {boolean} isCompacted // if it should reduce its size by reducing padding and font-size
+ * @param {function} onActiveTab // callback triggered when the tab is clicked
+ *
+ * @return {jsx}
+ */
+const Tabs = ({ activeIndex, children, className, isCompacted, onActiveTab }) => (
+  <Container className={className} isCompacted={isCompacted}>
+    {Children.map(children, (child, index) =>
+      cloneElement(child, {
+        isActive: index === activeIndex,
+        onActivate: () => {
+          onActiveTab(index);
+        },
+      }),
+    )}
+  </Container>
+);
+
+Tabs.displayName = 'Tabs';
+
+/** Prop types. */
+Tabs.propTypes = {
+  activeIndex: number,
+  children: node,
+  className: string,
+  isCompacted: bool,
+  onActiveTab: func,
+};
+
+/** Default props. */
+Tabs.defaultProps = {
+  activeIndex: 0,
+  children: null,
+  className: '',
+  isCompacted: false,
+  onActiveTab: () => {},
+};
+
+export default Tabs;

--- a/src/TabSwitcher/__stories__/TabSwitcher.stories.js
+++ b/src/TabSwitcher/__stories__/TabSwitcher.stories.js
@@ -1,0 +1,67 @@
+/* eslint-disable react/display-name */
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, boolean, number } from '@storybook/addon-knobs';
+
+import TabSwitcher from '..';
+
+storiesOf('TabSwitcher', module)
+  .addDecorator(withKnobs)
+  .add('default', () => {
+    const isDisabledValueTab1 = boolean('isDisabledTab1', false, 'ALL');
+    const isDisabledValueTab2 = boolean('isDisabledTab2', false, 'ALL');
+    const isDisabledValueTab3 = boolean('isDisabledTab3', false, 'ALL');
+    const isDisabledValueTab4 = boolean('isDisabledTab4', false, 'ALL');
+
+    const panes = [
+      {
+        name: 'Tab 1',
+        content: 'Content 1',
+        isDisabled: isDisabledValueTab1,
+      },
+      {
+        name: 'Tab 2',
+        content: 'Content 2',
+        isDisabled: isDisabledValueTab2,
+      },
+      {
+        name: 'Tab 3',
+        content: 'Content 3',
+        isDisabled: isDisabledValueTab3,
+      },
+      {
+        name: 'Tab 4',
+        content: 'Content 4',
+        isDisabled: isDisabledValueTab4,
+      },
+    ];
+
+    const activeIndexValue = number(
+      'activeIndex',
+      0,
+      {
+        range: true,
+        min: 0,
+        max: 3,
+        step: 1,
+      },
+      'ALL',
+    );
+
+    return (
+      <TabSwitcher activeIndex={activeIndexValue}>
+        <TabSwitcher.Tabs>
+          {panes.map(({ isDisabled, name }) => (
+            <TabSwitcher.Tab key={name} isDisabled={isDisabled}>
+              {name}
+            </TabSwitcher.Tab>
+          ))}
+        </TabSwitcher.Tabs>
+        <TabSwitcher.Panes>
+          {panes.map(({ name, content }) => (
+            <TabSwitcher.Pane key={name}>{content}</TabSwitcher.Pane>
+          ))}
+        </TabSwitcher.Panes>
+      </TabSwitcher>
+    );
+  });

--- a/src/TabSwitcher/__stories__/TabSwitcher.stories.js
+++ b/src/TabSwitcher/__stories__/TabSwitcher.stories.js
@@ -13,6 +13,8 @@ storiesOf('TabSwitcher', module)
     const isDisabledValueTab3 = boolean('isDisabledTab3', false, 'ALL');
     const isDisabledValueTab4 = boolean('isDisabledTab4', false, 'ALL');
 
+    const isCompactedValue = boolean('isCompactedValue', false, 'ALL');
+
     const panes = [
       {
         name: 'Tab 1',
@@ -49,7 +51,7 @@ storiesOf('TabSwitcher', module)
     );
 
     return (
-      <TabSwitcher activeIndex={activeIndexValue}>
+      <TabSwitcher activeIndex={activeIndexValue} isCompacted={isCompactedValue}>
         <TabSwitcher.Tabs>
           {panes.map(({ isDisabled, name }) => (
             <TabSwitcher.Tab key={name} isDisabled={isDisabled}>

--- a/src/TabSwitcher/__tests__/TabSwitcher.test.js
+++ b/src/TabSwitcher/__tests__/TabSwitcher.test.js
@@ -52,6 +52,27 @@ describe('<TabSwitcher />', () => {
     expect(availableTabNode).toHaveStyleRule('color', 'hsl(207,13%,45%)');
   });
 
+  test('should render the compacted version', () => {
+    const { getByText } = render(
+      <TabSwitcher isCompacted>
+        <TabSwitcher.Tabs>
+          {panes.map(({ name }) => (
+            <TabSwitcher.Tab key={name}>{name}</TabSwitcher.Tab>
+          ))}
+        </TabSwitcher.Tabs>
+        <TabSwitcher.Panes>
+          {panes.map(({ name, content }) => (
+            <TabSwitcher.Pane key={name}>{content}</TabSwitcher.Pane>
+          ))}
+        </TabSwitcher.Panes>
+      </TabSwitcher>,
+    );
+
+    const activeTabNode = getByText('I am active');
+
+    expect(activeTabNode).toHaveStyleRule('padding-bottom', '1.2rem');
+  });
+
   test('should correctly display disabled tabs', () => {
     const { getAllByText } = render(
       <TabSwitcher>
@@ -77,8 +98,10 @@ describe('<TabSwitcher />', () => {
   });
 
   test('should update tab on click', () => {
+    const spy = jest.fn();
+
     const { getByText } = render(
-      <TabSwitcher>
+      <TabSwitcher onActiveTabChange={spy}>
         <TabSwitcher.Tabs>
           {panes.map(({ name, isDisabled }) => (
             <TabSwitcher.Tab key={name} isDisabled={isDisabled}>
@@ -102,6 +125,7 @@ describe('<TabSwitcher />', () => {
 
     fireEvent.click(availableTabNode);
 
+    expect(spy).toHaveBeenCalledTimes(1);
     expect(availableTabNode).toHaveStyleRule('border-bottom', '3px solid hsl(200,74%,46%)');
     expect(activeTabNode).toHaveStyleRule('color', 'hsl(207,13%,45%)');
   });

--- a/src/TabSwitcher/__tests__/TabSwitcher.test.js
+++ b/src/TabSwitcher/__tests__/TabSwitcher.test.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import { fireEvent } from 'react-testing-library';
+
+import TabSwitcher from '..';
+
+const panes = [
+  {
+    name: 'I am active',
+    content: 'Content 1',
+    isDisabled: false,
+  },
+  {
+    name: 'I am disabled',
+    content: 'Content 2',
+    isDisabled: true,
+  },
+  {
+    name: 'I am disabled too',
+    content: 'Content 3',
+    isDisabled: true,
+  },
+  {
+    name: 'I am available',
+    content: 'Content 4',
+    isDisabled: false,
+  },
+];
+
+describe('<TabSwitcher />', () => {
+  test('should render without a problem', () => {
+    const { getByText, queryAllByText } = render(
+      <TabSwitcher>
+        <TabSwitcher.Tabs>
+          {panes.map(({ name }) => (
+            <TabSwitcher.Tab key={name}>{name}</TabSwitcher.Tab>
+          ))}
+        </TabSwitcher.Tabs>
+        <TabSwitcher.Panes>
+          {panes.map(({ name, content }) => (
+            <TabSwitcher.Pane key={name}>{content}</TabSwitcher.Pane>
+          ))}
+        </TabSwitcher.Panes>
+      </TabSwitcher>,
+    );
+
+    const tabs = queryAllByText(/I am/);
+    const activeTabNode = getByText('I am active');
+    const availableTabNode = getByText('I am available');
+
+    expect(tabs).toHaveLength(4);
+    expect(activeTabNode).toHaveStyleRule('border-bottom', '3px solid hsl(200,74%,46%)');
+    expect(availableTabNode).toHaveStyleRule('color', 'hsl(207,13%,45%)');
+  });
+
+  test('should correctly display disabled tabs', () => {
+    const { getAllByText } = render(
+      <TabSwitcher>
+        <TabSwitcher.Tabs>
+          {panes.map(({ name, isDisabled }) => (
+            <TabSwitcher.Tab key={name} isDisabled={isDisabled}>
+              {name}
+            </TabSwitcher.Tab>
+          ))}
+        </TabSwitcher.Tabs>
+        <TabSwitcher.Panes>
+          {panes.map(({ name, content }) => (
+            <TabSwitcher.Pane key={name}>{content}</TabSwitcher.Pane>
+          ))}
+        </TabSwitcher.Panes>
+      </TabSwitcher>,
+    );
+
+    const disabledTabNodes = getAllByText(/I am disabled/);
+
+    expect(disabledTabNodes[0]).toHaveStyleRule('color', 'hsl(206,23%,69%)');
+    expect(disabledTabNodes[1]).toHaveStyleRule('color', 'hsl(206,23%,69%)');
+  });
+
+  test('should update tab on click', () => {
+    const { getByText } = render(
+      <TabSwitcher>
+        <TabSwitcher.Tabs>
+          {panes.map(({ name, isDisabled }) => (
+            <TabSwitcher.Tab key={name} isDisabled={isDisabled}>
+              {name}
+            </TabSwitcher.Tab>
+          ))}
+        </TabSwitcher.Tabs>
+        <TabSwitcher.Panes>
+          {panes.map(({ name, content }) => (
+            <TabSwitcher.Pane key={name}>{content}</TabSwitcher.Pane>
+          ))}
+        </TabSwitcher.Panes>
+      </TabSwitcher>,
+    );
+
+    const activeTabNode = getByText('I am active');
+    const availableTabNode = getByText('I am available');
+
+    expect(activeTabNode).toHaveStyleRule('border-bottom', '3px solid hsl(200,74%,46%)');
+    expect(availableTabNode).toHaveStyleRule('color', 'hsl(207,13%,45%)');
+
+    fireEvent.click(availableTabNode);
+
+    expect(availableTabNode).toHaveStyleRule('border-bottom', '3px solid hsl(200,74%,46%)');
+    expect(activeTabNode).toHaveStyleRule('color', 'hsl(207,13%,45%)');
+  });
+});

--- a/src/TabSwitcher/index.js
+++ b/src/TabSwitcher/index.js
@@ -12,6 +12,11 @@ const { bool, func, node, number } = PropTypes;
  * A TabSwitcher wraps all the logic between tabs (elements allowing to display content)
  * and panes (content displayable when its tab is clicked)
  *
+ * @param {number} activeIndex - index of the active tab
+ * @param {node} children - tabs and panes to be displayed
+ * @param {boolean} isCompacted - if it should reduce its size by reducing padding and font-size
+ * @param {function} onActiveTabChange - callback triggered when the active tab changes
+ *
  * @return {jsx}
  */
 class TabSwitcher extends PureComponent {
@@ -23,7 +28,7 @@ class TabSwitcher extends PureComponent {
   /** Prop types. */
   static propTypes = {
     activeIndex: number,
-    children: node,
+    children: node.isRequired,
     isCompacted: bool,
     onActiveTabChange: func,
   };
@@ -31,7 +36,6 @@ class TabSwitcher extends PureComponent {
   /** Default props. */
   static defaultProps = {
     activeIndex: null,
-    children: null,
     isCompacted: false,
     onActiveTabChange: () => {},
   };

--- a/src/TabSwitcher/index.js
+++ b/src/TabSwitcher/index.js
@@ -1,0 +1,88 @@
+import React, { Children, cloneElement, PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+import Pane from './Pane';
+import Panes from './Panes';
+import Tab from './Tab';
+import Tabs from './Tabs';
+
+const { func, node, number } = PropTypes;
+
+/**
+ * A TabSwitcher wraps all the logic between tabs (elements allowing to display content)
+ * and panes (content displayable when its tab is clicked)
+ *
+ * @return {jsx}
+ */
+class TabSwitcher extends PureComponent {
+  static Pane = Pane;
+  static Panes = Panes;
+  static Tab = Tab;
+  static Tabs = Tabs;
+
+  /** Prop types. */
+  static propTypes = {
+    activeIndex: number,
+    children: node,
+    onActiveTabChange: func,
+  };
+
+  /** Default props. */
+  static defaultProps = {
+    activeIndex: null,
+    children: null,
+    onActiveTabChange: () => {},
+  };
+
+  /** Internal state. */
+  state = {
+    activeIndex: 0,
+  };
+
+  /**
+   * Component lifecycle method
+   * Set activeIndex if provided by parent
+   *
+   */
+  componentDidMount() {
+    const { activeIndex } = this.props;
+    activeIndex !== null && this.setState({ activeIndex });
+  }
+
+  /**
+   * Callback that sets the active index when a tab is clicked.
+   * Allows the component to display the proper pane.
+   * If provided, triggers a callback for the parent component
+   */
+  onActiveTab = activeIndex => {
+    const { onActiveTabChange } = this.props;
+
+    this.setState({ activeIndex }, () => {
+      onActiveTabChange(activeIndex);
+    });
+  };
+
+  render() {
+    const { children } = this.props;
+    const { activeIndex } = this.state;
+
+    const content = Children.map(children, child => {
+      if (child.type.displayName === 'Panes') {
+        return cloneElement(child, {
+          activeIndex: activeIndex,
+        });
+      } else if (child.type.displayName === 'Tabs') {
+        return cloneElement(child, {
+          activeIndex: activeIndex,
+          onActiveTab: this.onActiveTab,
+        });
+      } else {
+        return child;
+      }
+    });
+
+    return <div>{content}</div>;
+  }
+}
+
+export default TabSwitcher;

--- a/src/TabSwitcher/index.js
+++ b/src/TabSwitcher/index.js
@@ -6,7 +6,7 @@ import Panes from './Panes';
 import Tab from './Tab';
 import Tabs from './Tabs';
 
-const { func, node, number } = PropTypes;
+const { bool, func, node, number } = PropTypes;
 
 /**
  * A TabSwitcher wraps all the logic between tabs (elements allowing to display content)
@@ -24,6 +24,7 @@ class TabSwitcher extends PureComponent {
   static propTypes = {
     activeIndex: number,
     children: node,
+    isCompacted: bool,
     onActiveTabChange: func,
   };
 
@@ -31,6 +32,7 @@ class TabSwitcher extends PureComponent {
   static defaultProps = {
     activeIndex: null,
     children: null,
+    isCompacted: false,
     onActiveTabChange: () => {},
   };
 
@@ -63,18 +65,20 @@ class TabSwitcher extends PureComponent {
   };
 
   render() {
-    const { children } = this.props;
+    const { children, isCompacted } = this.props;
     const { activeIndex } = this.state;
 
     const content = Children.map(children, child => {
       if (child.type.displayName === 'Panes') {
         return cloneElement(child, {
           activeIndex: activeIndex,
+          isCompacted: isCompacted,
         });
       } else if (child.type.displayName === 'Tabs') {
         return cloneElement(child, {
           activeIndex: activeIndex,
           onActiveTab: this.onActiveTab,
+          isCompacted: isCompacted,
         });
       } else {
         return child;

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ export { default as RadioButton } from './RadioButton';
 export { default as RadioGroup } from './RadioGroup';
 export { default as Select } from './Select';
 export { default as Table } from './Table';
+export { default as TabSwitcher } from './TabSwitcher';
 export { default as Tag } from './Tag';
 export { default as Theme } from './Theme';
 export { default as ToggleButton } from './ToggleButton';


### PR DESCRIPTION
- [x] Feature
- [ ] Fix
- [ ] Enhancement

## Brief
Add new TabSwitcher component.

## Description
The TabSwitcher can hold content provided on instanciation and has a mobile version handled by the prop `isCompacted`. The component has been created following the compound components pattern. The tabs will need to have its style customized if they are elsewhere than at the top of the panes in order to fit design. 

In the future, animation may be nice to add to animate the blue underline of the selected tab (but for now, each Tab is a separate component so it may need to change).

cf design: [desktop](https://app.zeplin.io/project/5c08e7dab171cd2fd787d7d6/screen/5c505a64ef01a50342e6aaf7) and [mobile](https://app.zeplin.io/project/5c08e7dab171cd2fd787d7d6/screen/5ca5fd0374b8e63e5e5bc9dd)

<img width="839" alt="Screenshot 2019-04-04 at 15 47 25" src="https://user-images.githubusercontent.com/6019103/55560657-fc819000-56f0-11e9-9c89-9a69c0f2c68f.png">
<img width="838" alt="Screenshot 2019-04-04 at 15 47 35" src="https://user-images.githubusercontent.com/6019103/55560659-fc819000-56f0-11e9-9145-18d9fc9e78b9.png">

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
