### PR TITLE
fix(TabSwitcher): wrap pane in styled component

### DIFF
--- a/src/TabSwitcher/Pane/elements.js
+++ b/src/TabSwitcher/Pane/elements.js
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  width: 100%;
+  height: 100%;
+`;

--- a/src/TabSwitcher/Pane/index.js
+++ b/src/TabSwitcher/Pane/index.js
@@ -1,5 +1,6 @@
 import React, { memo } from 'react';
 import PropTypes from 'prop-types';
+import { Container } from './elements';
 
 const { node, string } = PropTypes;
 
@@ -12,7 +13,7 @@ const { node, string } = PropTypes;
  * @return {jsx}
  */
 
-const Pane = ({ children, className }) => <div className={className}>{children}</div>;
+const Pane = ({ children, className }) => <Container className={className}>{children}</Container>;
 
 /** Prop types. */
 Pane.propTypes = {


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description
Forgot to add some style to properly display content in a pane.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
