### PR TITLE
fix(TabSwitcher): check for child displayName

### DIFF
--- a/src/TabSwitcher/index.js
+++ b/src/TabSwitcher/index.js
@@ -27,12 +27,15 @@ const TabSwitcher = ({ children, defaultIndex, index, isCompacted, onChange }) =
   const [activeIndex, setActiveIndex] = useState(defaultIndex);
 
   const content = Children.map(children, child => {
-    // ignore random <div/>s etc.
-    if (child) {
-      if (typeof child.type === 'string') return child;
+    if (child.type.displayName === 'Panes') {
       return cloneElement(child, {
         activeIndex: isControlled ? index : activeIndex,
-        isCompacted,
+        isCompacted: isCompacted,
+      });
+    } else if (child.type.displayName === 'Tabs') {
+      return cloneElement(child, {
+        activeIndex: isControlled ? index : activeIndex,
+        isCompacted: isCompacted,
         onActiveTab: index => {
           onChange && onChange(index);
           if (!isControlled) {
@@ -40,6 +43,8 @@ const TabSwitcher = ({ children, defaultIndex, index, isCompacted, onChange }) =
           }
         },
       });
+    } else {
+      return child;
     }
   });
 


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description
We need to check for child `diplayName` to avoid error when we use a styled component as child

## Requirements :
<!--- Eventually remove the following. -->
:warning: Requires running `yarn` command.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
