### PR TITLE
fix(Dropdown): put empty array to filtered items when searchable is false

### DIFF
--- a/src/Dropdown/index.js
+++ b/src/Dropdown/index.js
@@ -161,9 +161,11 @@ class Dropdown extends PureComponent {
     // Filter items based on search key word
     // TODO: when need to refactor this later, children may have some children
     // we need to filter recursively. - @Thomas -
-    const FiltredItem = Children.toArray(children).filter(({ props: { children } }) =>
-      children.toLowerCase().includes(searchKeyword.toLowerCase()),
-    );
+    const FilteredItems = searchable
+      ? Children.toArray(children).filter(({ props: { children } }) =>
+          children.toLowerCase().includes(searchKeyword.toLowerCase()),
+        )
+      : [];
 
     return (
       <div className={className} data-testid="dropdown">
@@ -196,8 +198,8 @@ class Dropdown extends PureComponent {
                 )}
 
                 {searchable &&
-                  (FiltredItem.length !== 0
-                    ? FiltredItem.map(child => (
+                  (FilteredItems.length !== 0
+                    ? FilteredItems.map(child => (
                         <MenuItem key={child.key} searchable={searchable} role="menuitem">
                           {child}
                         </MenuItem>


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description
When trying to use the Dropdown elsewhere, I stumbled upon an error on the FilteredItems because `children,.toLowerCase()` did not exist. As we don't need the FilteredItems when the component is not searchable, I just put an empty array.

## Requirements :
<!--- Eventually remove the following. -->
:warning: Requires running `yarn` command.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
