### PR TITLE
chore(babel): specify corejs number in babelrc

### DIFF
--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["@babel/preset-env", { "modules": false }],
+    ["@babel/preset-env", { "modules": false, "useBuiltIns": "usage", "corejs": 3 }],
     "@babel/react",
   ],
   "plugins": ["@babel/plugin-proposal-class-properties"]


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description
Since we update corjs to 3.0 we have a problem to build storybook.
<img width="835" alt="Screenshot 2019-07-09 at 11 47 05" src="https://user-images.githubusercontent.com/531935/60878068-57baa580-a23f-11e9-8fbc-0def0d89e3cc.png">
To avoid this error we need to explicity add wich version of corejs we use in the storybook `.babelrc`
https://github.com/storybookjs/storybook/issues/6204#issuecomment-503480927

## Requirements :
<!--- Eventually remove the following. -->
:warning: Requires running `yarn` command.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
