### PR TITLE
fix(Table): never call handleSortingClick function if selected column…

### DIFF
--- a/src/Table/__stories__/Table.stories.js
+++ b/src/Table/__stories__/Table.stories.js
@@ -10,12 +10,15 @@ storiesOf('Table', module)
   .add('default', () => {
     const striped = boolean('Striped', false, 'State');
     const selectableRow = boolean('Selectable row', false, 'State');
+    const dishRowSortable = boolean('Dish row is sortable', true, 'State');
+    const priceRowSortable = boolean('Price row is sortable', true, 'State');
+    const titleRowSortable = boolean('Title row is sortable', true, 'State');
 
     const getColsDef = () => [
       {
         title: 'DISH',
         value: d => d.code,
-        sortable: true,
+        sortable: dishRowSortable,
         align: 'left',
       },
       {
@@ -23,14 +26,14 @@ storiesOf('Table', module)
         value: d => d.value,
         format: v => `${v.toFixed(2)} €`,
         align: 'right',
-        sortable: true,
+        sortable: priceRowSortable,
       },
       {
         title: 'TAX',
         value: d => d.tax,
         format: v => `${v.toFixed(2)} %`,
         align: 'right',
-        sortable: true,
+        sortable: titleRowSortable,
       },
     ];
 

--- a/src/Table/__tests__/Table.test.js
+++ b/src/Table/__tests__/Table.test.js
@@ -20,7 +20,7 @@ const getColsDef = () => [
     value: d => d.value,
     format: v => `${v.toFixed(2)} €`,
     align: 'right',
-    sortable: true,
+    sortable: false,
   },
   {
     title: 'TAX',
@@ -153,5 +153,24 @@ describe('<Table />', () => {
     const sortedBodyRows = getAllByTestId('body-row');
 
     expect(sortedBodyRows[0]).toHaveTextContent(/oeuf cocotte/i);
+  });
+
+  test('should not render differently when clicked on sorting', () => {
+    const { getByText, getAllByTestId } = render(
+      <Table colsDef={getColsDef()} data={data} striped />,
+    );
+
+    const priceNode = getByText(/price/i);
+
+    const initialBodyRows = getAllByTestId('body-row');
+
+    expect(initialBodyRows[0]).toHaveTextContent('15.00 €');
+
+    // Click on the the dish node
+    fireEvent.click(priceNode);
+
+    const sortedBodyRows = getAllByTestId('body-row');
+
+    expect(sortedBodyRows[0]).toHaveTextContent('15.00 €');
   });
 });

--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -134,7 +134,7 @@ class Table extends PureComponent {
             <TableHeaderCell
               key={`${title}-${columnIndex}`}
               align={align}
-              onClick={() => this.handleSortingClick(columnIndex)}
+              onClick={() => (sortable ? this.handleSortingClick(columnIndex) : undefined)}
             >
               <HeaderSortingContainer align={align}>
                 <HeaderLabel>{title}</HeaderLabel>


### PR DESCRIPTION
… is not sortable

- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description
Fix a bug that allowed a column to be sortable even if it had been specified that it should not be

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
