### PR TITLE
refactor(Popover): wrap popover with portal and popper.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@tippy.js/react": "2.2.2",
+    "exenv": "1.2.2",
     "initials": "3.0.1",
     "luxon": "1.17.1",
     "polished": "3.4.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "luxon": "1.17.1",
     "polished": "3.4.1",
     "react-onclickoutside": "6.8.0",
+    "react-popper": "1.3.3",
     "react-portal": "4.2.0",
     "styled-components-breakpoint": "2.1.1"
   },

--- a/src/EventListener/__tests__/EventListener.test.js
+++ b/src/EventListener/__tests__/EventListener.test.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { cleanup, fireEvent } from '@testing-library/react';
+
+import EventListener from '..';
+
+describe('<EventListener />', () => {
+  afterEach(cleanup);
+
+  test('should add event listener on specified elements', () => {
+    const wrapper = document.createElement('div');
+    const text = document.createTextNode('I am a text node');
+    wrapper.appendChild(text);
+    document.body.appendChild(wrapper);
+
+    const handleDocumentClick = jest.fn();
+
+    const listeners = [
+      {
+        target: 'document',
+        event: 'click',
+        handler: handleDocumentClick,
+      },
+    ];
+    const { getByText } = render(<EventListener listeners={listeners} />);
+
+    const textNode = getByText(/text node/);
+
+    fireEvent.click(textNode);
+    expect(handleDocumentClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/EventListener/index.js
+++ b/src/EventListener/index.js
@@ -1,0 +1,87 @@
+import { PureComponent } from 'react';
+import { canUseDOM, canUseEventListeners } from 'exenv';
+
+import PropTypes from 'prop-types';
+
+/**
+ * Components can delegates to EventListener the listening of specific elements
+ * and trigger callback if the specified events have been triggered to these elements
+ * Comes handy to handle outside clicks for example.
+ *
+ * @param {Array} listeners - array of object { target: string, event: string, handler: fn, options: boolean }
+ * e.g. { target: 'document', event: 'click', handler: () => { ... },  options: true }
+ *
+ * @return null
+ */
+class EventListener extends PureComponent {
+  /**
+   * componentDidMount - lifeycle method
+   * Adds event listeners on mount
+   *
+   */
+  componentDidMount() {
+    const { listeners } = this.props;
+    this.addEventListeners(listeners);
+  }
+
+  /**
+   * componentDidUpdate - lifeycle method
+   * Update event listeners
+   *
+   */
+  componentDidUpdate(prevProps) {
+    const { listeners } = this.props;
+    this.removeEventListeners(prevProps.listeners);
+    this.addEventListeners(listeners);
+  }
+
+  /**
+   * componentWillUnmount - lifeycle method
+   * Update event listeners
+   *
+   */
+  componentWillUnmount() {
+    const { listeners } = this.props;
+    this.removeEventListeners(listeners);
+  }
+
+  getTargetNode = target => {
+    if (canUseDOM) {
+      return global[target] || global.document.querySelector(target);
+    }
+  };
+
+  addEventListeners = listeners => {
+    if (canUseEventListeners) {
+      listeners.forEach(({ target, event, handler, options }) => {
+        const node = this.getTargetNode(target);
+        node && node.addEventListener(event, handler, options);
+      });
+    }
+  };
+
+  removeEventListeners = listeners => {
+    if (canUseEventListeners) {
+      listeners.forEach(({ target, event, handler, options }) => {
+        const node = this.getTargetNode(target);
+        node && node.removeEventListener(event, handler, options);
+      });
+    }
+  };
+
+  render() {
+    return null;
+  }
+}
+
+/**
+ * PropTypes Validation.
+ */
+const { array } = PropTypes;
+EventListener.propTypes = {
+  listeners: array.isRequired,
+};
+
+EventListener.displayName = 'EventListener';
+
+export default EventListener;

--- a/src/Input/DatePickerInput/README.md
+++ b/src/Input/DatePickerInput/README.md
@@ -2,29 +2,18 @@
 
 ### Usage
 
+The DatePickerInput component is a text input that toggles a popover with a date picker.
+The date can be updated either on the input or on the date picker displayed through a Popover
+component. Date picker will close on selected date or on outside click if the date picker
+was open.
+
 ```jsx
 import { DatePickerInput } from '@tillersystems/stardust';
 ```
 
 <!-- STORY -->
 
-### Properties
-
-- `fluid` - Whether the input takes all available space or not.
-- `value` - The value of the selected date (controlled mode).
-- `onChange` - Handler on date changed.
-- `error` - Whether the input has a status error.
-- `minDate` - The minimum selectable date.
-- `maxDate` - The maximum selectable date.
-
-| `propName` |     propType     | defaultValue | isRequired |
-| ---------- | :--------------: | :----------: | :--------: |
-| `fluid`    |      `bool`      |   `false`    |     -      |
-| `value`    | `luxon.DateTime` |    `null`    |     -      |
-| `onChange` |    `function`    |  `() => {}`  |     -      |
-| `error`    |      `bool`      |   `false`    |     -      |
-| `minDate`  | `luxon.DateTime` |    `null`    |     -      |
-| `maxDate`  | `luxon.DateTime` |    `null`    |     -      |
+<!-- PROPS -->
 
 ### Examples
 

--- a/src/Input/DatePickerInput/__tests__/DatePickerInput.test.js
+++ b/src/Input/DatePickerInput/__tests__/DatePickerInput.test.js
@@ -8,6 +8,8 @@ import Theme from '../../../Theme';
 
 Settings.defaultZoneName = 'utc';
 
+jest.mock('popper.js');
+
 describe('<DatePickerInput />', () => {
   const dateValue = DateTime.fromObject({
     year: 2018,
@@ -35,13 +37,12 @@ describe('<DatePickerInput />', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('should select the provided date value', async () => {
+  test('should select the provided date value', () => {
     const { getByTestId, getByText } = render(<DatePickerInput value={dateValue} />);
 
     const inputNode = getByTestId('input');
     fireEvent.focus(inputNode);
 
-    await wait();
     const selectedDay = getByText('15');
 
     expect(selectedDay).toHaveStyleRule('color', Theme.palette.white);
@@ -52,7 +53,6 @@ describe('<DatePickerInput />', () => {
     const { getByTestId, getByText, getAllByText } = render(<DatePickerInput value={dateValue} />);
     const inputNode = getByTestId('input');
     fireEvent.focus(inputNode);
-    await wait();
 
     const selectedDay = getByText('15');
     expect(selectedDay).toHaveStyleRule('color', Theme.palette.white);
@@ -74,7 +74,6 @@ describe('<DatePickerInput />', () => {
     const { getByTestId, getByText } = render(<DatePickerInput value={dateValue} />);
     const inputNode = getByTestId('input');
     fireEvent.focus(inputNode);
-    await wait();
 
     const selectedDay = getByText('15');
 

--- a/src/Input/DatePickerInput/__tests__/__snapshots__/DatePickerInput.test.js.snap
+++ b/src/Input/DatePickerInput/__tests__/__snapshots__/DatePickerInput.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<DatePickerInput /> should render without a problem 1`] = `
-.c1 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -21,7 +21,7 @@ exports[`<DatePickerInput /> should render without a problem 1`] = `
   background-color: hsl(0,100%,100%);
 }
 
-.c2 {
+.c4 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -35,32 +35,36 @@ exports[`<DatePickerInput /> should render without a problem 1`] = `
   text-align: left;
 }
 
-.c2::-webkit-input-placeholder {
+.c4::-webkit-input-placeholder {
   font-size: 1.4rem;
 }
 
-.c2::-moz-placeholder {
+.c4::-moz-placeholder {
   font-size: 1.4rem;
 }
 
-.c2:-ms-input-placeholder {
+.c4:-ms-input-placeholder {
   font-size: 1.4rem;
 }
 
-.c2::placeholder {
+.c4::placeholder {
   font-size: 1.4rem;
 }
 
-.c2:focus,
-.c2:active {
+.c4:focus,
+.c4:active {
   outline: none;
+}
+
+.c2 {
+  display: inline-block;
 }
 
 .c0 {
   position: relative;
 }
 
-.c3 {
+.c1 {
   position: absolute;
 }
 
@@ -69,21 +73,26 @@ exports[`<DatePickerInput /> should render without a problem 1`] = `
 >
   <div
     class="c1"
-    data-testid="input-container"
-    width="25rem"
   >
-    <input
+    <span
       class="c2"
-      data-testid="input"
-      id=""
-      placeholder=""
-      tabindex="0"
-      type="text"
-      value="7/15/2018"
-    />
+    >
+      <div
+        class="c3"
+        data-testid="input-container"
+        width="25rem"
+      >
+        <input
+          class="c4"
+          data-testid="input"
+          id=""
+          placeholder=""
+          tabindex="0"
+          type="text"
+          value="7/15/2018"
+        />
+      </div>
+    </span>
   </div>
-  <div
-    class="c3"
-  />
 </div>
 `;

--- a/src/Input/DatePickerInput/index.js
+++ b/src/Input/DatePickerInput/index.js
@@ -2,16 +2,13 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { DateTime } from 'luxon';
 
-import { DatePicker, Popover, TextInput } from '../..';
+import { DatePicker, EventListener, Popover, TextInput } from '../..';
 import { Container, DatePickerWrapper, PopoverContainer } from './elements';
 
 /**
  * The DatePickerInput component is an input that toggles a popover with a date picker
  *
- * @param {luxon.DateTime} value - The currently selected date.
- * @param {Function} onChange - The callback to notify that the date changed.
- * @param {luxon.DateTime} minDate - Minimum allowed date.
- * @param {luxon.DateTime} maxDate - Maximum allowed date.
+ * See README.md and stories from Storybook for more documentation
  *
  * @returns {jsx}
  */
@@ -29,11 +26,10 @@ class DatePickerInput extends PureComponent {
 
   /**
    * Component lifecycle method
-   * Adds the listener allowing DatePicker display
+   * Sets initial values if provided by the parent otherwise take today
    *
    */
   componentDidMount() {
-    document.addEventListener('mousedown', this.handleClick, false);
     const { value, error } = this.props;
     this.setState({
       dateValue: value || DateTime.local(),
@@ -59,32 +55,20 @@ class DatePickerInput extends PureComponent {
       this.setState({ error: currentErrorProp });
     }
   }
-
   /**
-   * Component lifecycle method
-   * Removes the listener allowing DatePicker display
-   *
-   */
-  componentWillUnmount() {
-    document.removeEventListener('mousedown', this.handleClick, false);
-  }
-
-  /**
-   * Toggles visibility of the date picker.
+   * Toggles visibility of the date picker
    * Closes the date picker if the user has clicked outside this component
    *
-   * @param {Object} event - event on click
    */
-  handleClick = event => {
-    if (!event || (event && !this.ref.contains(event.target))) {
-      this.setState({
-        isDatePickerOpen: false,
-      });
-    }
+  handleOutsideClick = () => {
+    this.setState({
+      isDatePickerOpen: false,
+    });
   };
 
   /**
-   * Handles change of date from DatePicker.
+   * Handles change of date from DatePicker
+   * Updates value displayed in text input and closes date picker
    *
    * @param {Object} dateValue - clicked date on date picker component
    */
@@ -138,25 +122,30 @@ class DatePickerInput extends PureComponent {
 
     return (
       <Container ref={node => (this.ref = node)}>
-        <TextInput
-          fluid={fluid}
-          value={textValue ? textValue.toLocaleString(DateTime.DATE_SHORT) : ''}
-          type="text"
-          onFocus={() => this.setState({ isDatePickerOpen: true })}
-          onChange={this.handleInputChange}
-          error={error}
-        />
         <PopoverContainer>
-          <Popover active={isDatePickerOpen} arrowPositionX="6rem">
-            <DatePickerWrapper>
-              <DatePicker
-                minDate={minDate}
-                maxDate={maxDate}
-                defaultValue={dateValue}
-                value={dateValue}
-                onDateChanged={this.handleDateChange}
-              />
-            </DatePickerWrapper>
+          <Popover
+            isOpen={isDatePickerOpen}
+            content={
+              <DatePickerWrapper>
+                <DatePicker
+                  minDate={minDate}
+                  maxDate={maxDate}
+                  defaultValue={dateValue}
+                  value={dateValue}
+                  onDateChanged={this.handleDateChange}
+                />
+              </DatePickerWrapper>
+            }
+            onClickOutside={this.handleOutsideClick}
+          >
+            <TextInput
+              fluid={fluid}
+              value={textValue ? textValue.toLocaleString(DateTime.DATE_SHORT) : ''}
+              type="text"
+              onFocus={() => this.setState({ isDatePickerOpen: true })}
+              onChange={this.handleInputChange}
+              error={error}
+            />
           </Popover>
         </PopoverContainer>
       </Container>
@@ -167,12 +156,35 @@ class DatePickerInput extends PureComponent {
 const { bool, func, object } = PropTypes;
 /** Prop types validation. */
 DatePickerInput.propTypes = {
-  fluid: bool,
-  value: object,
-  onChange: func,
+  /*
+   * Whether the input has a status error
+   */
   error: bool,
+
+  /*
+   * Whether the input takes all available space or not
+   */
+  fluid: bool,
+
+  /*
+   * The maximum selectable date
+   */
   maxDate: object,
+
+  /*
+   * The minimum selectable date
+   */
   minDate: object,
+
+  /*
+   * Handler on date changed
+   */
+  onChange: func,
+
+  /*
+   * The current value of the selected date (controlled mode)
+   */
+  value: object,
 };
 
 /** Default props. */

--- a/src/Popover/README.md
+++ b/src/Popover/README.md
@@ -2,30 +2,16 @@
 
 ### Usage
 
-```jsx
-import { Popover } from '@tillersystems/stardust';
-```
-
-<!-- STORY -->
-
-### Properties
-
-- `active` - Boolean set to display or hide the popover.
-- `children` - Anything that can be rendered: numbers, strings, elements or an array (or fragment).
-- `width` - Popover width.
-
-| propName   | propType | defaultValue | isRequired |
-| ---------- | :------: | :----------: | :--------: |
-| `active`   |  `bool`  |   `false`    |     -      |
-| `children` |  `node`  |    `null`    |     -      |
-| `width`    | `string` |   `28rem`    |     -      |
-
-### Example
+A popover displays a content in a Portal according to a boolean prop `isOpen`. Value of this prop is left to be handled by the parent (controlled state). Component may be updated in the near future to handle uncontrolled state too.
 
 ```jsx
 import { Popover } from 'components/Popover';
 
 render() {
-  return <Popover width='28rem' />
+  return <Popover width='28rem' isOpen />
 }
 ```
+
+<!-- STORY -->
+
+<!-- PROPS -->

--- a/src/Popover/__stories__/Popover.stories.js
+++ b/src/Popover/__stories__/Popover.stories.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { State, Store } from '@sambego/storybook-state';
-import { withKnobs, boolean, number } from '@storybook/addon-knobs';
+import { withKnobs, boolean, number, select } from '@storybook/addon-knobs';
 
 import { Button, Popover } from '../..';
 import PopoverReadme from '../README.md';
 
 const store = new Store({
-  active: false,
+  isOpen: false,
 });
 
 storiesOf('Popover', module)
@@ -19,6 +19,20 @@ storiesOf('Popover', module)
     },
   })
   .add('default', () => {
+    const hasArrowValue = boolean('hasArrow', false, 'State');
+    const placement = select(
+      'Placement',
+      {
+        bottom: 'bottom',
+        top: 'top',
+        right: 'right',
+        left: 'left',
+      },
+      'bottom',
+      'State',
+    );
+    const isOverflowingContainer = boolean('isOverflowingContainer', false, 'State');
+
     const widthValue = number(
       'Width',
       28,
@@ -31,40 +45,39 @@ storiesOf('Popover', module)
       'Dimensions',
     );
 
-    const arrowPositionXValue = number(
-      'arrowPositionX',
-      50,
-      {
-        range: true,
-        min: 5,
-        max: 90,
-        step: 1,
-      },
-      'Dimensions',
-    );
-
     return (
       <div style={{ position: 'relative' }}>
-        <Button appearance="primary" onClick={() => store.set({ active: !store.get('active') })}>
-          Show Popover
-        </Button>
-        <div style={{ position: 'absolute', top: '100%', left: '-78px' }}>
-          <State store={store}>
-            <Popover
-              width={`${widthValue}rem`}
-              arrowPositionX={`${(widthValue * arrowPositionXValue) / 100}rem`}
-              active={store.get('active')}
+        <State store={store}>
+          <Popover
+            isOpen={store.get('isOpen')}
+            content="Ventes nettes (ventes brutes moins les réductions et les annulations) plus les taxes sur
+          la période sélectionnée."
+            hasArrow={hasArrowValue}
+            modifiers={
+              isOverflowingContainer
+                ? {
+                    preventOverflow: {
+                      escapeWithReference: true,
+                    },
+                  }
+                : {}
+            }
+            placement={placement}
+            width={`${widthValue}rem`}
+          >
+            <Button
+              appearance="primary"
+              onClick={() => store.set({ isOpen: !store.get('isOpen') })}
             >
-              Ventes nettes (ventes brutes moins les réductions et les annulations) plus les taxes
-              sur la période séléctionnée.
-            </Popover>
-          </State>
-        </div>
+              Show Popover
+            </Button>
+          </Popover>
+        </State>
       </div>
     );
   })
   .add('controlled', () => {
-    const activeValue = boolean('Active', false, 'State');
+    const isOpenValue = boolean('isOpen', false, 'State');
 
     const widthValue = number(
       'Width',
@@ -81,7 +94,7 @@ storiesOf('Popover', module)
     return (
       <div>
         <span>Control modal from knobs!</span>
-        <Popover width={`${widthValue}rem`} active={activeValue}>
+        <Popover width={`${widthValue}rem`} isOpen={isOpenValue}>
           Ventes nettes (ventes brutes moins les réductions et les annulations) plus les taxes sur
           la période séléctionnée.
         </Popover>

--- a/src/Popover/__stories__/Popover.stories.js
+++ b/src/Popover/__stories__/Popover.stories.js
@@ -18,7 +18,7 @@ storiesOf('Popover', module)
       content: PopoverReadme,
     },
   })
-  .add('default', () => {
+  .add('controlled', () => {
     const hasArrowValue = boolean('hasArrow', false, 'State');
     const placement = select(
       'Placement',
@@ -63,6 +63,7 @@ storiesOf('Popover', module)
                 : {}
             }
             placement={placement}
+            onClickOutside={() => store.set({ isOpen: false })}
             width={`${widthValue}rem`}
           >
             <Button
@@ -73,31 +74,6 @@ storiesOf('Popover', module)
             </Button>
           </Popover>
         </State>
-      </div>
-    );
-  })
-  .add('controlled', () => {
-    const isOpenValue = boolean('isOpen', false, 'State');
-
-    const widthValue = number(
-      'Width',
-      60,
-      {
-        range: true,
-        min: 10,
-        max: 60,
-        step: 2,
-      },
-      'Dimensions',
-    );
-
-    return (
-      <div>
-        <span>Control modal from knobs!</span>
-        <Popover width={`${widthValue}rem`} isOpen={isOpenValue}>
-          Ventes nettes (ventes brutes moins les réductions et les annulations) plus les taxes sur
-          la période séléctionnée.
-        </Popover>
       </div>
     );
   });

--- a/src/Popover/__stories__/Popover.stories.js
+++ b/src/Popover/__stories__/Popover.stories.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { State, Store } from '@sambego/storybook-state';
 import { withKnobs, boolean, number, select } from '@storybook/addon-knobs';
 
-import { Button, Popover } from '../..';
+import { Button, Popover, ScrollBox } from '../..';
 import PopoverReadme from '../README.md';
 
 const store = new Store({
@@ -47,7 +47,7 @@ storiesOf('Popover', module)
     );
 
     return (
-      <div style={{ position: 'relative' }}>
+      <ScrollBox>
         <State store={store}>
           <Popover
             isOpen={store.get('isOpen')}
@@ -75,6 +75,6 @@ storiesOf('Popover', module)
             </Button>
           </Popover>
         </State>
-      </div>
+      </ScrollBox>
     );
   });

--- a/src/Popover/__stories__/Popover.stories.js
+++ b/src/Popover/__stories__/Popover.stories.js
@@ -16,10 +16,11 @@ storiesOf('Popover', module)
     readme: {
       // Show readme before story
       content: PopoverReadme,
+      includePropTables: [Popover],
     },
   })
   .add('controlled', () => {
-    const hasArrowValue = boolean('hasArrow', false, 'State');
+    const hasArrowValue = boolean('hasArrow', false, 'Props');
     const placement = select(
       'Placement',
       {
@@ -29,9 +30,9 @@ storiesOf('Popover', module)
         left: 'left',
       },
       'bottom',
-      'State',
+      'Props',
     );
-    const isOverflowingContainer = boolean('isOverflowingContainer', false, 'State');
+    const isOverflowingContainer = boolean('isOverflowingContainer', false, 'Props');
 
     const widthValue = number(
       'Width',
@@ -42,7 +43,7 @@ storiesOf('Popover', module)
         max: 60,
         step: 2,
       },
-      'Dimensions',
+      'Props',
     );
 
     return (

--- a/src/Popover/__tests__/Popover.test.js
+++ b/src/Popover/__tests__/Popover.test.js
@@ -4,13 +4,17 @@ import Popover from '..';
 
 describe('<Popover />', () => {
   test('should render without a problem', () => {
-    const { container } = render(<Popover>Children</Popover>);
+    const { container } = render(<Popover content="content">Children</Popover>);
 
     expect(container.firstChild).toMatchSnapshot();
   });
 
   test('should render open popover without a problem', () => {
-    const { getByTestId } = render(<Popover active>Children</Popover>);
+    const { getByTestId } = render(
+      <Popover content="content" isOpen>
+        Children
+      </Popover>,
+    );
     const popoverNode = getByTestId('popover');
 
     expect(popoverNode).toBeInTheDocument();
@@ -19,7 +23,7 @@ describe('<Popover />', () => {
   test('should render with a different width', () => {
     const width = '10rem';
     const { getByTestId } = render(
-      <Popover active width={width}>
+      <Popover isOpen content="content" width={width}>
         Children
       </Popover>,
     );

--- a/src/Popover/__tests__/Popover.test.js
+++ b/src/Popover/__tests__/Popover.test.js
@@ -1,8 +1,11 @@
 import React from 'react';
+import { cleanup, fireEvent } from '@testing-library/react';
 
 import Popover from '..';
 
 describe('<Popover />', () => {
+  afterEach(cleanup);
+
   test('should render without a problem', () => {
     const { container } = render(<Popover content="content">Children</Popover>);
 
@@ -12,7 +15,7 @@ describe('<Popover />', () => {
   test('should render open popover without a problem', () => {
     const { getByTestId } = render(
       <Popover content="content" isOpen>
-        Children
+        Trigger
       </Popover>,
     );
     const popoverNode = getByTestId('popover');
@@ -24,11 +27,30 @@ describe('<Popover />', () => {
     const width = '10rem';
     const { getByTestId } = render(
       <Popover isOpen content="content" width={width}>
-        Children
+        Trigger
       </Popover>,
     );
     const popoverNode = getByTestId('popover');
 
     expect(popoverNode).toHaveStyleRule('width', width);
+  });
+
+  test('should trigger callback on click outside', () => {
+    const wrapper = document.createElement('div');
+    const externalElement = document.createTextNode('I am outside the popover');
+    wrapper.appendChild(externalElement);
+    document.body.appendChild(wrapper);
+
+    const spy = jest.fn();
+    const { getByText } = render(
+      <Popover content="content" isOpen onClickOutside={spy}>
+        Trigger
+      </Popover>,
+    );
+    const outsideNode = getByText(/outside the popover/);
+
+    fireEvent.click(outsideNode);
+
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/Popover/__tests__/__snapshots__/Popover.test.js.snap
+++ b/src/Popover/__tests__/__snapshots__/Popover.test.js.snap
@@ -1,3 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Popover /> should render without a problem 1`] = `null`;
+exports[`<Popover /> should render without a problem 1`] = `
+.c0 {
+  display: inline-block;
+}
+
+<span
+  class="c0"
+>
+  Children
+</span>
+`;

--- a/src/Popover/elements.js
+++ b/src/Popover/elements.js
@@ -1,34 +1,51 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-export const PopOver = styled.div`
-position: relative;
+export const ARROW_SIZE = '8px';
 
-width: ${({ width }) => width};
+export const PopoverContentWrapper = styled.div`
+  background: ${({ theme: { palette } }) => palette.white};
+  border-radius: ${({ theme: { dimensions } }) => dimensions.radius};
 
-padding: 1.8rem;
+  box-shadow: 0 0.2rem 1.6rem 0 hsla(0, 0%, 0%, 0.1), 0 0.2rem 1.6rem 0 hsla(206, 23%, 69%, 0.1),
+    0 0 0 0.05rem ${({ theme: { palette } }) => palette.lightGrey};
 
-border-radius: ${({ theme: { dimensions } }) => dimensions.radius};
+  padding: 1.8rem;
+  position: relative;
 
-box-shadow: 0 0.2rem 1.6rem 0 hsla(0, 0%, 0%, 0.1), 0 0.2rem 1.6rem 0 hsla(206, 23%, 69%, 0.1),
-  0 0 0 0.1rem hsl(207, 22%, 90%);
+  width: ${({ width }) => width};
 
-background: ${({ theme: { palette } }) => palette.white};
+  ${props =>
+    props['data-placement'] === 'top' &&
+    css`
+      margin-bottom: ${ARROW_SIZE};
+    `}
 
-&::before {
-  content: "";
+  ${props =>
+    props['data-placement'] === 'bottom' &&
+    css`
+      margin-top: ${ARROW_SIZE};
+    `}
 
-  display:block;
+  ${props =>
+    props['data-placement'] === 'left' &&
+    css`
+      margin-right: ${ARROW_SIZE};
+    `}
 
-  position:absolute;
-  top: -0.7rem;
-  left: ${({ arrowPositionX }) => arrowPositionX};
-  z-index:-1;
+  ${props =>
+    props['data-placement'] === 'right' &&
+    css`
+      margin-left: ${ARROW_SIZE};
+    `}
 
-  height:14.14px;
-  width:14.14px;
+  ${props =>
+    props['data-out-of-boundaries'] &&
+    css`
+      visibility: hidden;
+    `}
+`;
 
-  transform: rotate(135deg);
-
-  background:white;
-  box-shadow: -1px 1px 2px 0px rgba(0,0,0,0.2);
+export const PopoverTriggerWrapper = styled.span`
+  cursor: ${({ cursor }) => cursor};
+  display: inline-block;
 `;

--- a/src/Popover/elements.js
+++ b/src/Popover/elements.js
@@ -1,15 +1,68 @@
 import styled, { css } from 'styled-components';
 
-export const ARROW_SIZE = '8px';
+export const ARROW_SIZE = 8;
+export const CONTENT_PADDING = 1.8;
+export const MARGIN = 12;
+
+export const Arrow = styled.span`
+  color: ${({ theme: { palette } }) => palette.white};
+
+  position: absolute;
+  display: inline-block;
+  font-size: ${ARROW_SIZE * 2}px;
+
+  ${({ placement }) =>
+    placement.startsWith('top') &&
+    css`
+      bottom: ${-CONTENT_PADDING + 0.5}rem;
+      left: calc(50% - ${ARROW_SIZE}px);
+      margin-bottom: 0;
+      margin-top: 0;
+      text-shadow: 1px -5px 5px hsla(0, 0%, 0%, 0.1);
+      transform: rotate(180deg);
+    `}
+
+  ${({ placement }) =>
+    placement.startsWith('bottom') &&
+    css`
+      top: ${-CONTENT_PADDING + 0.5}rem;
+      left: calc(50% - ${ARROW_SIZE}px);
+      margin-bottom: 0;
+      margin-top: 0;
+      text-shadow: 1px -4px 6px hsla(0, 0%, 0%, 0.1);
+      transform: rotate(0deg);
+    `}
+
+  ${({ placement }) =>
+    placement.startsWith('left') &&
+    css`
+      right: ${-CONTENT_PADDING + 0.8}rem;
+      top: calc(50% - ${ARROW_SIZE}px);
+      margin-left: 0;
+      margin-right: 0;
+      text-shadow: 1px -5px 5px hsla(0, 0%, 0%, 0.1);
+      transform: rotate(90deg);
+    `}
+
+  ${({ placement }) =>
+    placement.startsWith('right') &&
+    css`
+      left: ${-CONTENT_PADDING + 0.8}rem;
+      top: calc(50% - ${ARROW_SIZE}px);
+      margin-left: 0;
+      margin-right: 0;
+      text-shadow: 1px -5px 5px hsla(0, 0%, 0%, 0.1);
+      transform: rotate(-90deg);
+    `}
+`;
 
 export const PopoverContentWrapper = styled.div`
   background: ${({ theme: { palette } }) => palette.white};
   border-radius: ${({ theme: { dimensions } }) => dimensions.radius};
 
-  box-shadow: 0 0.2rem 1.6rem 0 hsla(0, 0%, 0%, 0.1), 0 0.2rem 1.6rem 0 hsla(206, 23%, 69%, 0.1),
+  box-shadow: 0 0.2rem 0.6rem 0 hsla(0, 0%, 0%, 0.1), 0 0.2rem 0.6rem 0 hsla(206, 23%, 69%, 0.1),
     0 0 0 0.05rem ${({ theme: { palette } }) => palette.lightGrey};
-
-  padding: 1.8rem;
+  padding: ${CONTENT_PADDING}rem;
   position: relative;
 
   width: ${({ width }) => width};
@@ -17,25 +70,25 @@ export const PopoverContentWrapper = styled.div`
   ${props =>
     props['data-placement'] === 'top' &&
     css`
-      margin-bottom: ${ARROW_SIZE};
+      margin-bottom: ${MARGIN}px;
     `}
 
   ${props =>
     props['data-placement'] === 'bottom' &&
     css`
-      margin-top: ${ARROW_SIZE};
+      margin-top: ${MARGIN}px;
     `}
 
   ${props =>
     props['data-placement'] === 'left' &&
     css`
-      margin-right: ${ARROW_SIZE};
+      margin-right: ${MARGIN}px;
     `}
 
   ${props =>
     props['data-placement'] === 'right' &&
     css`
-      margin-left: ${ARROW_SIZE};
+      margin-left: ${MARGIN}px;
     `}
 
   ${props =>
@@ -46,6 +99,5 @@ export const PopoverContentWrapper = styled.div`
 `;
 
 export const PopoverTriggerWrapper = styled.span`
-  cursor: ${({ cursor }) => cursor};
   display: inline-block;
 `;

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -10,23 +10,7 @@ import { Arrow, PopoverContentWrapper, PopoverTriggerWrapper } from './elements'
 /**
  * Popover using popperjs and portal
  *
- * A popover displays a content in a Portal according to a boolean prop `isOpen`. Value of this prop
- * is left to be handled by the parent (controlled state). Component may be updated in the near future
- * to handle uncontrolled state too.
- *
- * @param {bool} hasArrow - if popover content should display with an arrow or not
- * @param {HTMLElement|node|string} children - must be a single element that will be the trigger of the popover
- * @param {node|string} content - displayed in a portal according to `isOpen` value
- * @param {boolean} isOpen - boolean set to display or hide the popover
- * @param {Object} modifiers - Popper option. Plugins to alter the behaviour of the popper. See https://popper.js.org/popper-documentation.html
- * @param {function} onClickOutside - Pass this prop on click outside event (for example close the popover by updating `isOpen` prop value)
- * @param {string} placement - Popper option. Placement applied to popper. See https://popper.js.org/popper-documentation.html
- * @param {boolean} positionFixed - Popper option. Put the popper in "fixed" mode. See https://popper.js.org/popper-documentation.html
- * @param {function} triggerRef - Callback ref of trigger element
- * @param {Array} triggerWrapperCss - css provided to the trigger wrapper. Must use `css` method from styled-components.
- * @param {string} width - Popover width
- *
- * @return {jsx}
+ * See README, run storybook or see propTypes below for documentation
  */
 class Popover extends PureComponent {
   popoverContent = null;
@@ -179,16 +163,59 @@ class Popover extends PureComponent {
  */
 const { array, bool, func, node, object, oneOfType, string } = PropTypes;
 Popover.propTypes = {
+  /**
+   * If popover content should display with an arrow or not
+   */
   hasArrow: bool,
+
+  /**
+   * Must be a single element that will be the trigger of the popover
+   */
   children: node.isRequired,
+
+  /**
+   * Displayed in a portal according to `isOpen` value
+   */
   content: oneOfType([string, node]).isRequired,
+
+  /**
+   * Boolean set to display or hide the popover
+   */
   isOpen: bool,
+
+  /**
+   * Popper option. Plugins to alter the behaviour of the popper. See https://popper.js.org/popper-documentation.html
+   */
   modifiers: object,
+
+  /**
+   * Pass this prop on click outside event (for example close the popover by updating `isOpen` prop value)
+   */
   onClickOutside: func,
+
+  /**
+   * Popper option. Placement applied to popper. See https://popper.js.org/popper-documentation.html
+   */
   placement: string,
+
+  /**
+   * Popper option. Put the popper in "fixed" mode. See https://popper.js.org/popper-documentation.html
+   */
   positionFixed: bool,
+
+  /**
+   * Callback ref of trigger element
+   */
   triggerRef: func,
+
+  /**
+   * css provided to the trigger wrapper. Must use `css` method from styled-components.
+   */
   triggerWrapperCss: array,
+
+  /**
+   * Popover width
+   */
   width: string,
 };
 

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -112,12 +112,12 @@ class Popover extends PureComponent {
             );
           }}
         </Reference>
-        {isOpen && (
-          <Portal>
-            <Popper modifiers={modifiers} placement={placement} positionFixed={positionFixed}>
-              {({ arrowProps, outOfBoundaries, placement, ref: popperRef, style }) => {
-                return (
-                  <PoseGroup flipMove={false}>
+        <Portal>
+          <Popper modifiers={modifiers} placement={placement} positionFixed={positionFixed}>
+            {({ arrowProps, outOfBoundaries, placement, ref: popperRef, style }) => {
+              return (
+                <PoseGroup flipMove={false}>
+                  {isOpen && (
                     <PopoverContentWrapperAnimation
                       key="popover"
                       data-testid="popover"
@@ -137,22 +137,22 @@ class Popover extends PureComponent {
                         </Arrow>
                       )}
                     </PopoverContentWrapperAnimation>
-                  </PoseGroup>
-                );
-              }}
-            </Popper>
-            <EventListener
-              listeners={[
-                {
-                  target: 'document',
-                  event: 'click',
-                  handler: this.handleDocumentClick,
-                  options: true,
-                },
-              ]}
-            />
-          </Portal>
-        )}
+                  )}
+                </PoseGroup>
+              );
+            }}
+          </Popper>
+          <EventListener
+            listeners={[
+              {
+                target: 'document',
+                event: 'click',
+                handler: this.handleDocumentClick,
+                options: true,
+              },
+            ]}
+          />
+        </Portal>
       </Manager>
     );
   }
@@ -239,7 +239,6 @@ Popover.defaultProps = {
  */
 const PopoverContentWrapperAnimation = posed(PopoverContentWrapper)({
   enter: {
-    y: 15,
     opacity: 1,
     transition: {
       y: { type: 'spring', stiffness: 900, damping: 30 },
@@ -247,7 +246,6 @@ const PopoverContentWrapperAnimation = posed(PopoverContentWrapper)({
     },
   },
   exit: {
-    y: 30,
     opacity: 0,
     transition: { duration: 150 },
   },

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -5,7 +5,7 @@ import { Portal } from 'react-portal';
 import { Manager, Popper, Reference } from 'react-popper';
 
 import EventListener from '../EventListener';
-import { PopoverContentWrapper, PopoverTriggerWrapper } from './elements';
+import { Arrow, PopoverContentWrapper, PopoverTriggerWrapper } from './elements';
 
 /**
  * Popover using popperjs and portal
@@ -147,7 +147,11 @@ class Popover extends PureComponent {
                       width={width}
                     >
                       {content}
-                      {/* {hasArrow && <PopoverArrow {...popoverArrowProps} />} */}
+                      {hasArrow && placement && (
+                        <Arrow placement={placement} {...arrowProps}>
+                          ▲
+                        </Arrow>
+                      )}
                     </PopoverContentWrapperAnimation>
                   </PoseGroup>
                 );

--- a/src/ScrollBox/elements.js
+++ b/src/ScrollBox/elements.js
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+export const Recenter = styled.button`
+  left: 0;
+  position: absolute;
+  top: 0;
+`;
+
+export const Root = styled.div`
+  position: relative;
+`;
+
+export const ScrollArea = styled.div`
+  height: ${({ height }) => `${height}px`};
+  overflow: auto;
+  position: relative;
+`;
+
+export const ScrollContent = styled.div`
+  background-color: ${({ theme: { palette } }) => palette.veryLightBlue};
+  align-items: center;
+  display: flex;
+  height: ${({ height }) => `${height + 500}px`};
+  justify-content: center;
+  width: 200vw;
+`;

--- a/src/ScrollBox/index.js
+++ b/src/ScrollBox/index.js
@@ -1,0 +1,69 @@
+import React, { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+
+import { Recenter, Root, ScrollArea, ScrollContent } from './elements';
+
+/**
+ * Scrollbox is just an element with scrollbars allowing us to test the behaviour of
+ * our components wrapped in it.
+ *
+ */
+const Scrollbox = ({ children, height }) => {
+  const scrollAreaRef = useRef(null);
+  const scrollTargetRef = useRef(null);
+
+  /**
+   * Hook triggered on first render to scroll to center its content
+   *
+   */
+  useEffect(() => {
+    scrollToCenter();
+  }, []);
+
+  const scrollToCenter = () => {
+    const scrollArea = scrollAreaRef.current;
+    const scrollTarget = scrollTargetRef.current;
+
+    scrollArea.scrollTop =
+      scrollTarget.offsetTop + scrollTarget.clientHeight / 2 - scrollArea.clientHeight / 2;
+
+    scrollArea.scrollLeft =
+      scrollTarget.offsetLeft + scrollTarget.clientWidth / 2 - scrollArea.clientWidth / 2;
+  };
+
+  return (
+    <Root>
+      <ScrollArea ref={scrollAreaRef} height={height}>
+        <ScrollContent height={height}>
+          <span ref={scrollTargetRef}>{children}</span>
+        </ScrollContent>
+      </ScrollArea>
+      <Recenter onClick={scrollToCenter}>Re-center</Recenter>
+    </Root>
+  );
+};
+
+/**
+ * PropTypes Validation.
+ */
+const { node, number } = PropTypes;
+Scrollbox.propTypes = {
+  /**
+   * Anything that can be rendered (string, HTML element, React component)
+   */
+  children: node.isRequired,
+
+  /**
+   * Height of the box area
+   */
+  height: number,
+};
+
+/**
+ * Default props
+ */
+Scrollbox.defaultProps = {
+  height: 400,
+};
+
+export default Scrollbox;

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ export { default as Pin } from './Pin';
 export { default as Popover } from './Popover';
 export { default as RadioButton } from './RadioButton';
 export { default as RadioGroup } from './RadioGroup';
+export { default as ScrollBox } from './ScrollBox';
 export { default as Select } from './Select';
 export { default as Table } from './Table';
 export { default as TabSwitcher } from './TabSwitcher';

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ export { default as CheckBox } from './CheckBox';
 export { default as Counter } from './Counter';
 export { default as DatePicker } from './DatePicker';
 export { default as Dropdown } from './Dropdown';
+export { default as EventListener } from './EventListener';
 export { default as Flag } from './Flag';
 export { default as Form } from './Form';
 export { default as Icon } from './Icon';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5309,6 +5309,11 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+exenv@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
+  integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
+
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9288,9 +9288,10 @@ react-popper-tooltip@^2.8.3:
     "@babel/runtime" "^7.4.5"
     react-popper "^1.3.3"
 
-react-popper@^1.3.3:
+react-popper@1.3.3, react-popper@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.3.tgz#2c6cef7515a991256b4f0536cd4bdcb58a7b6af6"
+  integrity sha512-ynMZBPkXONPc5K4P5yFWgZx5JGAUIP3pGGLNs58cfAPgK67olx7fmLp+AdpZ0+GoQ+ieFDa/z4cdV6u7sioH6w==
   dependencies:
     "@babel/runtime" "^7.1.2"
     create-react-context "<=0.2.2"


### PR DESCRIPTION
- [ ] Feature
- [ ] Fix
- [x] Enhancement

## Brief
In order to fix our Select and Dropdown components, it seemed that a way was to use popper.js to help with the positioning. Since we already have a Popover component, I reworked this component to use popper.js and took the opportunity to add more utils like an EventListener component that can be instanciated each time we want to handle outside click.

Warning: if you test the story from the storybook, position of the arrow when you toggle `hasArrow` may not be accurate because it does not seem to update properly, but if you change the `placement` of the popover it should update.

## Requirements :
<!--- Eventually remove the following. -->
:warning: Requires running `yarn` command.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
