### PR TITLE
fix: update color and KpiChart height

### DIFF
--- a/src/Button/__tests__/__snapshots__/helpers.test.js.snap
+++ b/src/Button/__tests__/__snapshots__/helpers.test.js.snap
@@ -91,7 +91,7 @@ Array [
       background: linear-gradient(180deg, ",
   "hsl(0,100%,100%)",
   " 0%, ",
-  "hsl(216,45%,98%)",
+  "hsl(240,33%,99%)",
   " 100%);
       border: 1px solid ",
   "hsl(207,22%,90%)",

--- a/src/Button/helpers.js
+++ b/src/Button/helpers.js
@@ -42,7 +42,7 @@ export const getAppearance = ({ palette }, appearance) => {
     `,
     secondary: css`
       color: ${palette.spaceGrey};
-      background: linear-gradient(180deg, ${palette.white} 0%, ${palette.mysticGrey} 100%);
+      background: linear-gradient(180deg, ${palette.white} 0%, ${palette.paleGrey} 100%);
       border: 1px solid ${palette.lightGrey};
     `,
     success: css`

--- a/src/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.js.snap
+++ b/src/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.js.snap
@@ -30,7 +30,7 @@ exports[`<ButtonGroup /> should render without a problem 1`] = `
   -webkit-transition: background 200ms ease,box-shadow 200ms ease;
   transition: background 200ms ease,box-shadow 200ms ease;
   color: hsl(207,13%,45%);
-  background: linear-gradient(180deg,hsl(0,100%,100%) 0%,hsl(216,45%,98%) 100%);
+  background: linear-gradient(180deg,hsl(0,100%,100%) 0%,hsl(240,33%,99%) 100%);
   border: 1px solid hsl(207,22%,90%);
   padding: 0.75rem 1.6rem;
 }

--- a/src/Counter/__tests__/__snapshots__/Increment.test.js.snap
+++ b/src/Counter/__tests__/__snapshots__/Increment.test.js.snap
@@ -30,7 +30,7 @@ exports[`<Counter /> should render without a problem 1`] = `
   -webkit-transition: background 200ms ease,box-shadow 200ms ease;
   transition: background 200ms ease,box-shadow 200ms ease;
   color: hsl(207,13%,45%);
-  background: linear-gradient(180deg,hsl(0,100%,100%) 0%,hsl(216,45%,98%) 100%);
+  background: linear-gradient(180deg,hsl(0,100%,100%) 0%,hsl(240,33%,99%) 100%);
   border: 1px solid hsl(207,22%,90%);
   padding: 0.75rem 1.6rem;
 }

--- a/src/Dropdown/__tests__/__snapshots__/Dropdown.test.js.snap
+++ b/src/Dropdown/__tests__/__snapshots__/Dropdown.test.js.snap
@@ -14,7 +14,7 @@ exports[`<Dropdown /> should render without a problem 1`] = `
   font-size: 1.4rem;
   border: 1px solid hsl(207,22%,90%);
   border-radius: 0.4rem;
-  background: linear-gradient( 180deg, hsl(0,100%,100%) 0%, hsl(216,45%,98%) 100% );
+  background: linear-gradient( 180deg, hsl(0,100%,100%) 0%, hsl(240,33%,99%) 100% );
   color: hsl(207,13%,45%);
 }
 

--- a/src/Dropdown/elements.js
+++ b/src/Dropdown/elements.js
@@ -18,7 +18,7 @@ export const Header = styled.button`
   background: linear-gradient(
     180deg,
     ${({ theme: { palette } }) => palette.white} 0%,
-    ${({ theme: { palette } }) => palette.mysticGrey} 100%
+    ${({ theme: { palette } }) => palette.paleGrey} 100%
   );
   color: ${({ theme: { palette } }) => palette.spaceGrey};
 
@@ -72,7 +72,7 @@ export const Menu = styled.ul`
   background: linear-gradient(
     180deg,
     ${({ theme: { palette } }) => palette.white} 0%,
-    ${({ theme: { palette } }) => palette.mysticGrey} 100%
+    ${({ theme: { palette } }) => palette.paleGrey} 100%
   );
 
   color: ${({ theme: { palette } }) => palette.spaceGrey};

--- a/src/Input/Label/index.js
+++ b/src/Input/Label/index.js
@@ -45,7 +45,7 @@ export default styled(Label)`
   padding: 1.1rem;
 
   color: ${({ theme: { palette } }) => palette.darkGrey};
-  background: ${({ theme: { palette } }) => palette.mysticGrey};
+  background: ${({ theme: { palette } }) => palette.paleGrey};
 
   ${({ position }) =>
     position === 'left' &&

--- a/src/Input/NumberInput/__tests__/__snapshots__/NumberInput.test.js.snap
+++ b/src/Input/NumberInput/__tests__/__snapshots__/NumberInput.test.js.snap
@@ -16,7 +16,7 @@ exports[`<NumberInput /> should have a text label 1`] = `
   justify-content: center;
   padding: 1.1rem;
   color: hsl(206,16%,60%);
-  background: hsl(216,45%,98%);
+  background: hsl(240,33%,99%);
   border-right: 1px solid hsl(207,22%,90%);
 }
 
@@ -125,7 +125,7 @@ exports[`<NumberInput /> should have an icon icon label and label position 1`] =
   justify-content: center;
   padding: 1.1rem;
   color: hsl(206,16%,60%);
-  background: hsl(216,45%,98%);
+  background: hsl(240,33%,99%);
   border-left: 1px solid hsl(207,22%,90%);
 }
 
@@ -253,7 +253,7 @@ exports[`<NumberInput /> should have an icon label 1`] = `
   justify-content: center;
   padding: 1.1rem;
   color: hsl(206,16%,60%);
-  background: hsl(216,45%,98%);
+  background: hsl(240,33%,99%);
   border-right: 1px solid hsl(207,22%,90%);
 }
 

--- a/src/Input/TextInput/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/Input/TextInput/__tests__/__snapshots__/TextInput.test.js.snap
@@ -18,7 +18,7 @@ exports[`<TextInput /> should have a text label 1`] = `
   justify-content: center;
   padding: 1.1rem;
   color: hsl(206,16%,60%);
-  background: hsl(216,45%,98%);
+  background: hsl(240,33%,99%);
   border-right: 1px solid hsl(207,22%,90%);
 }
 
@@ -127,7 +127,7 @@ exports[`<TextInput /> should have an icon icon label and label position 1`] = `
   justify-content: center;
   padding: 1.1rem;
   color: hsl(206,16%,60%);
-  background: hsl(216,45%,98%);
+  background: hsl(240,33%,99%);
   border-left: 1px solid hsl(207,22%,90%);
 }
 
@@ -255,7 +255,7 @@ exports[`<TextInput /> should have an icon label 1`] = `
   justify-content: center;
   padding: 1.1rem;
   color: hsl(206,16%,60%);
-  background: hsl(216,45%,98%);
+  background: hsl(240,33%,99%);
   border-right: 1px solid hsl(207,22%,90%);
 }
 

--- a/src/KpiChart/Body/__tests__/__snapshots__/Body.test.js.snap
+++ b/src/KpiChart/Body/__tests__/__snapshots__/Body.test.js.snap
@@ -7,6 +7,7 @@ exports[`<KpiChart.Body /> should render without a problem 1`] = `
 
 <div
   class="c0"
+  data-testid="kpichart-body"
 >
   Body
 </div>

--- a/src/KpiChart/Body/index.js
+++ b/src/KpiChart/Body/index.js
@@ -13,7 +13,11 @@ import styled from 'styled-components';
  *
  * @return {jsx}
  */
-const KpiChartBody = ({ children, className }) => <div className={className}>{children}</div>;
+const KpiChartBody = ({ children, className }) => (
+  <div className={className} data-testid="kpichart-body">
+    {children}
+  </div>
+);
 
 /**
  * PropTypes Validation
@@ -22,6 +26,8 @@ const { node, string } = PropTypes;
 KpiChartBody.propTypes = {
   children: node,
   className: string,
+  // eslint-disable-next-line react/no-unused-prop-types
+  height: string,
 };
 
 /**
@@ -30,8 +36,9 @@ KpiChartBody.propTypes = {
 KpiChartBody.defaultProps = {
   children: null,
   className: '',
+  height: '37.3rem',
 };
 
 export default styled(KpiChartBody)`
-  height: 37.3rem;
+  height: ${({ height }) => (/^\d+(rem|px)$/.test(height) ? height : '37.3rem')};
 `;

--- a/src/KpiChart/__stories__/KpiChart.stories.js
+++ b/src/KpiChart/__stories__/KpiChart.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { withKnobs, boolean, number, text } from '@storybook/addon-knobs';
 import { ResponsiveBar } from '@nivo/bar';
 
 import { Button, KpiChart } from '../..';
@@ -69,13 +69,24 @@ storiesOf('KpiChart', module)
   .add('default', () => {
     const Title = text('Title', "Chiffre d'affaires de la journée", 'ALL');
     const label = text('Label', 'Afficher le rapport', 'ALL');
+    const height = number(
+      'Height (px)',
+      375,
+      {
+        range: true,
+        min: 200,
+        max: 600,
+        step: 10,
+      },
+      'ALL',
+    );
     const isCompactedValue = boolean('isCompacted', false, 'ALL');
     return (
       <KpiChart isCompacted={isCompactedValue}>
         <KpiChart.Header>
           <KpiChart.Title isCompacted={isCompactedValue}>{Title}</KpiChart.Title>
         </KpiChart.Header>
-        <KpiChart.Body>
+        <KpiChart.Body height={`${height}px`}>
           <ResponsiveBar
             data={data}
             keys={['25 juil. 2017', '25 juil. 2018']}

--- a/src/KpiChart/__tests__/KpiChart.test.js
+++ b/src/KpiChart/__tests__/KpiChart.test.js
@@ -54,4 +54,20 @@ describe('<KpiChart />', () => {
     expect(TitleNode).toHaveStyleRule('padding-bottom', '1.2rem');
     expect(container.firstChild).toHaveStyleRule('padding', '1.2rem 1.6rem');
   });
+
+  test('should render kpi chart with a defined height', () => {
+    const Title = 'My title';
+    const height = '300px';
+    const { getByTestId } = render(
+      <KpiChart isCompacted>
+        <KpiChart.Header>
+          <KpiChart.Title isCompacted>{Title}</KpiChart.Title>
+        </KpiChart.Header>
+        <KpiChart.Body height={height}>Body</KpiChart.Body>
+        <KpiChart.Footer>Footer</KpiChart.Footer>
+      </KpiChart>,
+    );
+    const KpiChartBody = getByTestId('kpichart-body');
+    expect(KpiChartBody).toHaveStyleRule('height', height);
+  });
 });

--- a/src/RadioButton/__tests__/__snapshots__/RadioButton.test.js.snap
+++ b/src/RadioButton/__tests__/__snapshots__/RadioButton.test.js.snap
@@ -31,8 +31,8 @@ exports[`<RadioButton /> should render without a problem 1`] = `
   height: 1.6rem;
   border: 1px solid hsl(207,22%,90%);
   border-radius: 50%;
-  background: linear-gradient( 0deg, hsl(216,45%,98%) 0%, hsl(0,100%,100%) 100% );
-  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05), 0 1px 1px 0 hsl(216,45%,98%);
+  background: linear-gradient( 0deg, hsl(240,33%,99%) 0%, hsl(0,100%,100%) 100% );
+  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05), 0 1px 1px 0 hsl(240,33%,99%);
   -webkit-transition: background-color ease 0.25s;
   transition: background-color ease 0.25s;
 }
@@ -100,8 +100,8 @@ exports[`<RadioButton /> should render without a problem when radio is not selec
   height: 1.6rem;
   border: 1px solid hsl(207,22%,90%);
   border-radius: 50%;
-  background: linear-gradient( 0deg, hsl(216,45%,98%) 0%, hsl(0,100%,100%) 100% );
-  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05), 0 1px 1px 0 hsl(216,45%,98%);
+  background: linear-gradient( 0deg, hsl(240,33%,99%) 0%, hsl(0,100%,100%) 100% );
+  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05), 0 1px 1px 0 hsl(240,33%,99%);
   -webkit-transition: background-color ease 0.25s;
   transition: background-color ease 0.25s;
   opacity: 0.4;
@@ -173,8 +173,8 @@ exports[`<RadioButton /> should render without a problem when radio is not selec
   height: 1.6rem;
   border: 1px solid hsl(207,22%,90%);
   border-radius: 50%;
-  background: linear-gradient( 0deg, hsl(216,45%,98%) 0%, hsl(0,100%,100%) 100% );
-  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05), 0 1px 1px 0 hsl(216,45%,98%);
+  background: linear-gradient( 0deg, hsl(240,33%,99%) 0%, hsl(0,100%,100%) 100% );
+  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05), 0 1px 1px 0 hsl(240,33%,99%);
   -webkit-transition: background-color ease 0.25s;
   transition: background-color ease 0.25s;
 }
@@ -240,8 +240,8 @@ exports[`<RadioButton /> should render without a problem when radio is selected 
   height: 1.6rem;
   border: 1px solid hsl(207,22%,90%);
   border-radius: 50%;
-  background: linear-gradient( 0deg, hsl(216,45%,98%) 0%, hsl(0,100%,100%) 100% );
-  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05), 0 1px 1px 0 hsl(216,45%,98%);
+  background: linear-gradient( 0deg, hsl(240,33%,99%) 0%, hsl(0,100%,100%) 100% );
+  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05), 0 1px 1px 0 hsl(240,33%,99%);
   -webkit-transition: background-color ease 0.25s;
   transition: background-color ease 0.25s;
   opacity: 0.4;
@@ -335,8 +335,8 @@ exports[`<RadioButton /> should render without a problem when radio is selected 
   height: 1.6rem;
   border: 1px solid hsl(207,22%,90%);
   border-radius: 50%;
-  background: linear-gradient( 0deg, hsl(216,45%,98%) 0%, hsl(0,100%,100%) 100% );
-  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05), 0 1px 1px 0 hsl(216,45%,98%);
+  background: linear-gradient( 0deg, hsl(240,33%,99%) 0%, hsl(0,100%,100%) 100% );
+  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05), 0 1px 1px 0 hsl(240,33%,99%);
   -webkit-transition: background-color ease 0.25s;
   transition: background-color ease 0.25s;
   border: 1px solid #1873a0;

--- a/src/RadioButton/elements.js
+++ b/src/RadioButton/elements.js
@@ -38,11 +38,11 @@ export const Container = styled.div`
 
   background: linear-gradient(
     0deg,
-    ${({ theme: { palette } }) => palette.mysticGrey} 0%,
+    ${({ theme: { palette } }) => palette.paleGrey} 0%,
     ${({ theme: { palette } }) => palette.white} 100%
   );
   box-shadow: inset 0 2px 0 0 ${({ theme: { palette } }) => palette.whiteOpacity(0.05)},
-    0 1px 1px 0 ${({ theme: { palette } }) => palette.mysticGrey};
+    0 1px 1px 0 ${({ theme: { palette } }) => palette.paleGrey};
 
   transition: background-color ease 0.25s;
 

--- a/src/RadioGroup/__tests__/__snapshots__/RadioGroup.test.js.snap
+++ b/src/RadioGroup/__tests__/__snapshots__/RadioGroup.test.js.snap
@@ -46,8 +46,8 @@ exports[`<RadioGroup /> should render without a problem 1`] = `
   height: 1.6rem;
   border: 1px solid hsl(207,22%,90%);
   border-radius: 50%;
-  background: linear-gradient( 0deg, hsl(216,45%,98%) 0%, hsl(0,100%,100%) 100% );
-  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05), 0 1px 1px 0 hsl(216,45%,98%);
+  background: linear-gradient( 0deg, hsl(240,33%,99%) 0%, hsl(0,100%,100%) 100% );
+  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05), 0 1px 1px 0 hsl(240,33%,99%);
   -webkit-transition: background-color ease 0.25s;
   transition: background-color ease 0.25s;
 }

--- a/src/Table/elements.js
+++ b/src/Table/elements.js
@@ -105,7 +105,7 @@ export const BodyRow = styled(Row)`
     striped &&
     css`
       &:nth-child(even) {
-        background: ${({ theme: { palette } }) => palette.mysticGrey};
+        background: ${({ theme: { palette } }) => palette.paleGrey};
       }
     `};
 `;

--- a/src/Theme/palette.js
+++ b/src/Theme/palette.js
@@ -18,7 +18,7 @@ const turquoise = 'hsl(168,76%,42%)';
 const googleBrandRed = 'hsl(5,81%,56%)';
 
 // Shades of grey
-const mysticGrey = 'hsl(216,45%,98%)';
+const mysticGrey = 'hsl(218, 29%, 95%)';
 const lightGrey = 'hsl(207,22%,90%)';
 const mediumGrey = 'hsl(206,23%,69%)';
 const darkGrey = 'hsl(206,16%,60%)';


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [x] Enhancement

## Brief
Update grey colors.
Add height prop to KpiChart.Body

## Description
mysticGrey value has been adjusted cf design on Zeplin (typo on visual).
<img width="168" alt="Screenshot 2019-04-24 at 11 07 41" src="https://user-images.githubusercontent.com/6019103/56647188-571f6380-6681-11e9-9fad-a0ef30286f77.png">
I updated the components using this color by a lighter grey.
I also added the possibility to set a height to the body of KpiChart.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
