### PR TITLE
fix(input): remove non handled @supports in jsdom and put 16px font-size

### DIFF
--- a/src/Form/__tests__/__snapshots__/Form.test.js.snap
+++ b/src/Form/__tests__/__snapshots__/Form.test.js.snap
@@ -148,30 +148,24 @@ exports[`<Form /> should render form with highlighted label when has focus 1`] =
 }
 
 .c8::-webkit-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c8::-moz-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c8:-ms-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c8::placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c8:focus,
 .c8:active {
   outline: none;
-}
-
-@supports (-webkit-overflow-scrolling:touch) {
-  .c8 {
-    font-size: 1.6rem;
-  }
 }
 
 <form
@@ -260,7 +254,7 @@ exports[`<Form /> should render form with highlighted label when has focus 2`] =
               width="25rem"
             >
               <input
-                class="sc-jWBwVP RhccY"
+                class="sc-jWBwVP kEJLSQ"
                 data-testid="input"
                 id=""
                 placeholder="tape inside me"
@@ -399,30 +393,24 @@ exports[`<Form /> should render form without label without a problem 1`] = `
 }
 
 .c7::-webkit-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c7::-moz-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c7:-ms-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c7::placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c7:focus,
 .c7:active {
   outline: none;
-}
-
-@supports (-webkit-overflow-scrolling:touch) {
-  .c7 {
-    font-size: 1.6rem;
-  }
 }
 
 <form
@@ -653,30 +641,24 @@ exports[`<Form /> should render row form with inline labels without a problem 1`
 }
 
 .c8::-webkit-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c8::-moz-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c8:-ms-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c8::placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c8:focus,
 .c8:active {
   outline: none;
-}
-
-@supports (-webkit-overflow-scrolling:touch) {
-  .c8 {
-    font-size: 1.6rem;
-  }
 }
 
 <form
@@ -938,30 +920,24 @@ exports[`<Form /> should render without a problem 1`] = `
 }
 
 .c8::-webkit-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c8::-moz-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c8:-ms-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c8::placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c8:focus,
 .c8:active {
   outline: none;
-}
-
-@supports (-webkit-overflow-scrolling:touch) {
-  .c8 {
-    font-size: 1.6rem;
-  }
 }
 
 <form

--- a/src/Input/DatePickerInput/__tests__/__snapshots__/DatePickerInput.test.js.snap
+++ b/src/Input/DatePickerInput/__tests__/__snapshots__/DatePickerInput.test.js.snap
@@ -37,19 +37,19 @@ exports[`<DatePickerInput /> should render without a problem 1`] = `
 }
 
 .c2::-webkit-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c2::-moz-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c2:-ms-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c2::placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c2:focus,
@@ -63,12 +63,6 @@ exports[`<DatePickerInput /> should render without a problem 1`] = `
 
 .c3 {
   position: absolute;
-}
-
-@supports (-webkit-overflow-scrolling:touch) {
-  .c2 {
-    font-size: 1.6rem;
-  }
 }
 
 <div

--- a/src/Input/NumberInput/__tests__/__snapshots__/NumberInput.test.js.snap
+++ b/src/Input/NumberInput/__tests__/__snapshots__/NumberInput.test.js.snap
@@ -56,30 +56,24 @@ exports[`<NumberInput /> should have a text label 1`] = `
 }
 
 .c2::-webkit-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c2::-moz-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c2:-ms-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c2::placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c2:focus,
 .c2:active {
   outline: none;
-}
-
-@supports (-webkit-overflow-scrolling:touch) {
-  .c2 {
-    font-size: 1.6rem;
-  }
 }
 
 <div
@@ -171,30 +165,24 @@ exports[`<NumberInput /> should have an icon icon label and label position 1`] =
 }
 
 .c1::-webkit-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c1::-moz-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c1:-ms-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c1::placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c1:focus,
 .c1:active {
   outline: none;
-}
-
-@supports (-webkit-overflow-scrolling:touch) {
-  .c1 {
-    font-size: 1.6rem;
-  }
 }
 
 <div
@@ -305,30 +293,24 @@ exports[`<NumberInput /> should have an icon label 1`] = `
 }
 
 .c3::-webkit-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c3::-moz-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c3:-ms-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c3::placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c3:focus,
 .c3:active {
   outline: none;
-}
-
-@supports (-webkit-overflow-scrolling:touch) {
-  .c3 {
-    font-size: 1.6rem;
-  }
 }
 
 <div
@@ -411,30 +393,24 @@ exports[`<NumberInput /> should render without a problem 1`] = `
 }
 
 .c1::-webkit-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c1::-moz-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c1:-ms-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c1::placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c1:focus,
 .c1:active {
   outline: none;
-}
-
-@supports (-webkit-overflow-scrolling:touch) {
-  .c1 {
-    font-size: 1.6rem;
-  }
 }
 
 <div

--- a/src/Input/TextInput/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/Input/TextInput/__tests__/__snapshots__/TextInput.test.js.snap
@@ -58,30 +58,24 @@ exports[`<TextInput /> should have a text label 1`] = `
 }
 
 .c2::-webkit-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c2::-moz-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c2:-ms-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c2::placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c2:focus,
 .c2:active {
   outline: none;
-}
-
-@supports (-webkit-overflow-scrolling:touch) {
-  .c2 {
-    font-size: 1.6rem;
-  }
 }
 
 <div
@@ -173,30 +167,24 @@ exports[`<TextInput /> should have an icon icon label and label position 1`] = `
 }
 
 .c1::-webkit-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c1::-moz-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c1:-ms-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c1::placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c1:focus,
 .c1:active {
   outline: none;
-}
-
-@supports (-webkit-overflow-scrolling:touch) {
-  .c1 {
-    font-size: 1.6rem;
-  }
 }
 
 <div
@@ -307,30 +295,24 @@ exports[`<TextInput /> should have an icon label 1`] = `
 }
 
 .c3::-webkit-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c3::-moz-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c3:-ms-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c3::placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c3:focus,
 .c3:active {
   outline: none;
-}
-
-@supports (-webkit-overflow-scrolling:touch) {
-  .c3 {
-    font-size: 1.6rem;
-  }
 }
 
 <div
@@ -442,30 +424,24 @@ exports[`<TextInput /> should render search status input without problem when fo
 }
 
 .c1::-webkit-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c1::-moz-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c1:-ms-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c1::placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c1:focus,
 .c1:active {
   outline: none;
-}
-
-@supports (-webkit-overflow-scrolling:touch) {
-  .c1 {
-    font-size: 1.6rem;
-  }
 }
 
 <div
@@ -549,30 +525,24 @@ exports[`<TextInput /> should render without a problem 1`] = `
 }
 
 .c1::-webkit-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c1::-moz-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c1:-ms-input-placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c1::placeholder {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .c1:focus,
 .c1:active {
   outline: none;
-}
-
-@supports (-webkit-overflow-scrolling:touch) {
-  .c1 {
-    font-size: 1.6rem;
-  }
 }
 
 <div

--- a/src/Input/TextInput/elements.js
+++ b/src/Input/TextInput/elements.js
@@ -66,9 +66,10 @@ export const InputElement = styled.input`
   margin: 0 ${({ theme: { dimensions } }) => dimensions.small};
   border-radius: ${({ theme: { dimensions } }) => dimensions.radius};
 
+  /* Set size to 16px for iOS devices to avoid auto-zoom */
   &::placeholder {
     color: ${({ theme: { palette } }) => palette.darGrey};
-    font-size: ${({ theme: { fonts } }) => fonts.size.medium};
+    font-size: ${({ theme: { fonts } }) => fonts.size.big};
   }
 
   font-size: ${({ theme: { fonts } }) => fonts.size.medium};
@@ -78,10 +79,5 @@ export const InputElement = styled.input`
   &:focus,
   &:active {
     outline: none;
-  }
-
-  /* Set size to 16px for iOS devices to avoid auto-zoom */
-  @supports (-webkit-overflow-scrolling: touch) {
-    font-size: ${({ theme: { fonts } }) => fonts.size.big};
   }
 `;


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description
Put 16px font-size in inputs for all browsers instead of trying to target only Safari (`@supports` is not supported by jsdom so our tests are failing).


## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
