### PR TITLE
fix(TextInput): replace margin by padding inside input

### DIFF
--- a/src/Form/__tests__/__snapshots__/Form.test.js.snap
+++ b/src/Form/__tests__/__snapshots__/Form.test.js.snap
@@ -139,11 +139,10 @@ exports[`<Form /> should render form with highlighted label when has focus 1`] =
   height: 100%;
   width: 100%;
   background-color: hsl(0,100%,100%);
-  margin: 0 0.7rem;
+  padding: 0 0.7rem;
   border-radius: 0.4rem;
   font-size: 1.6rem;
   border: none;
-  padding: 0;
   text-align: left;
 }
 
@@ -254,7 +253,7 @@ exports[`<Form /> should render form with highlighted label when has focus 2`] =
               width="25rem"
             >
               <input
-                class="sc-jWBwVP kCOVHR"
+                class="sc-jWBwVP jEwqHC"
                 data-testid="input"
                 id=""
                 placeholder="tape inside me"
@@ -384,11 +383,10 @@ exports[`<Form /> should render form without label without a problem 1`] = `
   height: 100%;
   width: 100%;
   background-color: hsl(0,100%,100%);
-  margin: 0 0.7rem;
+  padding: 0 0.7rem;
   border-radius: 0.4rem;
   font-size: 1.6rem;
   border: none;
-  padding: 0;
   text-align: left;
 }
 
@@ -632,11 +630,10 @@ exports[`<Form /> should render row form with inline labels without a problem 1`
   height: 100%;
   width: 100%;
   background-color: hsl(0,100%,100%);
-  margin: 0 0.7rem;
+  padding: 0 0.7rem;
   border-radius: 0.4rem;
   font-size: 1.6rem;
   border: none;
-  padding: 0;
   text-align: left;
 }
 
@@ -911,11 +908,10 @@ exports[`<Form /> should render without a problem 1`] = `
   height: 100%;
   width: 100%;
   background-color: hsl(0,100%,100%);
-  margin: 0 0.7rem;
+  padding: 0 0.7rem;
   border-radius: 0.4rem;
   font-size: 1.6rem;
   border: none;
-  padding: 0;
   text-align: left;
 }
 

--- a/src/Input/DatePickerInput/__tests__/__snapshots__/DatePickerInput.test.js.snap
+++ b/src/Input/DatePickerInput/__tests__/__snapshots__/DatePickerInput.test.js.snap
@@ -28,11 +28,10 @@ exports[`<DatePickerInput /> should render without a problem 1`] = `
   height: 100%;
   width: 100%;
   background-color: hsl(0,100%,100%);
-  margin: 0 0.7rem;
+  padding: 0 0.7rem;
   border-radius: 0.4rem;
   font-size: 1.6rem;
   border: none;
-  padding: 0;
   text-align: left;
 }
 

--- a/src/Input/NumberInput/__tests__/__snapshots__/NumberInput.test.js.snap
+++ b/src/Input/NumberInput/__tests__/__snapshots__/NumberInput.test.js.snap
@@ -47,11 +47,10 @@ exports[`<NumberInput /> should have a text label 1`] = `
   height: 100%;
   width: 100%;
   background-color: hsl(0,100%,100%);
-  margin: 0 0.7rem;
+  padding: 0 0.7rem;
   border-radius: 0.4rem;
   font-size: 1.6rem;
   border: none;
-  padding: 0;
   text-align: left;
 }
 
@@ -156,11 +155,10 @@ exports[`<NumberInput /> should have an icon icon label and label position 1`] =
   height: 100%;
   width: 100%;
   background-color: hsl(0,100%,100%);
-  margin: 0 0.7rem;
+  padding: 0 0.7rem;
   border-radius: 0.4rem;
   font-size: 1.6rem;
   border: none;
-  padding: 0;
   text-align: left;
 }
 
@@ -284,11 +282,10 @@ exports[`<NumberInput /> should have an icon label 1`] = `
   height: 100%;
   width: 100%;
   background-color: hsl(0,100%,100%);
-  margin: 0 0.7rem;
+  padding: 0 0.7rem;
   border-radius: 0.4rem;
   font-size: 1.6rem;
   border: none;
-  padding: 0;
   text-align: left;
 }
 
@@ -384,11 +381,10 @@ exports[`<NumberInput /> should render without a problem 1`] = `
   height: 100%;
   width: 100%;
   background-color: hsl(0,100%,100%);
-  margin: 0 0.7rem;
+  padding: 0 0.7rem;
   border-radius: 0.4rem;
   font-size: 1.6rem;
   border: none;
-  padding: 0;
   text-align: left;
 }
 

--- a/src/Input/TextInput/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/Input/TextInput/__tests__/__snapshots__/TextInput.test.js.snap
@@ -49,11 +49,10 @@ exports[`<TextInput /> should have a text label 1`] = `
   height: 100%;
   width: 100%;
   background-color: hsl(0,100%,100%);
-  margin: 0 0.7rem;
+  padding: 0 0.7rem;
   border-radius: 0.4rem;
   font-size: 1.6rem;
   border: none;
-  padding: 0;
   text-align: left;
 }
 
@@ -158,11 +157,10 @@ exports[`<TextInput /> should have an icon icon label and label position 1`] = `
   height: 100%;
   width: 100%;
   background-color: hsl(0,100%,100%);
-  margin: 0 0.7rem;
+  padding: 0 0.7rem;
   border-radius: 0.4rem;
   font-size: 1.6rem;
   border: none;
-  padding: 0;
   text-align: left;
 }
 
@@ -286,11 +284,10 @@ exports[`<TextInput /> should have an icon label 1`] = `
   height: 100%;
   width: 100%;
   background-color: hsl(0,100%,100%);
-  margin: 0 0.7rem;
+  padding: 0 0.7rem;
   border-radius: 0.4rem;
   font-size: 1.6rem;
   border: none;
-  padding: 0;
   text-align: left;
 }
 
@@ -415,11 +412,10 @@ exports[`<TextInput /> should render search status input without problem when fo
   height: 100%;
   width: 100%;
   background-color: hsl(0,100%,100%);
-  margin: 0 0.7rem;
+  padding: 0 0.7rem;
   border-radius: 0.4rem;
   font-size: 1.6rem;
   border: none;
-  padding: 0;
   text-align: left;
 }
 
@@ -516,11 +512,10 @@ exports[`<TextInput /> should render without a problem 1`] = `
   height: 100%;
   width: 100%;
   background-color: hsl(0,100%,100%);
-  margin: 0 0.7rem;
+  padding: 0 0.7rem;
   border-radius: 0.4rem;
   font-size: 1.6rem;
   border: none;
-  padding: 0;
   text-align: left;
 }
 

--- a/src/Input/TextInput/elements.js
+++ b/src/Input/TextInput/elements.js
@@ -63,7 +63,7 @@ export const InputElement = styled.input`
   width: 100%;
   background-color: ${({ theme: { palette } }) => palette.white};
 
-  margin: 0 ${({ theme: { dimensions } }) => dimensions.small};
+  padding: 0 ${({ theme: { dimensions } }) => dimensions.small};
   border-radius: ${({ theme: { dimensions } }) => dimensions.radius};
 
   &::placeholder {
@@ -74,7 +74,6 @@ export const InputElement = styled.input`
   /* Set size to 16px for iOS devices to avoid auto-zoom */
   font-size: ${({ theme: { fonts } }) => fonts.size.big};
   border: none;
-  padding: 0;
   text-align: left;
   &:focus,
   &:active {


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description
Replace **margin** by **padding** inside the input.

Before:
![Screenshot 2019-04-24 at 10 42 19](https://user-images.githubusercontent.com/531935/56645817-add76e00-667e-11e9-80b9-84c413ff8bba.png)

After: 
![Screenshot 2019-04-24 at 10 42 33](https://user-images.githubusercontent.com/531935/56645833-b5971280-667e-11e9-8a56-dec7ffeb7701.png)



## Related / Associated Jira Cards :
>  <!--- [Replace margin by padding on login page inputs - BP-62](https://tillersystems.atlassian.net/jira/software/projects/BP/boards/57?selectedIssue=BP-62) -->


## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
