### PR TITLE
fix(TabSwitcher): add guard for null children

### DIFF
--- a/src/TabSwitcher/index.js
+++ b/src/TabSwitcher/index.js
@@ -28,17 +28,19 @@ const TabSwitcher = ({ children, defaultIndex, index, isCompacted, onChange }) =
 
   const content = Children.map(children, child => {
     // ignore random <div/>s etc.
-    if (typeof child.type === 'string') return child;
-    return cloneElement(child, {
-      activeIndex: isControlled ? index : activeIndex,
-      isCompacted,
-      onActiveTab: index => {
-        onChange && onChange(index);
-        if (!isControlled) {
-          setActiveIndex(index);
-        }
-      },
-    });
+    if (child) {
+      if (typeof child.type === 'string') return child;
+      return cloneElement(child, {
+        activeIndex: isControlled ? index : activeIndex,
+        isCompacted,
+        onActiveTab: index => {
+          onChange && onChange(index);
+          if (!isControlled) {
+            setActiveIndex(index);
+          }
+        },
+      });
+    }
   });
 
   return <div>{content}</div>;


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description
If there is a null child, the component breaks as child does not have a type.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
