### PR TITLE
fix(TabSwitcher): check that child is not null

### DIFF
--- a/src/TabSwitcher/index.js
+++ b/src/TabSwitcher/index.js
@@ -27,24 +27,26 @@ const TabSwitcher = ({ children, defaultIndex, index, isCompacted, onChange }) =
   const [activeIndex, setActiveIndex] = useState(defaultIndex);
 
   const content = Children.map(children, child => {
-    if (child.type.displayName === 'Panes') {
-      return cloneElement(child, {
-        activeIndex: isControlled ? index : activeIndex,
-        isCompacted: isCompacted,
-      });
-    } else if (child.type.displayName === 'Tabs') {
-      return cloneElement(child, {
-        activeIndex: isControlled ? index : activeIndex,
-        isCompacted: isCompacted,
-        onActiveTab: index => {
-          onChange && onChange(index);
-          if (!isControlled) {
-            setActiveIndex(index);
-          }
-        },
-      });
-    } else {
-      return child;
+    if (child) {
+      if (child.type.displayName === 'Panes') {
+        return cloneElement(child, {
+          activeIndex: isControlled ? index : activeIndex,
+          isCompacted: isCompacted,
+        });
+      } else if (child.type.displayName === 'Tabs') {
+        return cloneElement(child, {
+          activeIndex: isControlled ? index : activeIndex,
+          isCompacted: isCompacted,
+          onActiveTab: index => {
+            onChange && onChange(index);
+            if (!isControlled) {
+              setActiveIndex(index);
+            }
+          },
+        });
+      } else {
+        return child;
+      }
     }
   });
 


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description
We forgot to check if child is not null in case of conditional rendering (which we do in mobile in Sonar)

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
