### PR TITLE
feat(TabSwicther): use context instead of react children map

### DIFF
--- a/src/TabSwitcher/Pane/elements.js
+++ b/src/TabSwitcher/Pane/elements.js
@@ -1,6 +1,0 @@
-import styled from 'styled-components';
-
-export const Container = styled.div`
-  width: 100%;
-  height: 100%;
-`;

--- a/src/TabSwitcher/Pane/index.js
+++ b/src/TabSwitcher/Pane/index.js
@@ -1,30 +1,63 @@
-import React, { memo } from 'react';
+import React, { memo, forwardRef, useContext } from 'react';
 import PropTypes from 'prop-types';
-import { Container } from './elements';
+import styled from 'styled-components';
 
-const { node, string } = PropTypes;
+import { context } from '..';
 
 /**
  * A pane wraps the content displayable by a tab
  *
- * @param {node} children // Anything that can be rendered: numbers, strings, elements or an array (or fragment)
- * @param {string} className // className needed by styled components
+ * @param {node} children - Anything that can be rendered: numbers, strings, elements or an array (or fragment)
+ * @param {string} className - className needed by styled components
+ * @param {string} tabId - Tab id
  *
  * @return {jsx}
  */
 
-const Pane = ({ children, className }) => <Container className={className}>{children}</Container>;
+const Pane = forwardRef(({ children, className, tabId }, ref) => {
+  const { activeTabId } = useContext(context);
 
-/** Prop types. */
+  return tabId !== activeTabId ? null : (
+    <div
+      className={className}
+      ref={ref}
+      aria-labelledby={tabId}
+      id={`panel:${tabId}`}
+      tabIndex="0"
+      role="tabpanel"
+    >
+      {children}
+    </div>
+  );
+});
+
+/**
+ * PropTypes Validation
+ */
+
+const { node, string } = PropTypes;
+
 Pane.propTypes = {
   children: node,
   className: string,
+  tabId: string.isRequired,
 };
 
-/** Default props. */
+/**
+ * Default props.
+ */
 Pane.defaultProps = {
   children: null,
-  className: '',
+  className: undefined,
 };
 
-export default memo(Pane);
+Pane.displayName = 'Pane';
+
+const StyledPane = styled(memo(Pane))`
+  width: 100%;
+  height: 100%;
+`;
+
+StyledPane.displayName = 'Pane';
+
+export default StyledPane;

--- a/src/TabSwitcher/Panes/elements.js
+++ b/src/TabSwitcher/Panes/elements.js
@@ -1,8 +1,0 @@
-import styled from 'styled-components';
-
-export const Container = styled.div`
-  width: 100%;
-  height: 100%;
-  display: flex;
-  padding: ${({ isCompacted }) => (isCompacted ? '1.2rem 1.6rem' : '2.4rem 3rem')};
-`;

--- a/src/TabSwitcher/Panes/index.js
+++ b/src/TabSwitcher/Panes/index.js
@@ -1,42 +1,42 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import { Container } from './elements';
-
-const { bool, node, number, string } = PropTypes;
+import styled from 'styled-components';
 
 /**
  * Panes hold the content of interactive tabs
  *
- * @param {number} activeIndex // index of the active tab
- * @param {node} children // Anything that can be rendered: numbers, strings, elements or an array (or fragment)
- * @param {string} className // className needed by styled components
- * @param {boolean} isCompacted // if it should reduce its size by reducing padding and font-size
+ * @param {node} children - Anything that can be rendered: numbers, strings, elements or an array (or fragment)
+ * @param {string} className - className needed by styled components
  *
  * @return {jsx}
  */
-const Panes = ({ activeIndex, children, className, isCompacted }) => (
-  <Container className={className} isCompacted={isCompacted}>
-    {children[activeIndex] ? children[activeIndex] : children}
-  </Container>
-);
+const Panes = ({ children, className }) => <div className={className}>{children}</div>;
 
-Panes.displayName = 'Panes';
+/**
+ * PropTypes Validation
+ */
 
-/** Prop types. */
+const { node, string } = PropTypes;
+
 Panes.propTypes = {
-  activeIndex: number,
-  children: node,
+  children: node.isRequired,
   className: string,
-  isCompacted: bool,
 };
 
-/** Default props. */
+/**
+ * Default props.
+ */
 Panes.defaultProps = {
-  activeIndex: 0,
-  children: null,
-  className: '',
-  isCompacted: false,
+  className: undefined,
 };
 
-export default Panes;
+const StyledPanes = styled(Panes)`
+  display: flex;
+
+  width: 100%;
+  height: 100%;
+`;
+
+StyledPanes.displayName = 'Panes';
+
+export default StyledPanes;

--- a/src/TabSwitcher/README.md
+++ b/src/TabSwitcher/README.md
@@ -11,17 +11,15 @@ import { TabSwitcher } from '@tillersystems/stardust';
 ### Properties
 
 - `children` - Tabs and Panes to be displayed.
-- `defaultIndex` - Starts the tab at a specific index.
-- `index` - Like form inputs, a tab's state can be controlled by the owner.
-- `isCompacted` - If it is true, should reduce its size by reducing padding and font-size.
-- `onChange` - Callback with the tab index triggered when the user changes tabs allowing your app to synchronize with it.
+- `defaultTabId` - Starts the tab at a specific id.
+- `tabId` - Like form inputs, a tab's state can be controlled by the owner.
+- `onChange` - Callback with the tab id triggered when the user changes tabs allowing your app to synchronize with it.
 
 | propName       |  propType  | defaultValue | isRequired |
 | -------------- | :--------: | :----------: | :--------: |
 | `children`     |   `node`   |              |     \*     |
-| `defaultIndex` |  `number`  |     `0`      |     -      |
-| `index`        |  `number`  |     `0`      |     -      |
-| `isCompacted`  | `boolean`  |   `false`    |     -      |
+| `defaultTabId` |  `string`  | `undefined`  |     -      |
+| `tabId`        |  `string`  | `undefined`  |     -      |
 | `onChange`     | `function` | `undefined`  |     -      |
 
 ### Example
@@ -29,36 +27,23 @@ import { TabSwitcher } from '@tillersystems/stardust';
 ```jsx
 import { TabSwitcher } from '@tillersystems/stardust';
 
-const panes = [
-  {
-    name: 'Tab 1',
-    content: 'Content 1',
-  },
-  {
-    name: 'Tab 2',
-    content: 'Content 2',
-  },
-  {
-    name: 'Tab 3',
-    content: 'Content 3',
-  },
-  {
-    name: 'Tab 4',
-    content: 'Content 4',
-  },
-];
-
 render() {
-  <TabSwitcher>
+  <TabSwitcher defaultTabId="tab-1">
     <TabSwitcher.Tabs>
-      {panes.map(({ name }) => (
-        <TabSwitcher.Tab key={name}>{name}</TabSwitcher.Tab>
-      ))}
+      <TabSwitcher.Tab id="tab-1">
+        Tab 1
+      </TabSwitcher.Tab>
+      <TabSwitcher.Tab isDisabled id="tab-2">
+        Tab 2
+      </TabSwitcher.Tab>
+      <TabSwitcher.Tab id="tab-3">
+        Tab 3
+      </TabSwitcher.Tab>
     </TabSwitcher.Tabs>
     <TabSwitcher.Panes>
-      {panes.map(({ name, content }) => (
-        <TabSwitcher.Pane key={name}>{content}</TabSwitcher.Pane>
-      ))}
+      <TabSwitcher.Pane tabId="tab-1">Content 1</TabSwitcher.Pane>
+      <TabSwitcher.Pane tabId="tab-2">Content 2</TabSwitcher.Pane>
+      <TabSwitcher.Pane tabId="tab-3">Content 3</TabSwitcher.Pane>
     </TabSwitcher.Panes>
   </TabSwitcher>
 }

--- a/src/TabSwitcher/Tab/elements.js
+++ b/src/TabSwitcher/Tab/elements.js
@@ -14,8 +14,7 @@ export const Container = styled.div`
     css`
       cursor: pointer;
     `}
-  font-size: ${({ isCompacted, theme: { fonts } }) =>
-    isCompacted ? fonts.size.medium : fonts.size.h6};
+  font-size: ${({ theme: { fonts } }) => fonts.size.h6};
   font-weight: ${({
     isActive,
     theme: {
@@ -23,5 +22,4 @@ export const Container = styled.div`
     },
   }) => (isActive ? weight.thick : weight.normal)};
   margin-right: 1.5rem;
-  padding-bottom: ${({ isCompacted }) => (isCompacted ? '1.4rem' : '2.4rem')};
 `;

--- a/src/TabSwitcher/Tab/index.js
+++ b/src/TabSwitcher/Tab/index.js
@@ -1,51 +1,63 @@
-import React, { memo } from 'react';
+import React, { memo, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Container } from './elements';
-
-const { bool, func, node, string } = PropTypes;
+import { context } from '..';
 
 /**
  * Tab are a link displaying the content of a pane
  *
- * @param {node} children // Anything that can be rendered: numbers, strings, elements or an array (or fragment)
- * @param {string} className // className needed by styled components
- * @param {boolean} isActive // if the tab is the current displayed content
- * @param {boolean} isCompacted // if it should reduce its size by reducing padding and font-size
- * @param {boolean} isDisabled // if this tab should be interactive or not
- * @param {function} onActivate - callback triggered when the tab is clicked
+ * @param {node} children - Anything that can be rendered: numbers, strings, elements or an array (or fragment).
+ * @param {string} className - className needed by styled components.
+ * @param {string} id - Id of the tab.
+ * @param {boolean} isDisabled - if this tab should be interactive or not.
  *
  * @return {jsx}
  */
-const Tab = ({ children, className, isActive, isCompacted, isDisabled, onActivate }) => (
-  <Container
-    className={className}
-    onClick={isDisabled ? null : () => onActivate()}
-    isActive={isActive}
-    isDisabled={isDisabled}
-    isCompacted={isCompacted}
-  >
-    {children}
-  </Container>
-);
+const Tab = ({ children, className, id, isDisabled }) => {
+  const { activeTabId, onTabChange } = useContext(context);
 
-/** Prop types. */
+  const isActive = activeTabId === id;
+  const onClick = isDisabled ? null : () => onTabChange(id);
+  const tabIndex = isActive ? 0 : -1;
+
+  return (
+    <Container
+      className={className}
+      onClick={onClick}
+      isActive={isActive}
+      isDisabled={isDisabled}
+      data-isactive={isActive}
+      data-isdisabled={isDisabled}
+      aria-selected={isActive}
+      aria-controls={`panel:${id}`}
+      tabIndex={tabIndex}
+      role="tab"
+    >
+      {children}
+    </Container>
+  );
+};
+
+/**
+ * PropTypes Validation
+ */
+
+const { bool, node, string } = PropTypes;
+
 Tab.propTypes = {
-  children: node,
-  onActivate: func,
-  isActive: bool,
-  isCompacted: bool,
+  children: node.isRequired,
+  id: string,
   isDisabled: bool,
   className: string,
 };
 
-/** Default props. */
+/**
+ * Default props.
+ */
 Tab.defaultProps = {
-  children: null,
-  onActivate: () => {},
-  isActive: false,
-  isCompacted: false,
+  id: undefined,
   isDisabled: false,
-  className: '',
+  className: undefined,
 };
 
 export default memo(Tab);

--- a/src/TabSwitcher/Tabs/elements.js
+++ b/src/TabSwitcher/Tabs/elements.js
@@ -1,7 +1,0 @@
-import styled from 'styled-components';
-
-export const Container = styled.div`
-  display: flex;
-  border-bottom: 1px solid ${({ theme: { palette } }) => palette.lightGrey};
-  padding: ${({ isCompacted }) => (isCompacted ? '1.4rem 1.6rem 0 1.6rem' : '2.4rem 3rem 0 3rem')};
-`;

--- a/src/TabSwitcher/Tabs/index.js
+++ b/src/TabSwitcher/Tabs/index.js
@@ -1,52 +1,45 @@
-import React, { Children, cloneElement } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { Container } from './elements';
-
-const { bool, func, node, number, string } = PropTypes;
+import styled from 'styled-components';
 
 /**
  * Tabs are links displaying the content of a pane
  *
- * @param {number} activeIndex // index of the active tab
- * @param {Array} children // interactive links displaying tabs on click
- * @param {string} className // className needed by styled components
- * @param {boolean} isCompacted // if it should reduce its size by reducing padding and font-size
- * @param {function} onActiveTab // callback triggered when the tab is clicked
+ * @param {Array} children - Interactive links displaying tabs on click
+ * @param {string} className - className needed by styled components
  *
  * @return {jsx}
  */
-const Tabs = ({ activeIndex, children, className, isCompacted, onActiveTab }) => (
-  <Container className={className} isCompacted={isCompacted}>
-    {Children.map(children, (child, index) =>
-      cloneElement(child, {
-        isCompacted,
-        isActive: index === activeIndex,
-        onActivate: () => {
-          onActiveTab(index);
-        },
-      }),
-    )}
-  </Container>
+const Tabs = ({ children, className }) => (
+  <div className={className} role="tablist">
+    {children}
+  </div>
 );
 
-Tabs.displayName = 'Tabs';
+/**
+ * PropTypes Validation
+ */
 
-/** Prop types. */
+const { node, string } = PropTypes;
+
 Tabs.propTypes = {
-  activeIndex: number,
-  children: node,
+  children: node.isRequired,
   className: string,
-  isCompacted: bool,
-  onActiveTab: func,
 };
 
-/** Default props. */
+/**
+ * Default props.
+ */
 Tabs.defaultProps = {
-  activeIndex: 0,
-  children: null,
-  className: '',
-  isCompacted: false,
-  onActiveTab: () => {},
+  className: undefined,
 };
 
-export default Tabs;
+const StyledTabs = styled(Tabs)`
+  display: flex;
+
+  border-bottom: 1px solid ${({ theme: { palette } }) => palette.lightGrey};
+`;
+
+StyledTabs.displayName = 'Tabs';
+
+export default StyledTabs;

--- a/src/TabSwitcher/__stories__/TabSwitcher.stories.js
+++ b/src/TabSwitcher/__stories__/TabSwitcher.stories.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/display-name */
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, boolean, number } from '@storybook/addon-knobs';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
 import { State, Store } from '@sambego/storybook-state';
 import { action } from '@storybook/addon-actions';
 
@@ -13,58 +13,24 @@ storiesOf('TabSwitcher', module)
     const isDisabledValueTab1 = boolean('isDisabledTab1', false, 'ALL');
     const isDisabledValueTab2 = boolean('isDisabledTab2', false, 'ALL');
     const isDisabledValueTab3 = boolean('isDisabledTab3', false, 'ALL');
-    const isDisabledValueTab4 = boolean('isDisabledTab4', false, 'ALL');
-
-    const isCompactedValue = boolean('isCompactedValue', false, 'ALL');
-
-    const panes = [
-      {
-        name: 'Tab 1',
-        content: 'Content 1',
-        isDisabled: isDisabledValueTab1,
-      },
-      {
-        name: 'Tab 2',
-        content: 'Content 2',
-        isDisabled: isDisabledValueTab2,
-      },
-      {
-        name: 'Tab 3',
-        content: 'Content 3',
-        isDisabled: isDisabledValueTab3,
-      },
-      {
-        name: 'Tab 4',
-        content: 'Content 4',
-        isDisabled: isDisabledValueTab4,
-      },
-    ];
-
-    const defaultIndexValue = number(
-      'default index',
-      0,
-      {
-        range: true,
-        min: 0,
-        max: 3,
-        step: 1,
-      },
-      'ALL',
-    );
 
     return (
-      <TabSwitcher defaultIndex={defaultIndexValue} isCompacted={isCompactedValue}>
+      <TabSwitcher defaultTabId="tab-1">
         <TabSwitcher.Tabs>
-          {panes.map(({ isDisabled, name }) => (
-            <TabSwitcher.Tab key={name} isDisabled={isDisabled}>
-              {name}
-            </TabSwitcher.Tab>
-          ))}
+          <TabSwitcher.Tab isDisabled={isDisabledValueTab1} id="tab-1">
+            Tab 1
+          </TabSwitcher.Tab>
+          <TabSwitcher.Tab isDisabled={isDisabledValueTab2} id="tab-2">
+            Tab 2
+          </TabSwitcher.Tab>
+          <TabSwitcher.Tab isDisabled={isDisabledValueTab3} id="tab-3">
+            Tab 3
+          </TabSwitcher.Tab>
         </TabSwitcher.Tabs>
         <TabSwitcher.Panes>
-          {panes.map(({ name, content }) => (
-            <TabSwitcher.Pane key={name}>{content}</TabSwitcher.Pane>
-          ))}
+          <TabSwitcher.Pane tabId="tab-1">Content 1</TabSwitcher.Pane>
+          <TabSwitcher.Pane tabId="tab-2">Content 2</TabSwitcher.Pane>
+          <TabSwitcher.Pane tabId="tab-3">Content 3</TabSwitcher.Pane>
         </TabSwitcher.Panes>
       </TabSwitcher>
     );
@@ -73,61 +39,38 @@ storiesOf('TabSwitcher', module)
     const isDisabledValueTab1 = boolean('isDisabledTab1', false, 'ALL');
     const isDisabledValueTab2 = boolean('isDisabledTab2', false, 'ALL');
     const isDisabledValueTab3 = boolean('isDisabledTab3', false, 'ALL');
-    const isDisabledValueTab4 = boolean('isDisabledTab4', false, 'ALL');
-
-    const isCompactedValue = boolean('isCompactedValue', false, 'ALL');
-
-    const panes = [
-      {
-        name: 'Tab 1',
-        content: 'Content 1',
-        isDisabled: isDisabledValueTab1,
-      },
-      {
-        name: 'Tab 2',
-        content: 'Content 2',
-        isDisabled: isDisabledValueTab2,
-      },
-      {
-        name: 'Tab 3',
-        content: 'Content 3',
-        isDisabled: isDisabledValueTab3,
-      },
-      {
-        name: 'Tab 4',
-        content: 'Content 4',
-        isDisabled: isDisabledValueTab4,
-      },
-    ];
 
     const onChangeAction = action('onChange');
 
     const store = new Store({
-      activeTabIndex: 0,
+      activeTabId: 'tab-1',
     });
 
     return (
       <State store={store}>
         {state => (
           <TabSwitcher
-            index={state.activeTabIndex}
-            isCompacted={isCompactedValue}
-            onChange={index => {
-              store.set({ activeTabIndex: index });
-              onChangeAction('Active Tab Index: ', index);
+            tabId={state.activeTabId}
+            onChange={id => {
+              store.set({ activeTabId: id });
+              onChangeAction('Active Tab Index: ', id);
             }}
           >
             <TabSwitcher.Tabs>
-              {panes.map(({ isDisabled, name }) => (
-                <TabSwitcher.Tab key={name} isDisabled={isDisabled}>
-                  {name}
-                </TabSwitcher.Tab>
-              ))}
+              <TabSwitcher.Tab isDisabled={isDisabledValueTab1} id="tab-1">
+                Tab 1
+              </TabSwitcher.Tab>
+              <TabSwitcher.Tab isDisabled={isDisabledValueTab2} id="tab-2">
+                Tab 2
+              </TabSwitcher.Tab>
+              <TabSwitcher.Tab isDisabled={isDisabledValueTab3} id="tab-3">
+                Tab 3
+              </TabSwitcher.Tab>
             </TabSwitcher.Tabs>
             <TabSwitcher.Panes>
-              {panes.map(({ name, content }) => (
-                <TabSwitcher.Pane key={name}>{content}</TabSwitcher.Pane>
-              ))}
+              <TabSwitcher.Pane tabId="tab-1">Content 1</TabSwitcher.Pane>
+              <TabSwitcher.Pane tabId="tab-2">Content 2</TabSwitcher.Pane>
+              <TabSwitcher.Pane tabId="tab-3">Content 3</TabSwitcher.Pane>
             </TabSwitcher.Panes>
           </TabSwitcher>
         )}

--- a/src/TabSwitcher/__tests__/TabSwitcher.test.js
+++ b/src/TabSwitcher/__tests__/TabSwitcher.test.js
@@ -3,129 +3,140 @@ import { fireEvent } from 'react-testing-library';
 
 import TabSwitcher from '..';
 
-const panes = [
-  {
-    name: 'I am active',
-    content: 'Content 1',
-    isDisabled: false,
-  },
-  {
-    name: 'I am disabled',
-    content: 'Content 2',
-    isDisabled: true,
-  },
-  {
-    name: 'I am disabled too',
-    content: 'Content 3',
-    isDisabled: true,
-  },
-  {
-    name: 'I am available',
-    content: 'Content 4',
-    isDisabled: false,
-  },
-];
-
 describe('<TabSwitcher />', () => {
   test('should render without a problem', () => {
-    const { getByText, queryAllByText } = render(
-      <TabSwitcher>
+    const { getByText, getAllByText } = render(
+      <TabSwitcher defaultTabId="tab-1">
         <TabSwitcher.Tabs>
-          {panes.map(({ name }) => (
-            <TabSwitcher.Tab key={name}>{name}</TabSwitcher.Tab>
-          ))}
+          <TabSwitcher.Tab id="tab-1">I am active tab</TabSwitcher.Tab>
+          <TabSwitcher.Tab id="tab-2">I am tab</TabSwitcher.Tab>
+          <TabSwitcher.Tab id="tab-3">I am tab</TabSwitcher.Tab>
         </TabSwitcher.Tabs>
         <TabSwitcher.Panes>
-          {panes.map(({ name, content }) => (
-            <TabSwitcher.Pane key={name}>{content}</TabSwitcher.Pane>
-          ))}
+          <TabSwitcher.Pane tabId="tab-1">content 1</TabSwitcher.Pane>
+          <TabSwitcher.Pane tabId="tab-2">content 2</TabSwitcher.Pane>
+          <TabSwitcher.Pane tabId="tab-3">content 3</TabSwitcher.Pane>
         </TabSwitcher.Panes>
       </TabSwitcher>,
     );
 
-    const tabs = queryAllByText(/I am/);
-    const activeTabNode = getByText('I am active');
-    const availableTabNode = getByText('I am available');
+    const tabs = getAllByText(/I am/);
+    const activeTabNode = getByText(/I am active/i);
 
-    expect(tabs).toHaveLength(4);
+    expect(tabs).toHaveLength(3);
     expect(activeTabNode).toHaveStyleRule('border-bottom', '3px solid hsl(200,74%,46%)');
-    expect(availableTabNode).toHaveStyleRule('color', 'hsl(207,13%,45%)');
-  });
+    expect(activeTabNode).toHaveStyleRule('color', 'hsl(213,17%,20%)');
 
-  test('should render the compacted version', () => {
-    const { getByText } = render(
-      <TabSwitcher isCompacted>
-        <TabSwitcher.Tabs>
-          {panes.map(({ name }) => (
-            <TabSwitcher.Tab key={name}>{name}</TabSwitcher.Tab>
-          ))}
-        </TabSwitcher.Tabs>
-        <TabSwitcher.Panes>
-          {panes.map(({ name, content }) => (
-            <TabSwitcher.Pane key={name}>{content}</TabSwitcher.Pane>
-          ))}
-        </TabSwitcher.Panes>
-      </TabSwitcher>,
-    );
+    const Panes = getAllByText(/content/);
+    const activePane = getByText(/content 1/);
 
-    const activeTabNode = getByText('I am active');
-
-    expect(activeTabNode).toHaveStyleRule('padding-bottom', '1.4rem');
+    expect(Panes).toHaveLength(1);
+    expect(activePane).toBeInTheDocument();
   });
 
   test('should correctly display disabled tabs', () => {
-    const { getAllByText } = render(
-      <TabSwitcher>
+    const { getByText } = render(
+      <TabSwitcher defaultTabId="tab-1">
         <TabSwitcher.Tabs>
-          {panes.map(({ name, isDisabled }) => (
-            <TabSwitcher.Tab key={name} isDisabled={isDisabled}>
-              {name}
-            </TabSwitcher.Tab>
-          ))}
+          <TabSwitcher.Tab id="tab-1">I am active tab</TabSwitcher.Tab>
+          <TabSwitcher.Tab id="tab-2" isDisabled>
+            I am disabled tab
+          </TabSwitcher.Tab>
+          <TabSwitcher.Tab id="tab-3">I am tab</TabSwitcher.Tab>
         </TabSwitcher.Tabs>
         <TabSwitcher.Panes>
-          {panes.map(({ name, content }) => (
-            <TabSwitcher.Pane key={name}>{content}</TabSwitcher.Pane>
-          ))}
+          <TabSwitcher.Pane tabId="tab-1">content 1</TabSwitcher.Pane>
+          <TabSwitcher.Pane tabId="tab-2">content 2</TabSwitcher.Pane>
+          <TabSwitcher.Pane tabId="tab-3">content 3</TabSwitcher.Pane>
         </TabSwitcher.Panes>
       </TabSwitcher>,
     );
 
-    const disabledTabNodes = getAllByText(/I am disabled/);
+    const disabledTab = getByText(/I am disabled/);
 
-    expect(disabledTabNodes[0]).toHaveStyleRule('color', 'hsl(206,23%,69%)');
-    expect(disabledTabNodes[1]).toHaveStyleRule('color', 'hsl(206,23%,69%)');
+    expect(disabledTab).toHaveStyleRule('color', 'hsl(206,23%,69%)');
   });
 
   describe('Uncontrolled mode: ', () => {
-    test('should update tab on click', () => {
-      const { getByText } = render(
-        <TabSwitcher>
+    test('should swicth tab on click', () => {
+      const { getByText, getAllByText, queryByText } = render(
+        <TabSwitcher defaultTabId="tab-1">
           <TabSwitcher.Tabs>
-            {panes.map(({ name, isDisabled }) => (
-              <TabSwitcher.Tab key={name} isDisabled={isDisabled}>
-                {name}
-              </TabSwitcher.Tab>
-            ))}
+            <TabSwitcher.Tab id="tab-1">I am active tab</TabSwitcher.Tab>
+            <TabSwitcher.Tab id="tab-2">I am tab</TabSwitcher.Tab>
+            <TabSwitcher.Tab id="tab-3">I am tab</TabSwitcher.Tab>
           </TabSwitcher.Tabs>
           <TabSwitcher.Panes>
-            {panes.map(({ name, content }) => (
-              <TabSwitcher.Pane key={name}>{content}</TabSwitcher.Pane>
-            ))}
+            <TabSwitcher.Pane tabId="tab-1">content 1</TabSwitcher.Pane>
+            <TabSwitcher.Pane tabId="tab-2">content 2</TabSwitcher.Pane>
+            <TabSwitcher.Pane tabId="tab-3">content 3</TabSwitcher.Pane>
           </TabSwitcher.Panes>
         </TabSwitcher>,
       );
 
-      const activeTabNode = getByText('I am active');
-      const availableTabNode = getByText('I am available');
+      const activeTabNode = getByText(/I am active/i);
+      const availableTabNodes = getAllByText(/I am tab/i);
+      const activePane = getByText(/content 1/);
+      const inactivePane = queryByText(/content 2/);
 
       expect(activeTabNode).toHaveStyleRule('border-bottom', '3px solid hsl(200,74%,46%)');
-      expect(availableTabNode).toHaveStyleRule('color', 'hsl(207,13%,45%)');
+      expect(activeTabNode).toHaveStyleRule('color', 'hsl(213,17%,20%)');
+      expect(availableTabNodes[0]).toHaveStyleRule('color', 'hsl(207,13%,45%)');
+      expect(availableTabNodes[1]).toHaveStyleRule('color', 'hsl(207,13%,45%)');
+      expect(activePane).toBeInTheDocument();
+      expect(inactivePane).not.toBeInTheDocument();
 
-      fireEvent.click(availableTabNode);
+      fireEvent.click(availableTabNodes[0]);
 
-      expect(availableTabNode).toHaveStyleRule('border-bottom', '3px solid hsl(200,74%,46%)');
-      expect(activeTabNode).toHaveStyleRule('color', 'hsl(207,13%,45%)');
+      const oldActiveTab = activeTabNode;
+      const newActiveTab = availableTabNodes[0];
+      const oldActivePane = activePane;
+      const newActivePane = getByText(/content 2/);
+
+      expect(newActiveTab).toHaveStyleRule('border-bottom', '3px solid hsl(200,74%,46%)');
+      expect(oldActiveTab).toHaveStyleRule('color', 'hsl(207,13%,45%)');
+      expect(newActivePane).toBeInTheDocument();
+      expect(oldActivePane).not.toBeInTheDocument();
+    });
+
+    test('should not swicth tab if disabled', () => {
+      const { getByText, getAllByText, queryByText } = render(
+        <TabSwitcher defaultTabId="tab-1">
+          <TabSwitcher.Tabs>
+            <TabSwitcher.Tab id="tab-1">I am active tab</TabSwitcher.Tab>
+            <TabSwitcher.Tab id="tab-2" isDisabled>
+              I am tab
+            </TabSwitcher.Tab>
+            <TabSwitcher.Tab id="tab-3">I am tab</TabSwitcher.Tab>
+          </TabSwitcher.Tabs>
+          <TabSwitcher.Panes>
+            <TabSwitcher.Pane tabId="tab-1">content 1</TabSwitcher.Pane>
+            <TabSwitcher.Pane tabId="tab-2">content 2</TabSwitcher.Pane>
+            <TabSwitcher.Pane tabId="tab-3">content 3</TabSwitcher.Pane>
+          </TabSwitcher.Panes>
+        </TabSwitcher>,
+      );
+
+      const activeTabNode = getByText(/I am active/i);
+      const availableTabNodes = getAllByText(/I am tab/i);
+      const activePane = getByText(/content 1/);
+      const inactivePane = queryByText(/content 2/);
+
+      expect(activeTabNode).toHaveStyleRule('border-bottom', '3px solid hsl(200,74%,46%)');
+      expect(activeTabNode).toHaveStyleRule('color', 'hsl(213,17%,20%)');
+      expect(availableTabNodes[0]).toHaveStyleRule('color', 'hsl(206,23%,69%)');
+      expect(availableTabNodes[1]).toHaveStyleRule('color', 'hsl(207,13%,45%)');
+      expect(activePane).toBeInTheDocument();
+      expect(inactivePane).not.toBeInTheDocument();
+
+      fireEvent.click(availableTabNodes[0]);
+
+      expect(activeTabNode).toHaveStyleRule('border-bottom', '3px solid hsl(200,74%,46%)');
+      expect(activeTabNode).toHaveStyleRule('color', 'hsl(213,17%,20%)');
+      expect(availableTabNodes[0]).toHaveStyleRule('color', 'hsl(206,23%,69%)');
+      expect(availableTabNodes[1]).toHaveStyleRule('color', 'hsl(207,13%,45%)');
+      expect(activePane).toBeInTheDocument();
+      expect(inactivePane).not.toBeInTheDocument();
     });
   });
 
@@ -133,29 +144,52 @@ describe('<TabSwitcher />', () => {
     test('should call onChange callback', () => {
       const spy = jest.fn();
 
-      const { getByText } = render(
-        <TabSwitcher onChange={spy} index={0}>
+      const { getAllByText } = render(
+        <TabSwitcher tabId="tab-1" onChange={spy}>
           <TabSwitcher.Tabs>
-            {panes.map(({ name, isDisabled }) => (
-              <TabSwitcher.Tab key={name} isDisabled={isDisabled}>
-                {name}
-              </TabSwitcher.Tab>
-            ))}
+            <TabSwitcher.Tab id="tab-1">I am active tab</TabSwitcher.Tab>
+            <TabSwitcher.Tab id="tab-2">I am tab</TabSwitcher.Tab>
+            <TabSwitcher.Tab id="tab-3">I am tab</TabSwitcher.Tab>
           </TabSwitcher.Tabs>
           <TabSwitcher.Panes>
-            {panes.map(({ name, content }) => (
-              <TabSwitcher.Pane key={name}>{content}</TabSwitcher.Pane>
-            ))}
+            <TabSwitcher.Pane tabId="tab-1">content 1</TabSwitcher.Pane>
+            <TabSwitcher.Pane tabId="tab-2">content 2</TabSwitcher.Pane>
+            <TabSwitcher.Pane tabId="tab-3">content 3</TabSwitcher.Pane>
           </TabSwitcher.Panes>
         </TabSwitcher>,
       );
+      const availableTabNodes = getAllByText(/I am tab/i);
 
-      const availableTabNode = getByText('I am available');
-
-      fireEvent.click(availableTabNode);
+      fireEvent.click(availableTabNodes[0]);
 
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenLastCalledWith(3);
+      expect(spy).toHaveBeenLastCalledWith('tab-2');
+    });
+
+    test('should not call onChange callback if tab is disabled ', () => {
+      const spy = jest.fn();
+
+      const { getAllByText } = render(
+        <TabSwitcher tabId="tab-1" onChange={spy}>
+          <TabSwitcher.Tabs>
+            <TabSwitcher.Tab id="tab-1">I am active tab</TabSwitcher.Tab>
+            <TabSwitcher.Tab id="tab-2" isDisabled>
+              I am tab
+            </TabSwitcher.Tab>
+            <TabSwitcher.Tab id="tab-3">I am tab</TabSwitcher.Tab>
+          </TabSwitcher.Tabs>
+          <TabSwitcher.Panes>
+            <TabSwitcher.Pane tabId="tab-1">content 1</TabSwitcher.Pane>
+            <TabSwitcher.Pane tabId="tab-2">content 2</TabSwitcher.Pane>
+            <TabSwitcher.Pane tabId="tab-3">content 3</TabSwitcher.Pane>
+          </TabSwitcher.Panes>
+        </TabSwitcher>,
+      );
+      const availableTabNodes = getAllByText(/I am tab/i);
+
+      fireEvent.click(availableTabNodes[0]);
+
+      expect(spy).toHaveBeenCalledTimes(0);
     });
   });
 });


### PR DESCRIPTION
- [x] Feature
- [ ] Fix
- [x] Enhancement

## Description
Completely  refactor of `TabSwicther` component: 
- use react context instead of react children map to to prevent redeclared`displayName`
- make the tab more accessible

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Requirements :
<!--- Eventually remove the following. -->
:warning: Requires running `yarn` command.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
