### PR TITLE
fix(Select): use prevent default method to cancel default action that…

### DIFF
--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -137,7 +137,8 @@ class Select extends PureComponent {
   /**
    * Toogle Menu
    */
-  toggleMenu = () => {
+  toggleMenu = event => {
+    event.preventDefault();
     const { displayMenu } = this.state;
     const { onToggle } = this.props;
 
@@ -158,7 +159,8 @@ class Select extends PureComponent {
    * @param {string} value
    *
    */
-  handleSelected(value) {
+  handleSelected(event, value) {
+    event.persist();
     const { onChange } = this.props;
 
     this.setState(
@@ -167,7 +169,7 @@ class Select extends PureComponent {
       },
       () => {
         onChange && onChange(value);
-        this.toggleMenu();
+        this.toggleMenu(event);
       },
     );
   }
@@ -201,7 +203,7 @@ class Select extends PureComponent {
                 <MenuItem
                   key={child}
                   role="menuitem"
-                  onClick={() => this.handleSelected(child.props.value)}
+                  onClick={event => this.handleSelected(event, child.props.value)}
                 >
                   {child}
                 </MenuItem>


### PR DESCRIPTION
… belongs to the event

- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description

Since we use a Button for our <Select /> component we need use prevent default method to cancel default action that belongs to the event, for example, to avoid trigger onSubmit on the form.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
