### PR TITLE
refactor(Dropdown): remove internal style of padding

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,27 +9,47 @@
     "@babel/react"
   ],
   "plugins": [
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-proposal-class-properties",
+    [
+      "babel-plugin-styled-components",
+      {
+        "displayName": true
+      }
+    ]
   ],
   "env": {
     "es": {
-      "ignore": [
-        "src/**/*.stories.js",
-        "src/**/*.test.js"
+      "ignore": ["src/**/*.stories.js", "src/**/*.test.js"],
+      "plugins": [
+        [
+          "babel-plugin-styled-components",
+          {
+            "displayName": true
+          }
+        ]
       ]
     },
     "commonjs": {
-      "ignore": [
-        "src/**/*.stories.js",
-        "src/**/*.test.js"
-      ],
+      "ignore": ["src/**/*.stories.js", "src/**/*.test.js"],
       "plugins": [
-        "@babel/plugin-transform-modules-commonjs"
+        "@babel/plugin-transform-modules-commonjs",
+        [
+          "babel-plugin-styled-components",
+          {
+            "displayName": true
+          }
+        ]
       ]
     },
     "test": {
       "plugins": [
-        "@babel/plugin-transform-modules-commonjs"
+        "@babel/plugin-transform-modules-commonjs",
+        [
+          "babel-plugin-styled-components",
+          {
+            "displayName": true
+          }
+        ]
       ]
     }
   }

--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -1,7 +1,7 @@
 {
   "presets": [
     ["@babel/preset-env", { "modules": false, "useBuiltIns": "usage", "corejs": 3 }],
-    "@babel/react",
+    "@babel/react"
   ],
-  "plugins": ["@babel/plugin-proposal-class-properties"]
+  "plugins": ["@babel/plugin-proposal-class-properties", "babel-plugin-styled-components"]
 }

--- a/src/Button/__tests__/Button.test.js
+++ b/src/Button/__tests__/Button.test.js
@@ -23,7 +23,7 @@ describe('<Button />', () => {
 
     expect(buttonNode).toHaveStyleRule(
       'background',
-      'hsl(200,74%,46%) linear-gradient( 0deg, hsla(0,100%,100%,0) 0%, hsla(0,100%,100%,0.1) 100% )',
+      'hsl(200,74%,46%) linear-gradient( 0deg,hsla(0,100%,100%,0) 0%,hsla(0,100%,100%,0.1) 100% )',
     );
     expect(buttonNode).toHaveStyleRule('border', `1px solid ${Theme.palette.primary.dark}`);
     expect(buttonNode).toHaveStyleRule('box-shadow', 'inset 0 0.2rem 0 0 hsla(0,100%,100%,0.1)');

--- a/src/Button/__tests__/__snapshots__/helpers.test.js.snap
+++ b/src/Button/__tests__/__snapshots__/helpers.test.js.snap
@@ -4,174 +4,110 @@ exports[`<Button /> -- helpers getAppearance should return danger css appearance
 
 exports[`<Button /> -- helpers getAppearance should return default css appearance 1`] = `
 Array [
-  "
-      color: ",
+  "color:",
   "hsl(213,17%,20%)",
-  ";
-      background: none;
-    ",
+  ";background:none;",
 ]
 `;
 
 exports[`<Button /> -- helpers getAppearance should return google css appearance 1`] = `
 Array [
-  "
-      background: ",
+  "background:",
   "hsl(5,81%,56%)",
-  ";
-      border: 0.1rem solid ",
+  ";border:0.1rem solid ",
   "hsl(5,81%,56%)",
-  ";
-      box-shadow: inset 0 0.2rem 0 0 ",
+  ";box-shadow:inset 0 0.2rem 0 0 ",
   "hsla(0, 100%, 100%, 0.1)",
-  ";
-
-      /* Hovered  */
-      &:hover:not([disabled]):not(:active) {
-        background: ",
+  ";&:hover:not([disabled]):not(:active){background:",
   "#d52616",
-  ";
-      }
-    ",
+  ";}",
 ]
 `;
 
 exports[`<Button /> -- helpers getAppearance should return primary css appearance 1`] = `
 Array [
-  "
-      background: ",
+  "background:",
   "hsl(200,74%,46%)",
-  "
-        linear-gradient(
-          0deg,
-          ",
+  " linear-gradient( 0deg,",
   [Function],
-  " 0%,
-          ",
+  " 0%,",
   [Function],
-  " 100%
-        );
-      border: 1px solid ",
+  " 100% );border:1px solid ",
   "#1873a0",
-  ";
-      box-shadow: inset 0 0.2rem 0 0 ",
+  ";box-shadow:inset 0 0.2rem 0 0 ",
   "hsla(0, 100%, 100%, 0.1)",
-  ";
-
-      /* Hovered  */
-      &:hover:not([disabled]):not(:active) {
-        background: ",
+  ";&:hover:not([disabled]):not(:active){background:",
   "hsl(200,74%,46%)",
-  ";
-        box-shadow: none;
-      }
-
-      /* Activated  */
-      &:active {
-        background-color: ",
+  ";box-shadow:none;}&:active{background-color:",
   "#1873a0",
-  ";
-        border: 1px solid ",
+  ";border:1px solid ",
   "#14638a",
-  ";
-        box-shadow: inset 0 0 0 0.1rem ",
+  ";box-shadow:inset 0 0 0 0.1rem ",
   "#14638a",
-  ";
-      }
-    ",
+  ";}",
 ]
 `;
 
 exports[`<Button /> -- helpers getAppearance should return secondary css appearance 1`] = `
 Array [
-  "
-      color: ",
+  "color:",
   "hsl(207,13%,45%)",
-  ";
-      background: linear-gradient(180deg, ",
+  ";background:linear-gradient(180deg,",
   "hsl(0,100%,100%)",
-  " 0%, ",
+  " 0%,",
   "hsl(240,33%,99%)",
-  " 100%);
-      border: 1px solid ",
+  " 100%);border:1px solid ",
   "hsl(207,22%,90%)",
-  ";
-    ",
+  ";",
 ]
 `;
 
 exports[`<Button /> -- helpers getAppearance should return success css appearance 1`] = `
 Array [
-  "
-      background: ",
+  "background:",
   "hsl(89,53%,52%)",
-  "
-        linear-gradient(0deg, ",
+  " linear-gradient(0deg,",
   "hsla(0, 100%, 100%, 0)",
-  " 0%, ",
+  " 0%,",
   "hsla(0, 100%, 100%, 0.1)",
-  " 100%);
-      border: 1px solid ",
+  " 100%);border:1px solid ",
   "#6da333",
-  ";
-      box-shadow: inset 0 0.2rem 0 0 ",
+  ";box-shadow:inset 0 0.2rem 0 0 ",
   "hsla(0, 100%, 100%, 0.1)",
-  ";
-
-      /* Hovered  */
-      &:hover:not([disabled]):not(:active) {
-        background: ",
+  ";&:hover:not([disabled]):not(:active){background:",
   "hsl(89,53%,52%)",
-  ";
-        box-shadow: none;
-      }
-
-      /* Activated  */
-      &:active {
-        background-color: ",
+  ";box-shadow:none;}&:active{background-color:",
   "#6da333",
-  ";
-        border: 1px solid ",
+  ";border:1px solid ",
   "#60902d",
-  ";
-        box-shadow: inset 0 0 0 0.1rem ",
+  ";box-shadow:inset 0 0 0 0.1rem ",
   "#60902d",
-  ";
-      }
-    ",
+  ";}",
 ]
 `;
 
 exports[`<Button /> -- helpers getSize should return default css size 1`] = `
 Array [
-  "
-      padding: ",
+  "padding:",
   "0.75rem 1.6rem",
-  ";
-    ",
+  ";",
 ]
 `;
 
 exports[`<Button /> -- helpers getSize should return large css size 1`] = `
 Array [
-  "
-      padding: ",
+  "padding:",
   "0.7rem 2rem",
-  ";
-      font-size: ",
+  ";font-size:",
   "1.6rem",
-  ";
-      line-height: 1.5;
-    ",
+  ";line-height:1.5;",
 ]
 `;
 
 exports[`<Button /> -- helpers getSize should return small css size 1`] = `
 Array [
-  "
-      padding: ",
+  "padding:",
   "0.35rem 1.4rem",
-  ";
-    ",
+  ";",
 ]
 `;

--- a/src/DatePicker/Header/__tests__/__snapshots__/Header.test.js.snap
+++ b/src/DatePicker/Header/__tests__/__snapshots__/Header.test.js.snap
@@ -57,6 +57,12 @@ exports[`Header should render without a problem 1`] = `
 
 .c1 {
   padding: 0;
+  padding: 0;
+}
+
+.c5 {
+  padding: 0;
+  padding: 0;
 }
 
 .c0 {
@@ -116,7 +122,7 @@ exports[`Header should render without a problem 1`] = `
     class="c4"
   />
   <button
-    class="c1 c2"
+    class="c5 c2"
     data-testid="next-month-button"
     type="button"
   >

--- a/src/DatePicker/__tests__/__snapshots__/DatePicker.test.js.snap
+++ b/src/DatePicker/__tests__/__snapshots__/DatePicker.test.js.snap
@@ -1,15 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<DatePicker /> Range should render without a problem 1`] = `
-.c10 {
+.c11 {
   margin-top: 0.8rem;
   font-size: 1.4rem;
   color: hsl(213,17%,20%);
   cursor: pointer;
 }
 
-.c10:not(:nth-child(7n)) {
+.c11:not(:nth-child(7n)) {
   padding-right: 0.8rem;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-basis: 2.8rem;
+  -ms-flex-preferred-size: 2.8rem;
+  flex-basis: 2.8rem;
+  width: 2.8rem;
+  height: 2.8rem;
+  max-width: 2.8rem;
+  border-radius: 50%;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c13:hover {
+  background: rgba(30,146,204,0.14);
 }
 
 .c12 {
@@ -36,40 +66,10 @@ exports[`<DatePicker /> Range should render without a problem 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-}
-
-.c12:hover {
-  background: rgba(30,146,204,0.14);
-}
-
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-flex-basis: 2.8rem;
-  -ms-flex-preferred-size: 2.8rem;
-  flex-basis: 2.8rem;
-  width: 2.8rem;
-  height: 2.8rem;
-  max-width: 2.8rem;
-  border-radius: 50%;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   color: hsl(206,23%,69%);
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -97,7 +97,7 @@ exports[`<DatePicker /> Range should render without a problem 1`] = `
   background: hsl(200,74%,46%);
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -107,7 +107,7 @@ exports[`<DatePicker /> Range should render without a problem 1`] = `
   flex-wrap: wrap;
 }
 
-.c8 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -130,11 +130,11 @@ exports[`<DatePicker /> Range should render without a problem 1`] = `
   color: hsl(207,13%,45%);
 }
 
-.c8:not(:nth-child(7n)) {
+.c9:not(:nth-child(7n)) {
   margin-right: 0.8rem;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -200,6 +200,12 @@ exports[`<DatePicker /> Range should render without a problem 1`] = `
 }
 
 .c3 {
+  padding: 0;
+  padding: 0;
+}
+
+.c7 {
+  padding: 0;
   padding: 0;
 }
 
@@ -281,7 +287,7 @@ exports[`<DatePicker /> Range should render without a problem 1`] = `
         July 2018
       </div>
       <button
-        class="c3 c4"
+        class="c7 c4"
         data-testid="next-month-button"
         type="button"
       >
@@ -310,421 +316,421 @@ exports[`<DatePicker /> Range should render without a problem 1`] = `
       </button>
     </div>
     <div
-      class="c7"
+      class="c8"
     >
       <div
-        class="c8"
+        class="c9"
       >
         Mon
       </div>
       <div
-        class="c8"
+        class="c9"
       >
         Tue
       </div>
       <div
-        class="c8"
+        class="c9"
       >
         Wed
       </div>
       <div
-        class="c8"
+        class="c9"
       >
         Thu
       </div>
       <div
-        class="c8"
+        class="c9"
       >
         Fri
       </div>
       <div
-        class="c8"
+        class="c9"
       >
         Sat
       </div>
       <div
-        class="c8"
+        class="c9"
       >
         Sun
       </div>
     </div>
     <div
-      class="c9"
+      class="c10"
     >
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           25
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           26
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           27
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           28
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           29
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           30
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           1
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           2
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           3
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           4
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           5
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           6
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           7
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           8
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           9
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           10
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           11
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           12
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           13
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           14
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c13"
+          class="c14"
         >
           15
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           16
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           17
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           18
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           19
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           20
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           21
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           22
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           23
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           24
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           25
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           26
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           27
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           28
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           29
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           30
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           31
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           1
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           2
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           3
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           4
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           5
         </div>
@@ -735,15 +741,45 @@ exports[`<DatePicker /> Range should render without a problem 1`] = `
 `;
 
 exports[`<DatePicker /> Simple should render without a problem 1`] = `
-.c10 {
+.c11 {
   margin-top: 0.8rem;
   font-size: 1.4rem;
   color: hsl(213,17%,20%);
   cursor: pointer;
 }
 
-.c10:not(:nth-child(7n)) {
+.c11:not(:nth-child(7n)) {
   padding-right: 0.8rem;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-basis: 2.8rem;
+  -ms-flex-preferred-size: 2.8rem;
+  flex-basis: 2.8rem;
+  width: 2.8rem;
+  height: 2.8rem;
+  max-width: 2.8rem;
+  border-radius: 50%;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c13:hover {
+  background: rgba(30,146,204,0.14);
 }
 
 .c12 {
@@ -770,40 +806,10 @@ exports[`<DatePicker /> Simple should render without a problem 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-}
-
-.c12:hover {
-  background: rgba(30,146,204,0.14);
-}
-
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-flex-basis: 2.8rem;
-  -ms-flex-preferred-size: 2.8rem;
-  flex-basis: 2.8rem;
-  width: 2.8rem;
-  height: 2.8rem;
-  max-width: 2.8rem;
-  border-radius: 50%;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   color: hsl(206,23%,69%);
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -831,7 +837,7 @@ exports[`<DatePicker /> Simple should render without a problem 1`] = `
   background: hsl(200,74%,46%);
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -841,7 +847,7 @@ exports[`<DatePicker /> Simple should render without a problem 1`] = `
   flex-wrap: wrap;
 }
 
-.c8 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -864,11 +870,11 @@ exports[`<DatePicker /> Simple should render without a problem 1`] = `
   color: hsl(207,13%,45%);
 }
 
-.c8:not(:nth-child(7n)) {
+.c9:not(:nth-child(7n)) {
   margin-right: 0.8rem;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -934,6 +940,12 @@ exports[`<DatePicker /> Simple should render without a problem 1`] = `
 }
 
 .c3 {
+  padding: 0;
+  padding: 0;
+}
+
+.c7 {
+  padding: 0;
   padding: 0;
 }
 
@@ -1015,7 +1027,7 @@ exports[`<DatePicker /> Simple should render without a problem 1`] = `
         July 2018
       </div>
       <button
-        class="c3 c4"
+        class="c7 c4"
         data-testid="next-month-button"
         type="button"
       >
@@ -1044,421 +1056,421 @@ exports[`<DatePicker /> Simple should render without a problem 1`] = `
       </button>
     </div>
     <div
-      class="c7"
+      class="c8"
     >
       <div
-        class="c8"
+        class="c9"
       >
         Mon
       </div>
       <div
-        class="c8"
+        class="c9"
       >
         Tue
       </div>
       <div
-        class="c8"
+        class="c9"
       >
         Wed
       </div>
       <div
-        class="c8"
+        class="c9"
       >
         Thu
       </div>
       <div
-        class="c8"
+        class="c9"
       >
         Fri
       </div>
       <div
-        class="c8"
+        class="c9"
       >
         Sat
       </div>
       <div
-        class="c8"
+        class="c9"
       >
         Sun
       </div>
     </div>
     <div
-      class="c9"
+      class="c10"
     >
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           25
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           26
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           27
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           28
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           29
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           30
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           1
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           2
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           3
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           4
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           5
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           6
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           7
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           8
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           9
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           10
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           11
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           12
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           13
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           14
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c13"
+          class="c14"
         >
           15
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           16
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           17
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           18
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           19
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           20
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           21
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           22
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           23
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           24
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           25
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           26
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           27
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           28
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           29
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           30
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c12"
+          class="c13"
         >
           31
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           1
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           2
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           3
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           4
         </div>
       </div>
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           5
         </div>

--- a/src/Dropdown/README.md
+++ b/src/Dropdown/README.md
@@ -12,6 +12,7 @@ import { Dropdown } from '@tillersystems/stardust';
 
 - `children` - Anything that can be rendered: numbers, strings, elements or an array (or fragment).
 - `className` - Add a text aside in the select next the selected value.
+- `itemCss` - Css provided to each item of the dropdown. Must use `css` method from styled-components.
 - `noResultLabel` - Label to display when no result found.
 - `onToggle` - Callback called when Dropdown is toggled.
 - `searchable` - A Dropdown may be searchable.
@@ -22,6 +23,7 @@ import { Dropdown } from '@tillersystems/stardust';
 | --------------------- | :--------: | :----------: | :--------: |
 | `children`            |   `node`   |              |     \*     |
 | `className`           |  `string`  |    `null`    |     -      |
+| `itemCss`             |  `array`   |    `null`    |     -      |
 | `noResultLabel`       |   `node`   |    `null`    |     -      |
 | `onToggle`            | `function` |  `() => {}`  |     -      |
 | `searchable`          |   `bool`   |   `false`    |     -      |
@@ -35,7 +37,7 @@ import { Dropdown } from '@tillersystems/stardust';
 
 render() {
   return (
-    <Dropdown title="Filter by">
+    <Dropdown title="Filter by" itemCss={css`padding: 0.9rem 1.2rem;`}>
       <CheckBox
         checked={state.color}
         id="color"

--- a/src/Dropdown/__stories__/Dropdown.stories.js
+++ b/src/Dropdown/__stories__/Dropdown.stories.js
@@ -3,12 +3,30 @@ import { storiesOf } from '@storybook/react';
 import { withKnobs, boolean, text } from '@storybook/addon-knobs/react';
 import { State, Store } from '@sambego/storybook-state';
 import { action } from '@storybook/addon-actions';
+import { css } from 'styled-components';
 
 import { Dropdown, CheckBox } from '../..';
 import DropdownReadme from '../README.md';
 
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
+
+const itemCss = css`
+  padding: 0.9rem 1.2rem;
+  &:first-child {
+    padding-top: 1.8rem;
+  }
+  ${({ searchable }) =>
+    searchable &&
+    css`
+      &:nth-child(2) {
+        padding-top: 1.8rem;
+      }
+    `}
+  &:last-child {
+    padding-bottom: 1.8rem;
+  }
+`;
 
 const store = new Store({
   streetBangkokBastille: false,
@@ -45,6 +63,7 @@ storiesOf('Dropdown', module)
               searchable={Searchable}
               noResultLabel={NoresultLabel}
               searchBarPlacholder={SearchBarPlacholder}
+              itemCss={itemCss}
             >
               <CheckBox
                 defaultChecked={state.streetBangkokBastille}

--- a/src/Dropdown/__tests__/Dropdown.test.js
+++ b/src/Dropdown/__tests__/Dropdown.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
+import { css } from 'styled-components';
 
 import Dropdown from '..';
 
@@ -174,5 +175,33 @@ describe('<Dropdown />', () => {
     expect(ItemNode[0]).toBeUndefined();
     expect(ItemNode[1]).toBeUndefined();
     expect(ItemNode[2]).toBeUndefined();
+  });
+
+  test('should have expected custom style on each item', () => {
+    const props = {
+      title: 'title',
+      itemCss: css`
+        padding: 0.9rem 1.2rem;
+        &:first-child {
+          padding-top: 1.8rem;
+        }
+        &:last-child {
+          padding-bottom: 1.8rem;
+        }
+      `,
+    };
+    const { getAllByRole, getByText } = render(
+      <Dropdown {...props}>
+        <div>Item1</div>
+        <div>Item2</div>
+        <div>Item3</div>
+      </Dropdown>,
+    );
+    const button = getByText(props.title);
+    fireEvent.click(button);
+
+    const [itemNode] = getAllByRole('menuitem');
+
+    expect(itemNode).toHaveStyleRule('padding', '0.9rem 1.2rem');
   });
 });

--- a/src/Dropdown/__tests__/__snapshots__/Dropdown.test.js.snap
+++ b/src/Dropdown/__tests__/__snapshots__/Dropdown.test.js.snap
@@ -14,7 +14,7 @@ exports[`<Dropdown /> should render without a problem 1`] = `
   font-size: 1.4rem;
   border: 1px solid hsl(207,22%,90%);
   border-radius: 0.4rem;
-  background: linear-gradient( 180deg, hsl(0,100%,100%) 0%, hsl(240,33%,99%) 100% );
+  background: linear-gradient( 180deg,hsl(0,100%,100%) 0%,hsl(240,33%,99%) 100% );
   color: hsl(207,13%,45%);
 }
 

--- a/src/Dropdown/elements.js
+++ b/src/Dropdown/elements.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
 export const Header = styled.button`
   display: flex;
@@ -82,25 +82,6 @@ export const Menu = styled.ul`
 export const MenuItem = styled.li`
   display: flex;
   align-items: center;
-
-  padding: 0.9rem 1.2rem;
-
-  &:first-child {
-    padding-top: 1.8rem;
-  }
-
-  ${({ searchable }) =>
-    searchable &&
-    css`
-      &:nth-child(2) {
-        padding-top: 1.8rem;
-      }
-    `}
-
-  &:last-child {
-    padding-bottom: 1.8rem;
-  }
-
   cursor: pointer;
 `;
 

--- a/src/Dropdown/index.js
+++ b/src/Dropdown/index.js
@@ -8,7 +8,7 @@ import onClickOutside from 'react-onclickoutside';
 import SearchBar from './SearchBar';
 import { Header, Menu, MenuItem, SearchInputContainer } from './elements';
 
-const { bool, func, node, string } = PropTypes;
+const { array, bool, func, node, string } = PropTypes;
 
 /**
  * Dropdown
@@ -32,6 +32,7 @@ class Dropdown extends PureComponent {
   static propTypes = {
     children: node.isRequired,
     className: string,
+    itemCss: array,
     noResultLabel: string,
     onToggle: func,
     searchable: bool,
@@ -42,6 +43,7 @@ class Dropdown extends PureComponent {
   /** Default props. */
   static defaultProps = {
     className: '',
+    itemCss: null,
     noResultLabel: null,
     onToggle: () => {},
     searchable: false,
@@ -51,12 +53,12 @@ class Dropdown extends PureComponent {
   /** Internal state. */
   state = {
     displayMenu: false,
-    searchKeyword: '',
     menuPosition: {
       width: 100,
       top: 0,
       left: 0,
     },
+    searchKeyword: '',
   };
 
   /** Create a ref for the dropdown header. */
@@ -151,10 +153,11 @@ class Dropdown extends PureComponent {
     const {
       children,
       className,
+      itemCss,
       noResultLabel,
-      title,
       searchable,
       searchBarPlaceholder,
+      title,
     } = this.props;
     const { displayMenu, searchKeyword, menuPosition } = this.state;
 
@@ -200,15 +203,14 @@ class Dropdown extends PureComponent {
                 {searchable &&
                   (FilteredItems.length !== 0
                     ? FilteredItems.map(child => (
-                        <MenuItem key={child.key} searchable={searchable} role="menuitem">
+                        <MenuItem key={child.key} role="menuitem" css={itemCss}>
                           {child}
                         </MenuItem>
                       ))
                     : noResultLabel && <MenuItem role="menuitem">{noResultLabel}</MenuItem>)}
-
                 {!searchable &&
                   Children.map(children, child => (
-                    <MenuItem key={child} role="menuitem">
+                    <MenuItem key={child} role="menuitem" css={itemCss}>
                       {child}
                     </MenuItem>
                   ))}

--- a/src/Dropdown/index.js
+++ b/src/Dropdown/index.js
@@ -18,6 +18,7 @@ const { array, bool, func, node, string } = PropTypes;
  *
  * @param {node} children // Anything that can be rendered: numbers, strings, elements or an array (or fragment).
  * @param {string} className // Add a text aside in the select next the selected value.
+ * @param {array} itemCss // css provided to each item of the dropdown. Must use `css` method from styled-components.
  * @param {node} noResultLabel // Label to display when no result found.
  * @param {function} onToggle // Callback called when Dropdown is toggled.
  * @param {bool} searchable // Whether the dropdown is searchable.

--- a/src/Form/__tests__/__snapshots__/Form.test.js.snap
+++ b/src/Form/__tests__/__snapshots__/Form.test.js.snap
@@ -220,40 +220,40 @@ exports[`<Form /> should render form with highlighted label when has focus 1`] =
 
 exports[`<Form /> should render form with highlighted label when has focus 2`] = `
 <form
-  class="sc-bdVaJa fMLCLO"
+  class="elements__Container-sc-19h58b9-0 bNVsOg"
   name="form"
 >
   <div
-    class="sc-bZQynM uJaUG"
+    class="elements__Container-eszpcu-0 fBQVkp"
     data-testid="form-group"
   >
     <div
-      class="sc-bwzfXH btkNfP"
+      class="elements__Wrapper-cp6xjm-0 eQvbgo"
       data-testid="form-field"
       size="1"
     >
       <div
-        class="sc-htpNat bnmNtp"
+        class="elements__Container-cp6xjm-1 bmrPGn"
       >
         <label
-          class="sc-bxivhb bEmEGS"
+          class="elements__Label-cp6xjm-2 cvJBua"
           width="10rem"
         >
           my label 1
         </label>
         <div
-          class="sc-ifAKCX futPH"
+          class="elements__ElementContainer-cp6xjm-3 iWMhRT"
         >
           <div
-            class="sc-EHOje dYYwli"
+            class="elements__ElementWrapper-cp6xjm-4 ShWHh"
           >
             <div
-              class="sc-cvbbAY jIVDhY"
+              class="elements__Container-x1mgn-0 dZCkhA"
               data-testid="input-container"
               width="25rem"
             >
               <input
-                class="sc-jWBwVP jEwqHC"
+                class="elements__InputElement-x1mgn-1 kDpBgJ"
                 data-testid="input"
                 id=""
                 placeholder="tape inside me"

--- a/src/RadioButton/__tests__/__snapshots__/RadioButton.test.js.snap
+++ b/src/RadioButton/__tests__/__snapshots__/RadioButton.test.js.snap
@@ -31,8 +31,8 @@ exports[`<RadioButton /> should render without a problem 1`] = `
   height: 1.6rem;
   border: 1px solid hsl(207,22%,90%);
   border-radius: 50%;
-  background: linear-gradient( 0deg, hsl(240,33%,99%) 0%, hsl(0,100%,100%) 100% );
-  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05), 0 1px 1px 0 hsl(240,33%,99%);
+  background: linear-gradient( 0deg,hsl(240,33%,99%) 0%,hsl(0,100%,100%) 100% );
+  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05),0 1px 1px 0 hsl(240,33%,99%);
   -webkit-transition: background-color ease 0.25s;
   transition: background-color ease 0.25s;
 }
@@ -100,8 +100,8 @@ exports[`<RadioButton /> should render without a problem when radio is not selec
   height: 1.6rem;
   border: 1px solid hsl(207,22%,90%);
   border-radius: 50%;
-  background: linear-gradient( 0deg, hsl(240,33%,99%) 0%, hsl(0,100%,100%) 100% );
-  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05), 0 1px 1px 0 hsl(240,33%,99%);
+  background: linear-gradient( 0deg,hsl(240,33%,99%) 0%,hsl(0,100%,100%) 100% );
+  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05),0 1px 1px 0 hsl(240,33%,99%);
   -webkit-transition: background-color ease 0.25s;
   transition: background-color ease 0.25s;
   opacity: 0.4;
@@ -173,8 +173,8 @@ exports[`<RadioButton /> should render without a problem when radio is not selec
   height: 1.6rem;
   border: 1px solid hsl(207,22%,90%);
   border-radius: 50%;
-  background: linear-gradient( 0deg, hsl(240,33%,99%) 0%, hsl(0,100%,100%) 100% );
-  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05), 0 1px 1px 0 hsl(240,33%,99%);
+  background: linear-gradient( 0deg,hsl(240,33%,99%) 0%,hsl(0,100%,100%) 100% );
+  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05),0 1px 1px 0 hsl(240,33%,99%);
   -webkit-transition: background-color ease 0.25s;
   transition: background-color ease 0.25s;
 }
@@ -240,13 +240,13 @@ exports[`<RadioButton /> should render without a problem when radio is selected 
   height: 1.6rem;
   border: 1px solid hsl(207,22%,90%);
   border-radius: 50%;
-  background: linear-gradient( 0deg, hsl(240,33%,99%) 0%, hsl(0,100%,100%) 100% );
-  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05), 0 1px 1px 0 hsl(240,33%,99%);
+  background: linear-gradient( 0deg,hsl(240,33%,99%) 0%,hsl(0,100%,100%) 100% );
+  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05),0 1px 1px 0 hsl(240,33%,99%);
   -webkit-transition: background-color ease 0.25s;
   transition: background-color ease 0.25s;
   opacity: 0.4;
   border: 1px solid #1873a0;
-  background: hsl(200,74%,46%) linear-gradient( 0deg, hsla(0,100%,100%,0) 0%, hsla(0,100%,100%,0.1) 100% );
+  background: hsl(200,74%,46%) linear-gradient( 0deg,hsla(0,100%,100%,0) 0%,hsla(0,100%,100%,0.1) 100% );
   box-shadow: inset 0 0.2rem 0 0 hsla(0,100%,100%,0.1);
   -webkit-transition: border ease 0.25s;
   transition: border ease 0.25s;
@@ -335,12 +335,12 @@ exports[`<RadioButton /> should render without a problem when radio is selected 
   height: 1.6rem;
   border: 1px solid hsl(207,22%,90%);
   border-radius: 50%;
-  background: linear-gradient( 0deg, hsl(240,33%,99%) 0%, hsl(0,100%,100%) 100% );
-  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05), 0 1px 1px 0 hsl(240,33%,99%);
+  background: linear-gradient( 0deg,hsl(240,33%,99%) 0%,hsl(0,100%,100%) 100% );
+  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05),0 1px 1px 0 hsl(240,33%,99%);
   -webkit-transition: background-color ease 0.25s;
   transition: background-color ease 0.25s;
   border: 1px solid #1873a0;
-  background: hsl(200,74%,46%) linear-gradient( 0deg, hsla(0,100%,100%,0) 0%, hsla(0,100%,100%,0.1) 100% );
+  background: hsl(200,74%,46%) linear-gradient( 0deg,hsla(0,100%,100%,0) 0%,hsla(0,100%,100%,0.1) 100% );
   box-shadow: inset 0 0.2rem 0 0 hsla(0,100%,100%,0.1);
   -webkit-transition: border ease 0.25s;
   transition: border ease 0.25s;

--- a/src/RadioGroup/__tests__/__snapshots__/RadioGroup.test.js.snap
+++ b/src/RadioGroup/__tests__/__snapshots__/RadioGroup.test.js.snap
@@ -49,8 +49,8 @@ exports[`<RadioGroup /> should render as row 1`] = `
   height: 1.6rem;
   border: 1px solid hsl(207,22%,90%);
   border-radius: 50%;
-  background: linear-gradient( 0deg, hsl(240,33%,99%) 0%, hsl(0,100%,100%) 100% );
-  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05), 0 1px 1px 0 hsl(240,33%,99%);
+  background: linear-gradient( 0deg,hsl(240,33%,99%) 0%,hsl(0,100%,100%) 100% );
+  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05),0 1px 1px 0 hsl(240,33%,99%);
   -webkit-transition: background-color ease 0.25s;
   transition: background-color ease 0.25s;
 }
@@ -175,8 +175,8 @@ exports[`<RadioGroup /> should render without a problem 1`] = `
   height: 1.6rem;
   border: 1px solid hsl(207,22%,90%);
   border-radius: 50%;
-  background: linear-gradient( 0deg, hsl(240,33%,99%) 0%, hsl(0,100%,100%) 100% );
-  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05), 0 1px 1px 0 hsl(240,33%,99%);
+  background: linear-gradient( 0deg,hsl(240,33%,99%) 0%,hsl(0,100%,100%) 100% );
+  box-shadow: inset 0 2px 0 0 hsla(0,100%,100%,0.05),0 1px 1px 0 hsl(240,33%,99%);
   -webkit-transition: background-color ease 0.25s;
   transition: background-color ease 0.25s;
 }

--- a/src/Select/__tests__/__snapshots__/Select.test.js.snap
+++ b/src/Select/__tests__/__snapshots__/Select.test.js.snap
@@ -14,7 +14,7 @@ exports[`<Select /> should render without a problem 1`] = `
   font-size: 1.4rem;
   border: 1px solid hsl(207,22%,90%);
   border-radius: 0.4rem;
-  background: linear-gradient( 180deg, hsl(0,100%,100%) 0%, hsl(240,33%,99%) 100% );
+  background: linear-gradient( 180deg,hsl(0,100%,100%) 0%,hsl(240,33%,99%) 100% );
   color: hsl(213,17%,20%);
 }
 
@@ -81,7 +81,7 @@ exports[`<Select /> should render without a problem when disabled 1`] = `
   font-size: 1.4rem;
   border: 1px solid hsl(207,22%,90%);
   border-radius: 0.4rem;
-  background: linear-gradient( 180deg, hsl(0,100%,100%) 0%, hsl(240,33%,99%) 100% );
+  background: linear-gradient( 180deg,hsl(0,100%,100%) 0%,hsl(240,33%,99%) 100% );
   color: hsl(213,17%,20%);
 }
 


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description
When using something else than checkboxes on my dropdown, the padding used inside the component was not right for my use, so the simplest way (may be cumbersome I know) was to let the user implement their own style as a prop `itemCss` to avoid that.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
