### PR TITLE
feat(Dropdown): Add portal to Dropdown component

### DIFF
--- a/src/Dropdown/elements.js
+++ b/src/Dropdown/elements.js
@@ -56,11 +56,10 @@ export const Header = styled.button`
 
 export const Menu = styled.ul`
   position: absolute;
-  top: calc(100% + 0.4rem);
-  left: 0;
-  z-index: 1;
+  top: ${({ position: { top } }) => `${top}px`};
+  left: ${({ position: { left } }) => `${left}px`};
 
-  width: 100%;
+  width: ${({ position: { width } }) => `${width}px`};
   max-height: 28rem;
 
   border: 1px solid ${({ theme: { palette } }) => palette.lightGrey};


### PR DESCRIPTION
- [x] Feature
- [ ] Fix
- [ ] Enhancement

## Description
<!--- Describe your changes in detail -->
We need to move the `<Dropdown />` component into a portal. I use the `<Portal>` component provided by the `react-portal` library to render the portal. The portal appear at the bottom of the body and it positioned according to the input.

## Related / Associated Jira Cards :
>  [BP-52](https://tillersystems.atlassian.net/browse/BP-52)

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
