### PR TITLE
fix(Modal): use fixed position on modal container to avoid scrolling …

### DIFF
--- a/src/Modal/elements.js
+++ b/src/Modal/elements.js
@@ -2,14 +2,14 @@ import styled from 'styled-components';
 import breakpoint from 'styled-components-breakpoint';
 
 export const Container = styled.div`
-  position: absolute;
+  position: fixed;
   display: grid;
   justify-content: center;
   align-content: center;
-  top: 0px;
-  bottom: 0px;
-  left: 0px;
-  right: 0px;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
 
   width: 100%;
 


### PR DESCRIPTION
…bug on mobile

- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description
Use `fixed` position on the modal container to avoid scrolling bug on mobile

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Requirements :
<!--- Eventually remove the following. -->
:warning: Requires running `yarn` command.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
