### PR TITLE
refactor(Select): put select in a portal and close select on outside click

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@tippy.js/react": "2.2.2",
+    "exenv": "1.2.2",
     "initials": "3.0.1",
     "luxon": "1.17.1",
     "polished": "3.4.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "luxon": "1.17.1",
     "polished": "3.4.1",
     "react-onclickoutside": "6.8.0",
+    "react-popper": "1.3.3",
     "react-portal": "4.2.0",
     "styled-components-breakpoint": "2.1.1"
   },

--- a/src/EventListener/__tests__/EventListener.test.js
+++ b/src/EventListener/__tests__/EventListener.test.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { cleanup, fireEvent } from '@testing-library/react';
+
+import EventListener from '..';
+
+describe('<EventListener />', () => {
+  afterEach(cleanup);
+
+  test('should add event listener on specified elements', () => {
+    const wrapper = document.createElement('div');
+    const text = document.createTextNode('I am a text node');
+    wrapper.appendChild(text);
+    document.body.appendChild(wrapper);
+
+    const handleDocumentClick = jest.fn();
+
+    const listeners = [
+      {
+        target: 'document',
+        event: 'click',
+        handler: handleDocumentClick,
+      },
+    ];
+    const { getByText } = render(<EventListener listeners={listeners} />);
+
+    const textNode = getByText(/text node/);
+
+    fireEvent.click(textNode);
+    expect(handleDocumentClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/EventListener/index.js
+++ b/src/EventListener/index.js
@@ -1,0 +1,64 @@
+import { canUseDOM, canUseEventListeners } from 'exenv';
+
+import { useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Components can delegates to EventListener the listening of specific elements
+ * and trigger callback if the specified events have been triggered to these elements
+ * Comes handy to handle outside clicks for example.
+ *
+ * @param {Array} listeners - array of object { target: string, event: string, handler: fn, options: boolean }
+ * e.g. { target: 'document', event: 'click', handler: () => { ... },  options: true }
+ *
+ * @return null
+ */
+const EventListener = ({ listeners }) => {
+  /**
+   * useEffect
+   * Removes and adds event listeners on listeners value change
+   *
+   */
+  useEffect(() => {
+    removeEventListeners(listeners);
+    addEventListeners(listeners);
+  }, [listeners]);
+
+  const getTargetNode = target => {
+    if (canUseDOM) {
+      return global[target] || global.document.querySelector(target);
+    }
+  };
+
+  const addEventListeners = (listeners = listeners) => {
+    if (canUseEventListeners) {
+      listeners.forEach(({ target, event, handler, options }) => {
+        const node = getTargetNode(target);
+        node && node.addEventListener(event, handler, options);
+      });
+    }
+  };
+
+  const removeEventListeners = (listeners = listeners) => {
+    if (canUseEventListeners) {
+      listeners.forEach(({ target, event, handler, options }) => {
+        const node = getTargetNode(target);
+        node && node.removeEventListener(event, handler, options);
+      });
+    }
+  };
+
+  return null;
+};
+
+/**
+ * PropTypes Validation.
+ */
+const { array } = PropTypes;
+EventListener.propTypes = {
+  listeners: array.isRequired,
+};
+
+EventListener.displayName = 'EventListener';
+
+export default EventListener;

--- a/src/Popover/__stories__/Popover.stories.js
+++ b/src/Popover/__stories__/Popover.stories.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { State, Store } from '@sambego/storybook-state';
-import { withKnobs, boolean, number } from '@storybook/addon-knobs';
+import { withKnobs, boolean, number, select } from '@storybook/addon-knobs';
 
 import { Button, Popover } from '../..';
 import PopoverReadme from '../README.md';
 
 const store = new Store({
-  active: false,
+  isOpen: false,
 });
 
 storiesOf('Popover', module)
@@ -19,6 +19,20 @@ storiesOf('Popover', module)
     },
   })
   .add('default', () => {
+    const hasArrowValue = boolean('hasArrow', false, 'State');
+    const placement = select(
+      'Placement',
+      {
+        bottom: 'bottom',
+        top: 'top',
+        right: 'right',
+        left: 'left',
+      },
+      'bottom',
+      'State',
+    );
+    const isOverflowingContainer = boolean('isOverflowingContainer', false, 'State');
+
     const widthValue = number(
       'Width',
       28,
@@ -31,40 +45,39 @@ storiesOf('Popover', module)
       'Dimensions',
     );
 
-    const arrowPositionXValue = number(
-      'arrowPositionX',
-      50,
-      {
-        range: true,
-        min: 5,
-        max: 90,
-        step: 1,
-      },
-      'Dimensions',
-    );
-
     return (
       <div style={{ position: 'relative' }}>
-        <Button appearance="primary" onClick={() => store.set({ active: !store.get('active') })}>
-          Show Popover
-        </Button>
-        <div style={{ position: 'absolute', top: '100%', left: '-78px' }}>
-          <State store={store}>
-            <Popover
-              width={`${widthValue}rem`}
-              arrowPositionX={`${(widthValue * arrowPositionXValue) / 100}rem`}
-              active={store.get('active')}
+        <State store={store}>
+          <Popover
+            isOpen={store.get('isOpen')}
+            content="Ventes nettes (ventes brutes moins les réductions et les annulations) plus les taxes sur
+          la période sélectionnée."
+            hasArrow={hasArrowValue}
+            modifiers={
+              isOverflowingContainer
+                ? {
+                    preventOverflow: {
+                      escapeWithReference: true,
+                    },
+                  }
+                : {}
+            }
+            placement={placement}
+            width={`${widthValue}rem`}
+          >
+            <Button
+              appearance="primary"
+              onClick={() => store.set({ isOpen: !store.get('isOpen') })}
             >
-              Ventes nettes (ventes brutes moins les réductions et les annulations) plus les taxes
-              sur la période séléctionnée.
-            </Popover>
-          </State>
-        </div>
+              Show Popover
+            </Button>
+          </Popover>
+        </State>
       </div>
     );
   })
   .add('controlled', () => {
-    const activeValue = boolean('Active', false, 'State');
+    const isOpenValue = boolean('isOpen', false, 'State');
 
     const widthValue = number(
       'Width',
@@ -81,7 +94,7 @@ storiesOf('Popover', module)
     return (
       <div>
         <span>Control modal from knobs!</span>
-        <Popover width={`${widthValue}rem`} active={activeValue}>
+        <Popover width={`${widthValue}rem`} isOpen={isOpenValue}>
           Ventes nettes (ventes brutes moins les réductions et les annulations) plus les taxes sur
           la période séléctionnée.
         </Popover>

--- a/src/Popover/__stories__/Popover.stories.js
+++ b/src/Popover/__stories__/Popover.stories.js
@@ -18,7 +18,7 @@ storiesOf('Popover', module)
       content: PopoverReadme,
     },
   })
-  .add('default', () => {
+  .add('controlled', () => {
     const hasArrowValue = boolean('hasArrow', false, 'State');
     const placement = select(
       'Placement',
@@ -63,6 +63,7 @@ storiesOf('Popover', module)
                 : {}
             }
             placement={placement}
+            onClickOutside={() => store.set({ isOpen: false })}
             width={`${widthValue}rem`}
           >
             <Button
@@ -73,31 +74,6 @@ storiesOf('Popover', module)
             </Button>
           </Popover>
         </State>
-      </div>
-    );
-  })
-  .add('controlled', () => {
-    const isOpenValue = boolean('isOpen', false, 'State');
-
-    const widthValue = number(
-      'Width',
-      60,
-      {
-        range: true,
-        min: 10,
-        max: 60,
-        step: 2,
-      },
-      'Dimensions',
-    );
-
-    return (
-      <div>
-        <span>Control modal from knobs!</span>
-        <Popover width={`${widthValue}rem`} isOpen={isOpenValue}>
-          Ventes nettes (ventes brutes moins les réductions et les annulations) plus les taxes sur
-          la période séléctionnée.
-        </Popover>
       </div>
     );
   });

--- a/src/Popover/__tests__/Popover.test.js
+++ b/src/Popover/__tests__/Popover.test.js
@@ -4,13 +4,17 @@ import Popover from '..';
 
 describe('<Popover />', () => {
   test('should render without a problem', () => {
-    const { container } = render(<Popover>Children</Popover>);
+    const { container } = render(<Popover content="content">Children</Popover>);
 
     expect(container.firstChild).toMatchSnapshot();
   });
 
   test('should render open popover without a problem', () => {
-    const { getByTestId } = render(<Popover active>Children</Popover>);
+    const { getByTestId } = render(
+      <Popover content="content" isOpen>
+        Children
+      </Popover>,
+    );
     const popoverNode = getByTestId('popover');
 
     expect(popoverNode).toBeInTheDocument();
@@ -19,7 +23,7 @@ describe('<Popover />', () => {
   test('should render with a different width', () => {
     const width = '10rem';
     const { getByTestId } = render(
-      <Popover active width={width}>
+      <Popover isOpen content="content" width={width}>
         Children
       </Popover>,
     );

--- a/src/Popover/__tests__/Popover.test.js
+++ b/src/Popover/__tests__/Popover.test.js
@@ -1,8 +1,11 @@
 import React from 'react';
+import { cleanup, fireEvent } from '@testing-library/react';
 
 import Popover from '..';
 
 describe('<Popover />', () => {
+  afterEach(cleanup);
+
   test('should render without a problem', () => {
     const { container } = render(<Popover content="content">Children</Popover>);
 
@@ -12,7 +15,7 @@ describe('<Popover />', () => {
   test('should render open popover without a problem', () => {
     const { getByTestId } = render(
       <Popover content="content" isOpen>
-        Children
+        Trigger
       </Popover>,
     );
     const popoverNode = getByTestId('popover');
@@ -24,11 +27,30 @@ describe('<Popover />', () => {
     const width = '10rem';
     const { getByTestId } = render(
       <Popover isOpen content="content" width={width}>
-        Children
+        Trigger
       </Popover>,
     );
     const popoverNode = getByTestId('popover');
 
     expect(popoverNode).toHaveStyleRule('width', width);
+  });
+
+  test('should trigger callback on click outside', () => {
+    const wrapper = document.createElement('div');
+    const externalElement = document.createTextNode('I am outside the popover');
+    wrapper.appendChild(externalElement);
+    document.body.appendChild(wrapper);
+
+    const spy = jest.fn();
+    const { getByText } = render(
+      <Popover content="content" isOpen onClickOutside={spy}>
+        Trigger
+      </Popover>,
+    );
+    const outsideNode = getByText(/outside the popover/);
+
+    fireEvent.click(outsideNode);
+
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/Popover/__tests__/__snapshots__/Popover.test.js.snap
+++ b/src/Popover/__tests__/__snapshots__/Popover.test.js.snap
@@ -1,3 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Popover /> should render without a problem 1`] = `null`;
+exports[`<Popover /> should render without a problem 1`] = `
+.c0 {
+  display: inline-block;
+}
+
+<span
+  class="c0"
+>
+  Children
+</span>
+`;

--- a/src/Popover/elements.js
+++ b/src/Popover/elements.js
@@ -1,34 +1,50 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-export const PopOver = styled.div`
-position: relative;
+export const ARROW_SIZE = '8px';
 
-width: ${({ width }) => width};
+export const PopoverContentWrapper = styled.div`
+  background: ${({ theme: { palette } }) => palette.white};
+  border-radius: ${({ theme: { dimensions } }) => dimensions.radius};
 
-padding: 1.8rem;
+  box-shadow: 0 0.2rem 1.6rem 0 hsla(0, 0%, 0%, 0.1), 0 0.2rem 1.6rem 0 hsla(206, 23%, 69%, 0.1),
+    0 0 0 0.1rem hsl(207, 22%, 90%);
+  padding: 1.8rem;
+  position: relative;
 
-border-radius: ${({ theme: { dimensions } }) => dimensions.radius};
+  width: ${({ width }) => width};
 
-box-shadow: 0 0.2rem 1.6rem 0 hsla(0, 0%, 0%, 0.1), 0 0.2rem 1.6rem 0 hsla(206, 23%, 69%, 0.1),
-  0 0 0 0.1rem hsl(207, 22%, 90%);
+  ${props =>
+    props['data-placement'] === 'top' &&
+    css`
+      margin-bottom: ${ARROW_SIZE};
+    `}
 
-background: ${({ theme: { palette } }) => palette.white};
+  ${props =>
+    props['data-placement'] === 'bottom' &&
+    css`
+      margin-top: ${ARROW_SIZE};
+    `}
 
-&::before {
-  content: "";
+  ${props =>
+    props['data-placement'] === 'left' &&
+    css`
+      margin-right: ${ARROW_SIZE};
+    `}
 
-  display:block;
+  ${props =>
+    props['data-placement'] === 'right' &&
+    css`
+      margin-left: ${ARROW_SIZE};
+    `}
 
-  position:absolute;
-  top: -0.7rem;
-  left: ${({ arrowPositionX }) => arrowPositionX};
-  z-index:-1;
+  ${props =>
+    props['data-out-of-boundaries'] &&
+    css`
+      visibility: hidden;
+    `}
+`;
 
-  height:14.14px;
-  width:14.14px;
-
-  transform: rotate(135deg);
-
-  background:white;
-  box-shadow: -1px 1px 2px 0px rgba(0,0,0,0.2);
+export const PopoverTriggerWrapper = styled.span`
+  cursor: ${({ cursor }) => cursor};
+  display: inline-block;
 `;

--- a/src/Select/__tests__/Select.test.js
+++ b/src/Select/__tests__/Select.test.js
@@ -34,6 +34,11 @@ describe('<Select />', () => {
 
   test('should toggle the Select', done => {
     const props = { placeholder: 'placeholder' };
+    let mouseDownListener;
+    document.addEventListener = jest.fn((event, listener) => {
+      if (event === 'mousedown') mouseDownListener = listener;
+    });
+
     const { queryAllByText, getByText } = render(
       <Select {...props}>
         <Select.Option value="1">Item</Select.Option>
@@ -48,8 +53,9 @@ describe('<Select />', () => {
     expect(button).toHaveAttribute('aria-expanded', 'false');
     expect(button).toHaveAttribute('aria-haspopup', 'true');
 
+    if (!mouseDownListener) throw new Error('Expected mouseDownListener not to be undefined.');
     // Open Select
-    fireEvent.click(button);
+    mouseDownListener({ preventDefault: () => {}, target: button });
 
     expect(button).toHaveAttribute('aria-expanded', 'true');
     expect(button).toHaveAttribute('aria-haspopup', 'true');
@@ -63,7 +69,7 @@ describe('<Select />', () => {
     expect(ItemNode[2]).toBeInTheDocument();
 
     // Close Select
-    fireEvent.click(button);
+    mouseDownListener({ preventDefault: () => {}, target: button });
 
     setTimeout(() => {
       ItemNode = queryAllByText(/Item/);
@@ -79,6 +85,11 @@ describe('<Select />', () => {
   test('should call onToggle when Select is toggled', () => {
     const spy = jest.fn();
     const props = { placeholder: 'placeholder', onToggle: spy };
+    let mouseDownListener;
+    document.addEventListener = jest.fn((event, listener) => {
+      if (event === 'mousedown') mouseDownListener = listener;
+    });
+
     const { getByText } = render(
       <Select {...props}>
         <Select.Option value="1">Item</Select.Option>
@@ -91,13 +102,13 @@ describe('<Select />', () => {
     const button = getByText(props.placeholder);
 
     // Open Select
-    fireEvent.click(button);
+    mouseDownListener({ preventDefault: () => {}, target: button });
 
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(true);
 
     // Close Select
-    fireEvent.click(button);
+    mouseDownListener({ preventDefault: () => {}, target: button });
 
     expect(spy).toHaveBeenCalledTimes(2);
     expect(spy).toHaveBeenCalledWith(false);
@@ -106,7 +117,12 @@ describe('<Select />', () => {
   test('should call onChange when an item option is selected', () => {
     const spy = jest.fn();
     const props = { placeholder: 'placeholder', onChange: spy };
-    const { queryAllByText, getByText } = render(
+    let mouseDownListener;
+    document.addEventListener = jest.fn((event, listener) => {
+      if (event === 'mousedown') mouseDownListener = listener;
+    });
+
+    const { debug, queryAllByText, getByText } = render(
       <Select {...props}>
         <Select.Option value="1">Item</Select.Option>
         <Select.Option value="2">Item</Select.Option>
@@ -118,7 +134,7 @@ describe('<Select />', () => {
     const button = getByText(props.placeholder);
 
     // Open Select
-    fireEvent.click(button);
+    mouseDownListener({ preventDefault: () => {}, target: button });
 
     const ItemNode = queryAllByText(/Item/);
 
@@ -198,6 +214,10 @@ describe('<Select />', () => {
   });
 
   test('should update its value accordingly', async () => {
+    let mouseDownListener;
+    document.addEventListener = jest.fn((event, listener) => {
+      if (event === 'mousedown') mouseDownListener = listener;
+    });
     const { container, queryByText, getByText, rerender } = render(
       <Select>
         <Select.Option value="1">Item 1</Select.Option>
@@ -216,7 +236,7 @@ describe('<Select />', () => {
     expect(thirdOption).not.toBeInTheDocument();
 
     // open select and pick another option
-    fireEvent.click(buttonNode);
+    mouseDownListener({ preventDefault: () => {}, target: buttonNode });
     thirdOption = getByText('Item 3');
     fireEvent.click(thirdOption);
 

--- a/src/Select/__tests__/__snapshots__/Select.test.js.snap
+++ b/src/Select/__tests__/__snapshots__/Select.test.js.snap
@@ -64,6 +64,7 @@ exports[`<Select /> should render without a problem 1`] = `
   >
     placeholder
   </button>
+  <div />
 </div>
 `;
 
@@ -137,5 +138,6 @@ exports[`<Select /> should render without a problem when disabled 1`] = `
   >
     placeholder
   </button>
+  <div />
 </div>
 `;

--- a/src/Select/elements.js
+++ b/src/Select/elements.js
@@ -56,11 +56,9 @@ export const Header = styled.button`
 
 export const Menu = styled.ul`
   position: absolute;
-  top: calc(100% + 0.1rem);
-  left: 0;
-  z-index: 1;
+  top: ${({ position: { top } }) => `${top}px`};
 
-  width: 100%;
+  width: ${({ position: { width } }) => `${width}px`};
   max-height: 28rem;
 
   border: 1px solid ${({ theme: { palette } }) => palette.lightGrey};

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ export { default as CheckBox } from './CheckBox';
 export { default as Counter } from './Counter';
 export { default as DatePicker } from './DatePicker';
 export { default as Dropdown } from './Dropdown';
+export { default as EventListener } from './EventListener';
 export { default as Flag } from './Flag';
 export { default as Form } from './Form';
 export { default as Icon } from './Icon';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5309,6 +5309,11 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+exenv@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
+  integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
+
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9288,9 +9288,10 @@ react-popper-tooltip@^2.8.3:
     "@babel/runtime" "^7.4.5"
     react-popper "^1.3.3"
 
-react-popper@^1.3.3:
+react-popper@1.3.3, react-popper@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.3.tgz#2c6cef7515a991256b4f0536cd4bdcb58a7b6af6"
+  integrity sha512-ynMZBPkXONPc5K4P5yFWgZx5JGAUIP3pGGLNs58cfAPgK67olx7fmLp+AdpZ0+GoQ+ieFDa/z4cdV6u7sioH6w==
   dependencies:
     "@babel/runtime" "^7.1.2"
     create-react-context "<=0.2.2"


### PR DESCRIPTION
- [ ] Feature
- [ ] Fix
- [x] Enhancement

## Brief
Select component uses a portal to display its content and an event listener allows the component to close its content when an outside click is made.
I did not use react-onclickoutside as it triggers me an error (don't precisely know why but there is something not working between the component and this lib).

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
