### PR TITLE
feat(Table): Add object support to hydrate row field

### DIFF
--- a/src/Table/README.md
+++ b/src/Table/README.md
@@ -29,6 +29,7 @@ import { Table } from '@tillersystems/stardust';
 - `title` - **required** - title of the column, can be either a `string` or a `Component`.
 - `value` - **required** - function to get the value from a column.
 - `format` - _optional_ - function to format the value for display.
+- `filteredBy` - _optional_ - Filters the object by the value.
 - `width` - _optional_ - width of the column (either a relative weight, or a fixed size in `rem` or `px`).
 - `align` - _optional_ - alignment of the cell's content (`left`, `center`, `right`, by default `center`).
 - `sortable` - _optional_ - whether the column is sortable or not (default `false`).
@@ -73,25 +74,35 @@ const data = [
   {
     name: 'Tartare de boeuf',
     price: 15.0,
-    tax: 10.0,
+    tax: {
+      fr: 9.0,
+      en: 10.0,
+    },
   },
   {
     name: 'Oeuf cocotte',
     price: 13.0,
-    tax: 10.0,
+    tax: {
+      fr: 7.0,
+      en: 6.0,
+    },
   },
   {
     name: 'Salade caesar',
     price: 16.0,
-    tax: 10.0,
+    tax: {
+      fr: 10.0,
+      en: 3.0,
+    },
   },
 ];
 
 const colsDef = [
   {
-    title: 'NAME',
+    title: 'DISH',
     value: d => d.name,
     format: v => <span style={{ color: 'hsl(213, 17%, 20%)', fontWeight: 600 }}>{v}</span>,
+    sortable: dishRowSortable,
     align: 'left',
     sortable: true,
   },
@@ -99,13 +110,18 @@ const colsDef = [
     title: 'PRICE',
     value: d => d.price,
     format: v => `${v.toFixed(2)} €`,
+    align: 'right',
+    sortable: priceRowSortable,
     width: '20rem',
     sortable: true,
   },
   {
     title: 'TAX',
     value: d => d.tax,
-    format: v => `${v.toFixed(2)}%`,
+    format: v => `${v.fr.toFixed(2)} %`,
+    filteredBy: v => v.fr,
+    align: 'right',
+    sortable: titleRowSortable,
     width: '20rem',
   },
 ];
@@ -116,6 +132,6 @@ const rowsDef = {
 }
 
 render() {
-  return <Table data={ data} colsDef={colsDef} rowsDef={rowsDef} />;
+  return <Table data={data} colsDef={colsDef} rowsDef={rowsDef} />;
 }
 ```

--- a/src/Table/__stories__/Table.stories.js
+++ b/src/Table/__stories__/Table.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, boolean } from '@storybook/addon-knobs';
+import { withKnobs, boolean, select } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
 import { Table } from '../..';
@@ -21,16 +21,23 @@ storiesOf('Table', module)
     const priceRowSortable = boolean('Price row is sortable', true, 'State');
     const titleRowSortable = boolean('Title row is sortable', true, 'State');
 
-    const getColsDef = () => [
+    const options = {
+      french: 'fr',
+      english: 'en',
+    };
+
+    const taxCountryCodeValue = select('Selectable taxes country', options, 'fr', 'State');
+
+    const getColsDef = (taxCountryCode = 'fr') => [
       {
         title: 'DISH',
-        value: d => d.code,
+        value: d => d.name,
         sortable: dishRowSortable,
         align: 'left',
       },
       {
         title: 'PRICE',
-        value: d => d.value,
+        value: d => d.price,
         format: v => `${v.toFixed(2)} €`,
         align: 'right',
         sortable: priceRowSortable,
@@ -38,7 +45,8 @@ storiesOf('Table', module)
       {
         title: 'TAX',
         value: d => d.tax,
-        format: v => `${v.toFixed(2)} %`,
+        format: v => `${v[taxCountryCode].toFixed(2)} %`,
+        filteredBy: v => v[taxCountryCode],
         align: 'right',
         sortable: titleRowSortable,
       },
@@ -53,21 +61,37 @@ storiesOf('Table', module)
 
     const data = [
       {
-        code: 'Tartare de boeuf',
-        value: 15.0,
-        tax: 10.0,
+        name: 'Tartare de boeuf',
+        price: 15.0,
+        tax: {
+          fr: 9.0,
+          en: 10.0,
+        },
       },
       {
-        code: 'Oeuf cocotte',
-        value: 13.0,
-        tax: 10.0,
+        name: 'Oeuf cocotte',
+        price: 13.0,
+        tax: {
+          fr: 7.0,
+          en: 6.0,
+        },
       },
       {
-        code: 'Salade caesar',
-        value: 16.0,
-        tax: 10.0,
+        name: 'Salade caesar',
+        price: 16.0,
+        tax: {
+          fr: 10.0,
+          en: 3.0,
+        },
       },
     ];
 
-    return <Table data={data} colsDef={getColsDef()} rowsDef={rowsDef} striped={striped} />;
+    return (
+      <Table
+        data={data}
+        colsDef={getColsDef(taxCountryCodeValue)}
+        rowsDef={rowsDef}
+        striped={striped}
+      />
+    );
   });

--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -43,6 +43,7 @@ class Table extends PureComponent {
         title: node.isRequired,
         value: func.isRequired,
         format: func,
+        filteredBy: func,
         width: oneOfType([string, number]),
         align: oneOf(['left', 'center', 'right']),
         sortable: bool,
@@ -181,11 +182,26 @@ class Table extends PureComponent {
       };
     });
     if (index >= 0) {
-      sortedData = sortedData.sort(
-        (a, b) =>
-          (direction === 'asc' ? -1 : direction === 'desc' ? 1 : 0) *
-          compare(colsDef[index].value(a.item), colsDef[index].value(b.item)),
-      );
+      sortedData = sortedData.sort((a, b) => {
+        const isSortableObject =
+          typeof colsDef[index].value(a.item) === 'object' && !!colsDef[index].filteredBy;
+
+        /**
+         * Check if the value should be sorted by an object key or directly by the value itself.
+         *
+         * @param {object} comparisonElement - element returned by the .sort() methode used to compare and sort data.
+         *
+         * @return {string|number}
+         */
+        const sortBy = comparisonElement =>
+          isSortableObject
+            ? colsDef[index].filteredBy(colsDef[index].value(comparisonElement.item))
+            : colsDef[index].value(comparisonElement.item);
+
+        return (
+          (direction === 'asc' ? -1 : direction === 'desc' ? 1 : 0) * compare(sortBy(a), sortBy(b))
+        );
+      });
     }
 
     return (


### PR DESCRIPTION
- [x] Feature
- [ ] Fix
- [ ] Enhancement

## Description

Actually field of the Table component could be hydrated by a single value. If an object was passed only one value could be displayed or no one. This pr add a new support for object in our Table component.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
