### PR TITLE
fix(Modal): add z-index to overlay to avoid elements overlapping it

### DIFF
--- a/src/Modal/elements.js
+++ b/src/Modal/elements.js
@@ -25,6 +25,7 @@ export const Overlay = styled.div`
   min-width: 100%;
   min-height: 100%;
   background-color: rgba(0, 0, 0, 0.5);
+  z-index: 99;
 `;
 
 export const Dialog = styled.dialog`


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Brief
Add z-index to overlay of modal

## Description
This is because I stumbled upon this: 
<img width="414" alt="Screenshot 2019-04-04 at 17 29 05" src="https://user-images.githubusercontent.com/6019103/55568037-2f328500-56ff-11e9-9a1a-bb61b313ffd9.png">
This may not be the best solution but as the overlay of the modal is supposed to cover up the whole page except modal, but that some elements may also have a z-index, this is the quickest solution to implement to me.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Requirements :
<!--- Eventually remove the following. -->
:warning: Requires running `yarn` command.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
