### PR TITLE
fix(Storybook): install @storybook/theming to fix Error: Cannot find …

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@storybook/addon-options": "5.0.6",
     "@storybook/addons": "5.0.6",
     "@storybook/react": "5.0.6",
+    "@storybook/theming": "^5.0.6",
     "@tillersystems/eslint-config": "1.1.8",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2138,7 +2138,7 @@
     memoizerific "^1.11.3"
     qs "^6.5.2"
 
-"@storybook/theming@5.0.6":
+"@storybook/theming@5.0.6", "@storybook/theming@^5.0.6":
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-5.0.6.tgz#5827d780eb45a031ad27cd19bd87cd70a818546f"
   integrity sha512-Kz0/ujHknhan7DHApLIdSzfLAMbpo7AEKmi+R060ZV0ImGmAP9O7Ytqws7u1O25fgA4AgCDyeDpT4N9i83la+w==


### PR DESCRIPTION
…module "@emotion/core/package.json"

- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description
Install @storybook/theming like mentioning [here](https://github.com/storybooks/storybook/issues/5817) to fix emotion-themeing and React loader bug  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Requirements :
<!--- Eventually remove the following. -->
:warning: Requires running `yarn` command.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
