### PR TITLE
fix(DatePicker): update range edges according to min and max boundaries

### DIFF
--- a/src/DatePicker/__stories__/DatePicker.stories.js
+++ b/src/DatePicker/__stories__/DatePicker.stories.js
@@ -10,6 +10,7 @@ import DatePickerReadme from '../README.md';
 
 const onChangeAction = action('onChange');
 const today = new Date();
+const beginningOfToday = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 0, 0, 0);
 
 const store = new Store({
   currentDate: DateTime.local(),
@@ -35,9 +36,9 @@ storiesOf('DatePicker', module)
     );
 
     const withMinDate = boolean('With minimum date', false, 'Bounds');
-    const minDateValue = date('Minimum date', today, 'Bounds');
+    const minDateValue = date('Minimum date', beginningOfToday, 'Bounds');
     const withMaxDate = boolean('With maximum date', false, 'Bounds');
-    const maxDateValue = date('Maximum date', today, 'Bounds');
+    const maxDateValue = date('Maximum date', beginningOfToday, 'Bounds');
 
     const numberOfMonthsToDisplay = number(
       'Number of month to display',
@@ -73,9 +74,9 @@ storiesOf('DatePicker', module)
     );
 
     const withMinDate = boolean('With minimum date', false, 'Bounds');
-    const minDateValue = date('Minimum date', today, 'Bounds');
+    const minDateValue = date('Minimum date', beginningOfToday, 'Bounds');
     const withMaxDate = boolean('With maximum date', false, 'Bounds');
-    const maxDateValue = date('Maximum date', today, 'Bounds');
+    const maxDateValue = date('Maximum date', beginningOfToday, 'Bounds');
 
     const numberOfMonthsToDisplay = number(
       'Number of month to display',
@@ -116,9 +117,9 @@ storiesOf('DatePicker', module)
     );
 
     const withMinDate = boolean('With minimum date', false, 'Bounds');
-    const minDateValue = date('Minimum date', today, 'Bounds');
+    const minDateValue = date('Minimum date', beginningOfToday, 'Bounds');
     const withMaxDate = boolean('With maximum date', false, 'Bounds');
-    const maxDateValue = date('Maximum date', today, 'Bounds');
+    const maxDateValue = date('Maximum date', beginningOfToday, 'Bounds');
 
     const numberOfMonthsToDisplay = number(
       'Number of month to display',

--- a/src/DatePicker/__tests__/DatePicker.test.js
+++ b/src/DatePicker/__tests__/DatePicker.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DateTime, Settings } from 'luxon';
+import { DateTime, Interval, Settings } from 'luxon';
 import Mockdate from 'mockdate';
 import { fireEvent } from '@testing-library/react';
 
@@ -115,11 +115,11 @@ describe('<DatePicker />', () => {
         <DatePicker defaultValue={dateValue} numberOfMonthsToDisplay={2} />,
       );
 
-      const excpectedFirstMonth = getByText(/July/);
-      const excpectedSecondMonth = getByText(/August/);
+      const expectedFirstMonth = getByText(/July/);
+      const expectedSecondMonth = getByText(/August/);
 
-      expect(excpectedFirstMonth).toBeInTheDocument();
-      expect(excpectedSecondMonth).toBeInTheDocument();
+      expect(expectedFirstMonth).toBeInTheDocument();
+      expect(expectedSecondMonth).toBeInTheDocument();
     });
 
     test('should select a date', () => {
@@ -170,9 +170,9 @@ describe('<DatePicker />', () => {
       // Click on previous month button
       fireEvent.click(previousMonthButton);
 
-      const excpectedMonth = getByText(/June/);
+      const expectedMonth = getByText(/June/);
 
-      expect(excpectedMonth).toBeInTheDocument();
+      expect(expectedMonth).toBeInTheDocument();
     });
 
     test('should handle next month', () => {
@@ -183,9 +183,9 @@ describe('<DatePicker />', () => {
       // Click on previous month button
       fireEvent.click(nextMonthButton);
 
-      const excpectedMonth = getByText(/August/);
+      const expectedMonth = getByText(/August/);
 
-      expect(excpectedMonth).toBeInTheDocument();
+      expect(expectedMonth).toBeInTheDocument();
     });
   });
 
@@ -271,9 +271,9 @@ describe('<DatePicker />', () => {
       // Click on previous month button
       fireEvent.click(previousMonthButton);
 
-      const excpectedMonth = getByText(/June/);
+      const expectedMonth = getByText(/June/);
 
-      expect(excpectedMonth).toBeInTheDocument();
+      expect(expectedMonth).toBeInTheDocument();
     });
 
     test('should handle next month', () => {
@@ -286,9 +286,47 @@ describe('<DatePicker />', () => {
       // Click on previous month button
       fireEvent.click(nextMonthButton);
 
-      const excpectedMonth = getByText(/August/);
+      const expectedMonth = getByText(/August/);
 
-      expect(excpectedMonth).toBeInTheDocument();
+      expect(expectedMonth).toBeInTheDocument();
+    });
+
+    test('should update edges of range depending on min and max boundaries', () => {
+      const minDate = DateTime.fromObject({
+        year: 2018,
+        month: 7,
+        day: 17,
+        hour: 0,
+        minute: 0,
+        second: 0,
+      });
+
+      const maxDate = DateTime.fromObject({
+        year: 2018,
+        month: 7,
+        day: 20,
+        hour: 0,
+        minute: 0,
+        second: 0,
+      });
+
+      const interval = Interval.fromDateTimes(
+        DateTime.fromObject({ year: 2018, month: 7, day: 14 }),
+        DateTime.fromObject({ year: 2018, month: 7, day: 23 }),
+      );
+
+      const { getByText } = render(
+        <DatePicker defaultValue={interval} minDate={minDate} maxDate={maxDate} rangePicker />,
+      );
+
+      const startIntervalNode = getByText('17');
+      const endIntervalNode = getByText('20');
+
+      expect(startIntervalNode).toHaveStyleRule('color', Theme.palette.white);
+      expect(startIntervalNode).toHaveStyleRule('background', Theme.palette.primary.default);
+
+      expect(endIntervalNode).toHaveStyleRule('color', Theme.palette.white);
+      expect(endIntervalNode).toHaveStyleRule('background', Theme.palette.primary.default);
     });
 
     describe('with 2 consecutives months displayed', () => {
@@ -417,10 +455,10 @@ describe('<DatePicker />', () => {
         // Click on previous month button
         fireEvent.click(previousMonthButton);
 
-        const excpectedMonth = [getByText(/June/), getByText(/July/)];
+        const expectedMonth = [getByText(/June/), getByText(/July/)];
 
-        expect(excpectedMonth[0]).toBeInTheDocument();
-        expect(excpectedMonth[1]).toBeInTheDocument();
+        expect(expectedMonth[0]).toBeInTheDocument();
+        expect(expectedMonth[1]).toBeInTheDocument();
       });
 
       test('should handle next month', () => {
@@ -433,10 +471,10 @@ describe('<DatePicker />', () => {
         // Click on previous month button
         fireEvent.click(nextMonthButton);
 
-        const excpectedMonth = [getByText(/August/), getByText(/September/)];
+        const expectedMonth = [getByText(/August/), getByText(/September/)];
 
-        expect(excpectedMonth[0]).toBeInTheDocument();
-        expect(excpectedMonth[1]).toBeInTheDocument();
+        expect(expectedMonth[0]).toBeInTheDocument();
+        expect(expectedMonth[1]).toBeInTheDocument();
       });
     });
   });

--- a/src/DatePicker/index.js
+++ b/src/DatePicker/index.js
@@ -90,20 +90,9 @@ class DatePicker extends PureComponent {
    *
    */
   componentDidMount() {
-    const { defaultValue } = this.props;
     const { isInterval } = this.state;
 
-    if (isInterval) {
-      // Always set the current date to the start of the interval.
-      this.setState({
-        selected: defaultValue,
-        currentDate: defaultValue.start,
-        startDate: defaultValue.start,
-        endDate: defaultValue.end,
-      });
-    } else {
-      this.setState({ selected: defaultValue, currentDate: defaultValue });
-    }
+    this.setInternalState(isInterval);
   }
 
   /**
@@ -115,13 +104,36 @@ class DatePicker extends PureComponent {
     const { defaultValue } = this.props;
 
     if (defaultValue !== prevDefaultValue) {
-      !prevState.isInterval &&
-        this.setState({
-          selected: defaultValue,
-          currentDate: defaultValue,
-        });
-      prevState.isInterval &&
-        this.setState({ selected: defaultValue, currentDate: defaultValue.start });
+      this.setInternalState(prevState.isInterval);
+    }
+  }
+
+  /**
+   * Set values for date depending on if this is an interval or not.
+   * If value is an interval, it checks if it does not go beyond boundaries set by minDate and maxDate
+   * props. If the whole interval is outside the boundaries, the interval is set as is and
+   * will no be visible since the interval will be in the disabled dates
+   *
+   * @param {boolean} isInterval if the selected date of the date picker is an interval
+   *
+   */
+  setInternalState(isInterval) {
+    const { defaultValue, minDate, maxDate } = this.props;
+
+    if (isInterval) {
+      // Always set the current date to the start of the interval.
+      this.setState({
+        selected: defaultValue,
+        currentDate: defaultValue.start,
+        startDate:
+          defaultValue.start < minDate && defaultValue.end >= minDate
+            ? minDate
+            : defaultValue.start,
+        endDate:
+          defaultValue.end > maxDate && defaultValue.start <= maxDate ? maxDate : defaultValue.end,
+      });
+    } else {
+      this.setState({ selected: defaultValue, currentDate: defaultValue });
     }
   }
 


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description
Avoid this: 
<img width="276" alt="Screenshot 2019-07-01 at 15 32 25" src="https://user-images.githubusercontent.com/6019103/60441004-63daad80-9c16-11e9-8846-f49eeba7612d.png">
If the component is provided with an interval that is outside the minDate and maxDate, the displayed range should stay within these boundaries.

You can play with the stories to check if everything works as expected.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
