### PR TITLE
fix(Dropdown): add z-index to menu

### DIFF
--- a/src/Dropdown/elements.js
+++ b/src/Dropdown/elements.js
@@ -58,6 +58,7 @@ export const Menu = styled.ul`
   position: absolute;
   top: calc(100% + 0.4rem);
   left: 0;
+  z-index: 1;
 
   width: 100%;
   max-height: 28rem;


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Brief
Add z-index to Menu of Dropdown.

## Description
Fix to avoid this: 
<img width="365" alt="Screenshot 2019-04-08 at 16 24 06" src="https://user-images.githubusercontent.com/6019103/55731792-14bc1c80-5a1b-11e9-8660-4f4f37f5b71e.png">

At first I wrapped the Dropdown in Sonar but with a Modal this is problematic:
![Untitled](https://user-images.githubusercontent.com/6019103/55731851-361d0880-5a1b-11e9-907f-5da885696c18.gif)
This fix is not perfect since we use z-index without checking how it would behave with other elements but this is a quick fix (use a Portal?)

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
