### PR TITLE
fix(Input): add bigger font-size for iOS mobile devices

### DIFF
--- a/src/Form/__tests__/__snapshots__/Form.test.js.snap
+++ b/src/Form/__tests__/__snapshots__/Form.test.js.snap
@@ -168,6 +168,12 @@ exports[`<Form /> should render form with highlighted label when has focus 1`] =
   outline: none;
 }
 
+@supports (-webkit-overflow-scrolling:touch) {
+  .c8 {
+    font-size: 1.6rem;
+  }
+}
+
 <form
   class="c0"
   name="form"
@@ -254,7 +260,7 @@ exports[`<Form /> should render form with highlighted label when has focus 2`] =
               width="25rem"
             >
               <input
-                class="sc-jWBwVP kgmPjO"
+                class="sc-jWBwVP RhccY"
                 data-testid="input"
                 id=""
                 placeholder="tape inside me"
@@ -411,6 +417,12 @@ exports[`<Form /> should render form without label without a problem 1`] = `
 .c7:focus,
 .c7:active {
   outline: none;
+}
+
+@supports (-webkit-overflow-scrolling:touch) {
+  .c7 {
+    font-size: 1.6rem;
+  }
 }
 
 <form
@@ -659,6 +671,12 @@ exports[`<Form /> should render row form with inline labels without a problem 1`
 .c8:focus,
 .c8:active {
   outline: none;
+}
+
+@supports (-webkit-overflow-scrolling:touch) {
+  .c8 {
+    font-size: 1.6rem;
+  }
 }
 
 <form
@@ -946,6 +964,12 @@ exports[`<Form /> should render without a problem 1`] = `
 .c8:focus,
 .c8:active {
   outline: none;
+}
+
+@supports (-webkit-overflow-scrolling:touch) {
+  .c8 {
+    font-size: 1.6rem;
+  }
 }
 
 <form

--- a/src/Input/DatePickerInput/__tests__/__snapshots__/DatePickerInput.test.js.snap
+++ b/src/Input/DatePickerInput/__tests__/__snapshots__/DatePickerInput.test.js.snap
@@ -65,6 +65,12 @@ exports[`<DatePickerInput /> should render without a problem 1`] = `
   position: absolute;
 }
 
+@supports (-webkit-overflow-scrolling:touch) {
+  .c2 {
+    font-size: 1.6rem;
+  }
+}
+
 <div
   class="c0"
 >

--- a/src/Input/NumberInput/__tests__/__snapshots__/NumberInput.test.js.snap
+++ b/src/Input/NumberInput/__tests__/__snapshots__/NumberInput.test.js.snap
@@ -76,6 +76,12 @@ exports[`<NumberInput /> should have a text label 1`] = `
   outline: none;
 }
 
+@supports (-webkit-overflow-scrolling:touch) {
+  .c2 {
+    font-size: 1.6rem;
+  }
+}
+
 <div
   class="c0"
   data-testid="input-container"
@@ -183,6 +189,12 @@ exports[`<NumberInput /> should have an icon icon label and label position 1`] =
 .c1:focus,
 .c1:active {
   outline: none;
+}
+
+@supports (-webkit-overflow-scrolling:touch) {
+  .c1 {
+    font-size: 1.6rem;
+  }
 }
 
 <div
@@ -313,6 +325,12 @@ exports[`<NumberInput /> should have an icon label 1`] = `
   outline: none;
 }
 
+@supports (-webkit-overflow-scrolling:touch) {
+  .c3 {
+    font-size: 1.6rem;
+  }
+}
+
 <div
   class="c0"
   data-testid="input-container"
@@ -411,6 +429,12 @@ exports[`<NumberInput /> should render without a problem 1`] = `
 .c1:focus,
 .c1:active {
   outline: none;
+}
+
+@supports (-webkit-overflow-scrolling:touch) {
+  .c1 {
+    font-size: 1.6rem;
+  }
 }
 
 <div

--- a/src/Input/TextInput/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/Input/TextInput/__tests__/__snapshots__/TextInput.test.js.snap
@@ -78,6 +78,12 @@ exports[`<TextInput /> should have a text label 1`] = `
   outline: none;
 }
 
+@supports (-webkit-overflow-scrolling:touch) {
+  .c2 {
+    font-size: 1.6rem;
+  }
+}
+
 <div
   class="c0"
   data-testid="input-container"
@@ -185,6 +191,12 @@ exports[`<TextInput /> should have an icon icon label and label position 1`] = `
 .c1:focus,
 .c1:active {
   outline: none;
+}
+
+@supports (-webkit-overflow-scrolling:touch) {
+  .c1 {
+    font-size: 1.6rem;
+  }
 }
 
 <div
@@ -313,6 +325,12 @@ exports[`<TextInput /> should have an icon label 1`] = `
 .c3:focus,
 .c3:active {
   outline: none;
+}
+
+@supports (-webkit-overflow-scrolling:touch) {
+  .c3 {
+    font-size: 1.6rem;
+  }
 }
 
 <div
@@ -444,6 +462,12 @@ exports[`<TextInput /> should render search status input without problem when fo
   outline: none;
 }
 
+@supports (-webkit-overflow-scrolling:touch) {
+  .c1 {
+    font-size: 1.6rem;
+  }
+}
+
 <div
   class="c0"
   data-testid="input-container"
@@ -543,6 +567,12 @@ exports[`<TextInput /> should render without a problem 1`] = `
 .c1:focus,
 .c1:active {
   outline: none;
+}
+
+@supports (-webkit-overflow-scrolling:touch) {
+  .c1 {
+    font-size: 1.6rem;
+  }
 }
 
 <div

--- a/src/Input/TextInput/elements.js
+++ b/src/Input/TextInput/elements.js
@@ -79,4 +79,9 @@ export const InputElement = styled.input`
   &:active {
     outline: none;
   }
+
+  /* Set size to 16px for iOS devices to avoid auto-zoom */
+  @supports (-webkit-overflow-scrolling: touch) {
+    font-size: ${({ theme: { fonts } }) => fonts.size.big};
+  }
 `;


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Brief
Avoid auto-zoom on inputs by setting a 16px font-size for iOS mobile devices.

## Description
The CSS rule is applied only for iOS devices.

## How Has This Been Tested?
It doesn't seem to work even when simulating an iOS mobile on Safari so it would be great if you could check on your iPhone 🙏 

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
