### PR TITLE
chore(circleci): Add Storybook generation and deploy on master pushes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
           command: yarn build-storybook
       - run:
           name: Sync to S3
-          command: aws s3 sync ./_site s3://stardust.tillersystems.com/ --acl public-read
+          command: aws s3 sync ./storybook-static/ s3://stardust.tillersystems.com/ --acl public-read
 
 #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # WORKFLOWS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ workflows:
           filters:
             branches:
               only: master
-       - deploy:
+      - deploy:
           requires:
             - lint
             - unit-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,13 @@ workflows:
           filters:
             branches:
               only: master
+       - deploy:
+          requires:
+            - lint
+            - unit-test
+          filters:
+            branches:
+              only: chore/circleci
 
   # Triggered every night.
   # Tests, formats and lints the source code, builds the artifact and deploys it to staging.
@@ -156,9 +163,3 @@ workflows:
           requires:
             - lint
             - unit-test
-      - deploy:
-          requires:
-            - build
-          filters:
-            branches:
-              only: chore/circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,7 @@
 # Tiller - Stardust
 # This configuration file is part of Tiller Stardust
 
-version: 2.1
-#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-# ORBS
-#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-orbs:
-  aws-cli: circleci/aws-cli@0.1.13
+version: 2
 
 #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # REFERENCES

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - run:
           name: Build project
           command: yarn build
-
+  # Build storybook and upload to S3
   deploy:
     <<: *defaults
     steps:
@@ -135,11 +135,10 @@ workflows:
               only: master
       - deploy:
           requires:
-            - lint
-            - unit-test
+            - build
           filters:
             branches:
-              only: chore/circleci
+              only: master
 
   # Triggered every night.
   # Tests, formats and lints the source code, builds the artifact and deploys it to staging.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,12 @@
 # Tiller - Stardust
 # This configuration file is part of Tiller Stardust
 
-version: 2
+version: 2.1
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# ORBS
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+orbs:
+  aws-cli: circleci/aws-cli@0.1.13
 
 #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # REFERENCES
@@ -25,6 +30,16 @@ references:
       key: dependencies-{{ checksum "package.json" }}
       paths:
         - node_modules
+
+  install_pip: &install_pip
+    run:
+      name: Installing pip
+      command: sudo apt-get install python-pip
+
+  install_awscli: &install_awscli
+    run:
+      name: Install AWS CLI
+      command: sudo pip install awscli
 
 #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # DEFAULTS
@@ -84,6 +99,19 @@ jobs:
           name: Build project
           command: yarn build
 
+  deploy:
+    <<: *defaults
+    steps:
+      - *attach_workspace
+      - *install_pip
+      - *install_awscli
+      - run:
+          name: Build storybook
+          command: yarn build-storybook
+      - run:
+          name: Sync to S3
+          command: aws s3 sync ./_site s3://stardust.tillersystems.com/ --acl public-read
+
 #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # WORKFLOWS
 #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -133,3 +161,9 @@ workflows:
           requires:
             - lint
             - unit-test
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: chore/circleci

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "BABEL_ENV=test jest",
     "test:cov": "yarn test --coverage",
     "test:ci": "BABEL_ENV=test jest --ci --maxWorkers=2",
-    "lint": "eslint .",
+    "lint": "eslint src/**/*.js",
     "format": "prettier --config .prettierrc --color --write \"src/**/*.js\"",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",


### PR DESCRIPTION
- [x] Enhancement

## Brief
- CircleCI workflow enhancement
- Change `eslint` pre-commit command to `src`

## Description
Adding `deploy` step on master pushes for build and deploy Storybook in production