### PR TITLE
fix(Table): specify pix instead of rm for Firefox support

### DIFF
--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -142,8 +142,8 @@ class Table extends PureComponent {
                   <Icon
                     name={sortingDirectionToIconName[columnIndex == index ? direction : 'none']}
                     color={Theme.palette.mediumGrey}
-                    width="1rem"
-                    height="1rem"
+                    width="10px"
+                    height="10px"
                   />
                 )}
               </HeaderSortingContainer>


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description
Maybe we should update the Icon component directly?

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
