### PR TITLE
fix(CheckBox): avoid width of checkbox being less than the width specified

### DIFF
--- a/src/CheckBox/__tests__/__snapshots__/CheckBox.test.js.snap
+++ b/src/CheckBox/__tests__/__snapshots__/CheckBox.test.js.snap
@@ -38,7 +38,7 @@ exports[`<CheckBox /> should render without a problem 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  width: 1.6rem;
+  min-width: 1.6rem;
   height: 1.6rem;
   margin-right: 0.7rem;
   background: hsl(0,100%,100%);

--- a/src/CheckBox/elements.js
+++ b/src/CheckBox/elements.js
@@ -13,7 +13,7 @@ export const StyledCheckbox = styled.div`
   justify-content: center;
   align-items: center;
 
-  width: 1.6rem;
+  min-width: 1.6rem;
   height: 1.6rem;
 
   margin-right: 0.7rem;


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description
Avoid this:
<img width="239" alt="Screenshot 2019-06-11 at 14 32 51" src="https://user-images.githubusercontent.com/6019103/59272211-d24ed000-8c55-11e9-929a-14cb8d658ae9.png">

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
