### PR TITLE
fix(TabSwitcher): display single Pane when there is only one

### DIFF
--- a/src/TabSwitcher/Panes/index.js
+++ b/src/TabSwitcher/Panes/index.js
@@ -17,7 +17,7 @@ const { bool, node, number, string } = PropTypes;
  */
 const Panes = ({ activeIndex, children, className, isCompacted }) => (
   <Container className={className} isCompacted={isCompacted}>
-    {children[activeIndex]}
+    {children[activeIndex] ? children[activeIndex] : children}
   </Container>
 );
 


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Brief
Fix bug in TabSwitcher display for single pane case.

## Description
The pane display is based on the index of the children, if there is only one child in Panes, the children is an object so it does not display properly.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
