### PR TITLE
fix(Tooltip): replace inline-block by inline-flex

### DIFF
--- a/src/Tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
+++ b/src/Tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Tooltip /> should render only the child element 1`] = `
 <div
-  style="display: inline-block;"
+  style="display: inline-flex;"
   tabindex="0"
 >
   <button

--- a/src/Tooltip/index.js
+++ b/src/Tooltip/index.js
@@ -53,7 +53,7 @@ const Tooltip = ({
         To use a component element as a child we need to wrap element with a div
         https://github.com/atomiks/tippy.js-react#component-children
       */}
-      <div style={{ display: 'inline-block' }}>{children}</div>
+      <div style={{ display: 'inline-flex' }}>{children}</div>
     </Tippy>
   );
 };


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description
Replace `inline-block` by` inline-flex` to fix the align issue with another element.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Requirements :
<!--- Eventually remove the following. -->
:warning: Requires running `yarn` command.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
