### PR TITLE
refactor: use Popover to wrap Select and Dropdown components

### DIFF
--- a/src/Dropdown/README.md
+++ b/src/Dropdown/README.md
@@ -13,22 +13,24 @@ import { Dropdown } from '@tillersystems/stardust';
 - `children` - Anything that can be rendered: numbers, strings, elements or an array (or fragment).
 - `className` - Add a text aside in the select next the selected value.
 - `itemCss` - Css provided to each item of the dropdown. Must use `css` method from styled-components.
+- `modifiers` - Customize popper behaviour. Plugins to alter the behaviour of the popper. See https://popper.js.org/popper-documentation.html
 - `noResultLabel` - Label to display when no result found.
 - `onToggle` - Callback called when Dropdown is toggled.
-- `searchable` - A Dropdown may be searchable.
-- `searchBarPlacholder` - SearchBar input placeholder.
+- `searchable` - Whether the dropdown is searchable.
+- `searchBarPlaceholder` - SearchBar input placeholder.
 - `title` - Dropdown title.
 
-| propName              |  propType  | defaultValue | isRequired |
-| --------------------- | :--------: | :----------: | :--------: |
-| `children`            |   `node`   |              |     \*     |
-| `className`           |  `string`  |    `null`    |     -      |
-| `itemCss`             |  `array`   |    `null`    |     -      |
-| `noResultLabel`       |   `node`   |    `null`    |     -      |
-| `onToggle`            | `function` |  `() => {}`  |     -      |
-| `searchable`          |   `bool`   |   `false`    |     -      |
-| `searchBarPlacholder` |  `string`  |     `''`     |     -      |
-| `title`               |   `node`   |              |     \*     |
+| propName               |  propType  | defaultValue | isRequired |
+| ---------------------- | :--------: | :----------: | :--------: |
+| `children`             |   `node`   |              |     \*     |
+| `className`            |  `string`  |    `null`    |     -      |
+| `itemCss`              |  `array`   |    `null`    |     -      |
+| `modifiers`            |  `object`  |    `null`    |     -      |
+| `noResultLabel`        |   `node`   |    `null`    |     -      |
+| `onToggle`             | `function` |  `() => {}`  |     -      |
+| `searchable`           |   `bool`   |   `false`    |     -      |
+| `searchBarPlaceholder` |  `string`  |     `''`     |     -      |
+| `title`                |   `node`   |              |     \*     |
 
 ### Example
 

--- a/src/Dropdown/__stories__/Dropdown.stories.js
+++ b/src/Dropdown/__stories__/Dropdown.stories.js
@@ -5,7 +5,7 @@ import { State, Store } from '@sambego/storybook-state';
 import { action } from '@storybook/addon-actions';
 import { css } from 'styled-components';
 
-import { Dropdown, CheckBox } from '../..';
+import { Dropdown, CheckBox, ScrollBox } from '../..';
 import DropdownReadme from '../README.md';
 
 /* eslint-disable jsx-a11y/click-events-have-key-events */
@@ -51,22 +51,28 @@ storiesOf('Dropdown', module)
     const onClickAction = action('onChange');
     const Searchable = boolean('Searchable', false, 'State');
     const NoresultLabel = text('No Result Label', 'No stores found ...', 'State');
-    const SearchBarPlacholder = text('Search Bar Placholder', 'Search ...', 'State');
+    const SearchBarPlaceholder = text('Search Bar Placholder', 'Search ...', 'State');
     const Title = text('Title', 'All stores', 'State');
 
     return (
-      <State store={store}>
-        {state => (
-          <div style={{ width: '25rem' }}>
+      <ScrollBox>
+        <State store={store}>
+          {state => (
             <Dropdown
+              headerStyle={{ width: '25rem' }}
+              itemCss={itemCss}
+              modifiers={{
+                preventOverflow: {
+                  escapeWithReference: true,
+                },
+              }}
+              noResultLabel={NoresultLabel}
               title={Title}
               searchable={Searchable}
-              noResultLabel={NoresultLabel}
-              searchBarPlacholder={SearchBarPlacholder}
-              itemCss={itemCss}
+              searchBarPlaceholder={SearchBarPlaceholder}
             >
               <CheckBox
-                defaultChecked={state.streetBangkokBastille}
+                checked={state.streetBangkokBastille}
                 value="Street Bangkok Bastille"
                 onChange={event =>
                   onClickAction(event.target.value, event.target.checked) ||
@@ -76,7 +82,7 @@ storiesOf('Dropdown', module)
                 Street Bangkok Bastille
               </CheckBox>
               <CheckBox
-                defaultChecked={state.streetBangkokMarais}
+                checked={state.streetBangkokMarais}
                 value="Street Bangkok Marais"
                 onChange={event =>
                   onClickAction(event.target.value, event.target.checked) ||
@@ -86,7 +92,7 @@ storiesOf('Dropdown', module)
                 Street Bangkok Marais
               </CheckBox>
               <CheckBox
-                defaultChecked={state.streetBangkokCanal}
+                checked={state.streetBangkokCanal}
                 value="Street Bangkok Canal"
                 onChange={event =>
                   onClickAction(event.target.value, event.target.checked) ||
@@ -96,7 +102,7 @@ storiesOf('Dropdown', module)
                 Street Bangkok Canal
               </CheckBox>
               <CheckBox
-                defaultChecked={state.streetBangkokMontorgeuil}
+                checked={state.streetBangkokMontorgeuil}
                 value="Street Bangkok Montorgeuil"
                 onChange={event =>
                   onClickAction(event.target.value, event.target.checked) ||
@@ -106,7 +112,7 @@ storiesOf('Dropdown', module)
                 Street Bangkok Montorgeuil
               </CheckBox>
               <CheckBox
-                defaultChecked={state.streetBangkokSentier}
+                checked={state.streetBangkokSentier}
                 value="Street Bangkok Sentier"
                 onChange={event =>
                   onClickAction(event.target.value, event.target.checked) ||
@@ -116,7 +122,7 @@ storiesOf('Dropdown', module)
                 Street Bangkok Sentier
               </CheckBox>
               <CheckBox
-                defaultChecked={state.streetBangkokStlouis}
+                checked={state.streetBangkokStlouis}
                 value="Street Bangkok St louis"
                 onChange={event =>
                   onClickAction(event.target.value, event.target.checked) ||
@@ -126,7 +132,7 @@ storiesOf('Dropdown', module)
                 Street Bangkok St louis
               </CheckBox>
               <CheckBox
-                defaultChecked={state.streetBangkokStMichel}
+                checked={state.streetBangkokStMichel}
                 value="Street Bangkok St Michel"
                 onChange={event =>
                   onClickAction(event.target.value, event.target.checked) ||
@@ -136,7 +142,7 @@ storiesOf('Dropdown', module)
                 Street Bangkok St Michel
               </CheckBox>
               <CheckBox
-                defaultChecked={state.streetBangkokOberkampf}
+                checked={state.streetBangkokOberkampf}
                 value="Street Bangkok Oberkampf"
                 onChange={event =>
                   onClickAction(event.target.value, event.target.checked) ||
@@ -146,8 +152,8 @@ storiesOf('Dropdown', module)
                 Street Bangkok Oberkampf
               </CheckBox>
             </Dropdown>
-          </div>
-        )}
-      </State>
+          )}
+        </State>
+      </ScrollBox>
     );
   });

--- a/src/Dropdown/__tests__/Dropdown.test.js
+++ b/src/Dropdown/__tests__/Dropdown.test.js
@@ -4,6 +4,8 @@ import { css } from 'styled-components';
 
 import Dropdown from '..';
 
+jest.mock('popper.js');
+
 describe('<Dropdown />', () => {
   test('should render without a problem', () => {
     const props = { title: 'title' };
@@ -20,14 +22,14 @@ describe('<Dropdown />', () => {
 
   test('should toggle the dropdown', done => {
     const props = { title: 'title' };
-    const { queryAllByText, getByText } = render(
+    const { container, queryAllByText } = render(
       <Dropdown {...props}>
         <div>Item1</div>
         <div>Item2</div>
         <div>Item3</div>
       </Dropdown>,
     );
-    const button = getByText(props.title);
+    const button = container.querySelector('button');
 
     expect(button).toHaveAttribute('aria-expanded', 'false');
     expect(button).toHaveAttribute('aria-haspopup', 'true');
@@ -60,55 +62,9 @@ describe('<Dropdown />', () => {
     }, 500);
   });
 
-  test('should close the dropdown when clicking outside of the component', done => {
-    const props = { title: 'title' };
-    const { queryAllByText, getByText } = render(
-      <Dropdown {...props}>
-        <div>Item1</div>
-        <div>Item2</div>
-        <div>Item3</div>
-      </Dropdown>,
-    );
-
-    const button = getByText(props.title);
-
-    expect(button).toHaveAttribute('aria-expanded', 'false');
-    expect(button).toHaveAttribute('aria-haspopup', 'true');
-
-    // Open Dropdown
-    fireEvent.click(button);
-
-    expect(button).toHaveAttribute('aria-expanded', 'true');
-    expect(button).toHaveAttribute('aria-haspopup', 'true');
-
-    let ItemNode;
-    ItemNode = queryAllByText(/Item/);
-
-    expect(ItemNode).toHaveLength(3);
-    expect(ItemNode[0]).toBeInTheDocument();
-    expect(ItemNode[1]).toBeInTheDocument();
-    expect(ItemNode[2]).toBeInTheDocument();
-
-    // Clicking outside of the conponent
-    // we need to dispatch a mousedown event: react-onclickoutside library
-    // explicitly listening for mousedown events.
-    // See: https://github.com/Pomax/react-onclickoutside/issues/104
-    document.dispatchEvent(new MouseEvent('mousedown'));
-
-    setTimeout(() => {
-      ItemNode = queryAllByText(/Item/);
-      expect(button).toHaveAttribute('aria-expanded', 'false');
-      expect(button).toHaveAttribute('aria-haspopup', 'true');
-      expect(ItemNode[0]).toBeUndefined();
-      expect(ItemNode[1]).toBeUndefined();
-      expect(ItemNode[2]).toBeUndefined();
-      done();
-    }, 500);
-  });
-
   test('should filter items', () => {
     const props = { title: 'title', searchable: true, searchBarPlaceholder: 'search' };
-    const { queryAllByText, getByText, getByPlaceholderText } = render(
+    const { container, queryAllByText, getByText, getByPlaceholderText } = render(
       <Dropdown {...props}>
         <div>Item1</div>
         <div>Item2</div>
@@ -116,7 +72,7 @@ describe('<Dropdown />', () => {
       </Dropdown>,
     );
 
-    const button = getByText(props.title);
+    const button = container.querySelector('button');
 
     expect(button).toHaveAttribute('aria-expanded', 'false');
     expect(button).toHaveAttribute('aria-haspopup', 'true');
@@ -144,7 +100,7 @@ describe('<Dropdown />', () => {
       searchBarPlaceholder: 'search',
       noResultLabel: 'Not Found',
     };
-    const { queryAllByText, getByText, getByPlaceholderText } = render(
+    const { container, queryAllByText, getByText, getByPlaceholderText } = render(
       <Dropdown {...props}>
         <div>Item1</div>
         <div>Item2</div>
@@ -152,7 +108,7 @@ describe('<Dropdown />', () => {
       </Dropdown>,
     );
 
-    const button = getByText(props.title);
+    const button = container.querySelector('button');
 
     expect(button).toHaveAttribute('aria-expanded', 'false');
     expect(button).toHaveAttribute('aria-haspopup', 'true');
@@ -190,14 +146,14 @@ describe('<Dropdown />', () => {
         }
       `,
     };
-    const { getAllByRole, getByText } = render(
+    const { container, getAllByRole, getByText } = render(
       <Dropdown {...props}>
         <div>Item1</div>
         <div>Item2</div>
         <div>Item3</div>
       </Dropdown>,
     );
-    const button = getByText(props.title);
+    const button = container.querySelector('button');
     fireEvent.click(button);
 
     const [itemNode] = getAllByRole('menuitem');

--- a/src/Dropdown/__tests__/__snapshots__/Dropdown.test.js.snap
+++ b/src/Dropdown/__tests__/__snapshots__/Dropdown.test.js.snap
@@ -2,12 +2,18 @@
 
 exports[`<Dropdown /> should render without a problem 1`] = `
 .c1 {
+  display: inline-block;
+  width: inherit;
+}
+
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   height: 100%;
   width: 100%;
+  position: relative;
   padding: 0.8rem 1.2rem;
   cursor: pointer;
   text-align: left;
@@ -18,7 +24,7 @@ exports[`<Dropdown /> should render without a problem 1`] = `
   color: hsl(207,13%,45%);
 }
 
-.c1::after {
+.c2::after {
   content: '';
   position: absolute;
   right: 1.4rem;
@@ -31,17 +37,30 @@ exports[`<Dropdown /> should render without a problem 1`] = `
   border-bottom: 3px solid hsl(207,13%,45%);
 }
 
-.c1::before {
+.c2::before {
   content: '';
   position: absolute;
   right: 1.4rem;
-  bottom: 37%;
+  bottom: 33%;
   width: 0;
   height: 0;
   border: 0 solid transparent;
   border-left-width: 3px;
   border-right-width: 3px;
   border-top: 3px solid hsl(207,13%,45%);
+}
+
+.c3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 2.2rem;
+  padding-right: 2rem;
 }
 
 .c0 {
@@ -57,13 +76,21 @@ exports[`<Dropdown /> should render without a problem 1`] = `
   class="c0"
   data-testid="dropdown"
 >
-  <button
-    aria-expanded="false"
-    aria-haspopup="true"
+  <span
     class="c1"
-    data-testid="dropdown-button"
   >
-    title
-  </button>
+    <button
+      aria-expanded="false"
+      aria-haspopup="true"
+      class="c2"
+      data-testid="dropdown-button"
+    >
+      <div
+        class="c3"
+      >
+        title
+      </div>
+    </button>
+  </span>
 </div>
 `;

--- a/src/Dropdown/elements.js
+++ b/src/Dropdown/elements.js
@@ -5,6 +5,7 @@ export const Header = styled.button`
 
   height: 100%;
   width: 100%;
+  position: relative;
 
   padding: 0.8rem 1.2rem;
 
@@ -42,7 +43,7 @@ export const Header = styled.button`
 
     position: absolute;
     right: 1.4rem;
-    bottom: 37%;
+    bottom: 33%;
 
     width: 0;
     height: 0;
@@ -52,6 +53,13 @@ export const Header = styled.button`
     border-right-width: 3px;
     border-top: 3px solid ${({ theme: { palette } }) => palette.spaceGrey};
   }
+`;
+
+export const HeaderContent = styled.div`
+  align-items: center;
+  display: flex;
+  height: 2.2rem;
+  padding-right: 2rem;
 `;
 
 export const Menu = styled.ul`

--- a/src/Input/DatePickerInput/__tests__/__snapshots__/DatePickerInput.test.js.snap
+++ b/src/Input/DatePickerInput/__tests__/__snapshots__/DatePickerInput.test.js.snap
@@ -58,6 +58,7 @@ exports[`<DatePickerInput /> should render without a problem 1`] = `
 
 .c2 {
   display: inline-block;
+  width: auto;
 }
 
 .c0 {

--- a/src/Input/DatePickerInput/__tests__/__snapshots__/DatePickerInput.test.js.snap
+++ b/src/Input/DatePickerInput/__tests__/__snapshots__/DatePickerInput.test.js.snap
@@ -1,6 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<DatePickerInput /> should render without a problem 1`] = `
+.c2 {
+  display: inline-block;
+  width: inherit;
+}
+
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -54,11 +59,6 @@ exports[`<DatePickerInput /> should render without a problem 1`] = `
 .c4:focus,
 .c4:active {
   outline: none;
-}
-
-.c2 {
-  display: inline-block;
-  width: auto;
 }
 
 .c0 {

--- a/src/Popover/__stories__/Popover.stories.js
+++ b/src/Popover/__stories__/Popover.stories.js
@@ -51,8 +51,12 @@ storiesOf('Popover', module)
         <State store={store}>
           <Popover
             isOpen={store.get('isOpen')}
-            content="Ventes nettes (ventes brutes moins les réductions et les annulations) plus les taxes sur
-          la période sélectionnée."
+            content={
+              <div style={{ padding: '1.8rem' }}>
+                Ventes nettes (ventes brutes moins les réductions et les annulations) plus les taxes
+                sur la période sélectionnée
+              </div>
+            }
             hasArrow={hasArrowValue}
             modifiers={
               isOverflowingContainer

--- a/src/Popover/__tests__/__snapshots__/Popover.test.js.snap
+++ b/src/Popover/__tests__/__snapshots__/Popover.test.js.snap
@@ -3,6 +3,7 @@
 exports[`<Popover /> should render without a problem 1`] = `
 .c0 {
   display: inline-block;
+  width: auto;
 }
 
 <span

--- a/src/Popover/__tests__/__snapshots__/Popover.test.js.snap
+++ b/src/Popover/__tests__/__snapshots__/Popover.test.js.snap
@@ -3,7 +3,7 @@
 exports[`<Popover /> should render without a problem 1`] = `
 .c0 {
   display: inline-block;
-  width: auto;
+  width: inherit;
 }
 
 <span

--- a/src/Popover/elements.js
+++ b/src/Popover/elements.js
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { transparentize } from 'polished';
 
 export const ARROW_SIZE = 8;
 export const CONTENT_PADDING = 1.8;
@@ -18,7 +19,7 @@ export const Arrow = styled.span`
       left: calc(50% - ${ARROW_SIZE}px);
       margin-bottom: 0;
       margin-top: 0;
-      text-shadow: 1px -5px 5px hsla(0, 0%, 0%, 0.1);
+      text-shadow: 1px -5px 5px ${({ theme: { palette } }) => transparentize(0.9, palette.black)};
       transform: rotate(180deg);
     `}
 
@@ -29,7 +30,7 @@ export const Arrow = styled.span`
       left: calc(50% - ${ARROW_SIZE}px);
       margin-bottom: 0;
       margin-top: 0;
-      text-shadow: 1px -4px 6px hsla(0, 0%, 0%, 0.1);
+      text-shadow: 1px -4px 6px ${({ theme: { palette } }) => transparentize(0.9, palette.black)};
       transform: rotate(0deg);
     `}
 
@@ -40,7 +41,7 @@ export const Arrow = styled.span`
       top: calc(50% - ${ARROW_SIZE}px);
       margin-left: 0;
       margin-right: 0;
-      text-shadow: 1px -5px 5px hsla(0, 0%, 0%, 0.1);
+      text-shadow: 1px -5px 5px ${({ theme: { palette } }) => transparentize(0.9, palette.black)};
       transform: rotate(90deg);
     `}
 
@@ -51,7 +52,7 @@ export const Arrow = styled.span`
       top: calc(50% - ${ARROW_SIZE}px);
       margin-left: 0;
       margin-right: 0;
-      text-shadow: 1px -5px 5px hsla(0, 0%, 0%, 0.1);
+      text-shadow: 1px -5px 5px ${({ theme: { palette } }) => transparentize(0.9, palette.black)};
       transform: rotate(-90deg);
     `}
 `;
@@ -60,9 +61,10 @@ export const PopoverContentWrapper = styled.div`
   background: ${({ theme: { palette } }) => palette.white};
   border-radius: ${({ theme: { dimensions } }) => dimensions.radius};
 
-  box-shadow: 0 0.2rem 0.6rem 0 hsla(0, 0%, 0%, 0.1), 0 0.2rem 0.6rem 0 hsla(206, 23%, 69%, 0.1),
+  box-shadow: 0 0.2rem 0.6rem 0 ${({ theme: { palette } }) =>
+    transparentize(0.9, palette.black)}, 0 0.2rem 0.6rem 0 ${({ theme: { palette } }) =>
+  transparentize(0.9, palette.mediumGrey)},
     0 0 0 0.05rem ${({ theme: { palette } }) => palette.lightGrey};
-  padding: ${CONTENT_PADDING}rem;
   position: relative;
 
   width: ${({ width }) => width};
@@ -100,4 +102,5 @@ export const PopoverContentWrapper = styled.div`
 
 export const PopoverTriggerWrapper = styled.span`
   display: inline-block;
+  width: inherit;
 `;

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -83,7 +83,9 @@ class Popover extends PureComponent {
    */
   render() {
     const {
+      animationProps,
       content,
+      contentWrapperStyle,
       hasArrow,
       isOpen,
       modifiers,
@@ -123,11 +125,12 @@ class Popover extends PureComponent {
                       data-testid="popover"
                       data-out-of-boundaries={outOfBoundaries || undefined}
                       data-placement={placement}
+                      animationProps={animationProps}
                       ref={node => {
                         this.setContentRef(node);
                         popperRef(node);
                       }}
-                      style={style}
+                      style={{ ...style, ...contentWrapperStyle }}
                       width={width}
                     >
                       {content}
@@ -164,9 +167,9 @@ class Popover extends PureComponent {
 const { array, bool, func, node, object, oneOfType, string } = PropTypes;
 Popover.propTypes = {
   /**
-   * If popover content should display with an arrow or not
+   * Custom animation options to pass to PopoverContentWrapperAnimation
    */
-  hasArrow: bool,
+  animationProps: object,
 
   /**
    * Must be a single element that will be the trigger of the popover
@@ -177,6 +180,16 @@ Popover.propTypes = {
    * Displayed in a portal according to `isOpen` value
    */
   content: oneOfType([string, node]).isRequired,
+
+  /**
+   * Custom style for content wrapper
+   */
+  contentWrapperStyle: object,
+
+  /**
+   * If popover content should display with an arrow or not
+   */
+  hasArrow: bool,
 
   /**
    * Boolean set to display or hide the popover
@@ -223,6 +236,8 @@ Popover.propTypes = {
  * Default props
  */
 Popover.defaultProps = {
+  animationProps: null,
+  contentWrapperStyle: null,
   hasArrow: false,
   isOpen: false,
   modifiers: {},

--- a/src/Select/README.md
+++ b/src/Select/README.md
@@ -8,27 +8,16 @@ import { Select } from '@tillersystems/stardust';
 
 <!-- STORY -->
 
-### Properties
-
-- `children` - Anything that can be rendered: numbers, strings, elements or an array (or fragment).
-- `className` - className needed by styled components.
-- `onChange` - Function fired when an element of the `<Select />` is selected.
-- `onToggle` - Function fired when the `<Select />` is toggled.
-- `placeholder` - placeholder of the `<Select />` component.
-- `initialValue` - displayed option value of the `<Select />`.
-- `resetValue` - Reset the `<Select />` value.
-- `width` - Width of the `<Select />`.
-
-| propName       | propType  | defaultValue | isRequired |
-| -------------- | :-------: | :----------: | :--------: |
-| `children`     | `string`  |    `null`    |     -      |
-| `className`    | `string`  |     `''`     |     -      |
-| `onChange`     |  `func`   |  `() => {}`  |     -      |
-| `onToggle`     |  `func`   |  `() => {}`  |     -      |
-| `placeholder`  | `string`  |    `null`    |     -      |
-| `initialValue` | `string`  |    `null`    |     -      |
-| `resetValue`   | `boolean` |   `false`    |     -      |
-| `width`        | `string`  |    `100%`    |     -      |
+| propName      | propType  | defaultValue | isRequired |
+| ------------- | :-------: | :----------: | :--------: |
+| `children`    | `string`  |    `null`    |     -      |
+| `className`   | `string`  |     `''`     |     -      |
+| `disabled`    |  `bool`   |   `false`    |     -      |
+| `onChange`    |  `func`   |      -       |     -      |
+| `onToggle`    |  `func`   |      -       |     -      |
+| `placeholder` | `string`  |      -       |     -      |
+| `resetValue`  | `boolean` |   `false`    |     -      |
+| `width`       | `string`  |    `100%`    |     -      |
 
 ### Example
 

--- a/src/Select/__stories__/Select.stories.js
+++ b/src/Select/__stories__/Select.stories.js
@@ -5,7 +5,7 @@ import { action } from '@storybook/addon-actions';
 import { State, Store } from '@sambego/storybook-state';
 import styled from 'styled-components';
 
-import { Icon, Select, Theme } from '../..';
+import { Icon, ScrollBox, Select, Theme } from '../..';
 import SelectReadme from '../README.md';
 
 storiesOf('Select', module)
@@ -24,18 +24,25 @@ storiesOf('Select', module)
     const resetValue = boolean('Reset value', false, 'State');
 
     return (
-      <Select
-        placeholder={placeholder}
-        onToggle={onToggle}
-        onChange={onChange}
-        disabled={disabled}
-        resetValue={resetValue}
-      >
-        <Select.Option value="home">Home</Select.Option>
-        <Select.Option value="calendar">Calendar</Select.Option>
-        <Select.Option value="settings">Settings</Select.Option>
-        <Select.Option value="user">User</Select.Option>
-      </Select>
+      <ScrollBox>
+        <Select
+          disabled={disabled}
+          modifiers={{
+            preventOverflow: {
+              escapeWithReference: true,
+            },
+          }}
+          placeholder={placeholder}
+          onChange={onChange}
+          onToggle={onToggle}
+          resetValue={resetValue}
+        >
+          <Select.Option value="home">Home</Select.Option>
+          <Select.Option value="calendar">Calendar</Select.Option>
+          <Select.Option value="settings">Settings</Select.Option>
+          <Select.Option value="user">User</Select.Option>
+        </Select>
+      </ScrollBox>
     );
   })
   .add('without placeholder', () => {
@@ -50,15 +57,17 @@ storiesOf('Select', module)
     `;
 
     return (
-      <Select onToggle={onToggle} onChange={onChange} disabled={disabled} resetValue={resetValue}>
-        <Select.Option value="home">
-          <StyledIcon name="home" width="1.5rem" height="1.5rem" color={Theme.palette.darkBlue} />
-          <div>Home</div>
-        </Select.Option>
-        <Select.Option value="calendar">Calendar</Select.Option>
-        <Select.Option value="settings">Settings</Select.Option>
-        <Select.Option value="user">User</Select.Option>
-      </Select>
+      <ScrollBox>
+        <Select onToggle={onToggle} onChange={onChange} disabled={disabled} resetValue={resetValue}>
+          <Select.Option value="home">
+            <StyledIcon name="home" width="1.5rem" height="1.5rem" color={Theme.palette.darkBlue} />
+            <div>Home</div>
+          </Select.Option>
+          <Select.Option value="calendar">Calendar</Select.Option>
+          <Select.Option value="settings">Settings</Select.Option>
+          <Select.Option value="user">User</Select.Option>
+        </Select>
+      </ScrollBox>
     );
   })
   .add('with width', () => {
@@ -79,18 +88,20 @@ storiesOf('Select', module)
     );
 
     return (
-      <Select
-        onToggle={onToggle}
-        onChange={onChange}
-        disabled={disabled}
-        resetValue={resetValue}
-        width={`${widthValue.toString()}px`}
-      >
-        <Select.Option value="home">Home</Select.Option>
-        <Select.Option value="calendar">Calendar</Select.Option>
-        <Select.Option value="settings">Settings</Select.Option>
-        <Select.Option value="user">User</Select.Option>
-      </Select>
+      <ScrollBox>
+        <Select
+          onToggle={onToggle}
+          onChange={onChange}
+          disabled={disabled}
+          resetValue={resetValue}
+          width={`${widthValue.toString()}px`}
+        >
+          <Select.Option value="home">Home</Select.Option>
+          <Select.Option value="calendar">Calendar</Select.Option>
+          <Select.Option value="settings">Settings</Select.Option>
+          <Select.Option value="user">User</Select.Option>
+        </Select>
+      </ScrollBox>
     );
   })
   .add('controlled state', () => {
@@ -109,32 +120,34 @@ storiesOf('Select', module)
     `;
 
     return (
-      <State store={store}>
-        {state => (
-          <Select
-            onToggle={onToggle}
-            onChange={value => {
-              onChangeAction(value);
-              store.set({ value });
-            }}
-            disabled={disabled}
-            resetValue={resetValue}
-            value={state.value}
-          >
-            <Select.Option value="home">
-              <StyledIcon
-                name="home"
-                width="1.5rem"
-                height="1.5rem"
-                color={Theme.palette.darkBlue}
-              />
-              <div>Home</div>
-            </Select.Option>
-            <Select.Option value="calendar">Calendar</Select.Option>
-            <Select.Option value="settings">Settings</Select.Option>
-            <Select.Option value="user">User</Select.Option>
-          </Select>
-        )}
-      </State>
+      <ScrollBox>
+        <State store={store}>
+          {state => (
+            <Select
+              onToggle={onToggle}
+              onChange={value => {
+                onChangeAction(value);
+                store.set({ value });
+              }}
+              disabled={disabled}
+              resetValue={resetValue}
+              value={state.value}
+            >
+              <Select.Option value="home">
+                <StyledIcon
+                  name="home"
+                  width="1.5rem"
+                  height="1.5rem"
+                  color={Theme.palette.darkBlue}
+                />
+                <div>Home</div>
+              </Select.Option>
+              <Select.Option value="calendar">Calendar</Select.Option>
+              <Select.Option value="settings">Settings</Select.Option>
+              <Select.Option value="user">User</Select.Option>
+            </Select>
+          )}
+        </State>
+      </ScrollBox>
     );
   });

--- a/src/Select/__stories__/Select.stories.js
+++ b/src/Select/__stories__/Select.stories.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, boolean, text, number, select } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
+import { State, Store } from '@sambego/storybook-state';
 import styled from 'styled-components';
 
 import { Icon, Select, Theme } from '../..';
@@ -15,7 +16,7 @@ storiesOf('Select', module)
       content: SelectReadme,
     },
   })
-  .add('default', () => {
+  .add('uncontrolled state', () => {
     const placeholder = text('Placeholder', 'Choose your menu', 'State');
     const onToggle = action('onToggle');
     const onChange = action('onChange');
@@ -92,22 +93,15 @@ storiesOf('Select', module)
       </Select>
     );
   })
-  .add('with default value', () => {
+  .add('controlled state', () => {
+    const store = new Store({
+      value: 'settings',
+    });
+
     const onToggle = action('onToggle');
-    const onChange = action('onChange');
+    const onChangeAction = action('onChange');
     const disabled = boolean('Disabled', false, 'Props');
     const resetValue = boolean('Reset value', false, 'Props');
-    const value = select(
-      'Value',
-      {
-        home: 'home',
-        calendar: 'calendar',
-        settings: 'settings',
-        user: 'user',
-      },
-      'home',
-      'Props',
-    );
 
     const StyledIcon = styled(Icon)`
       vertical-align: middle;
@@ -115,20 +109,32 @@ storiesOf('Select', module)
     `;
 
     return (
-      <Select
-        onToggle={onToggle}
-        onChange={onChange}
-        disabled={disabled}
-        resetValue={resetValue}
-        value={value}
-      >
-        <Select.Option value="home">
-          <StyledIcon name="home" width="1.5rem" height="1.5rem" color={Theme.palette.darkBlue} />
-          <div>Home</div>
-        </Select.Option>
-        <Select.Option value="calendar">Calendar</Select.Option>
-        <Select.Option value="settings">Settings</Select.Option>
-        <Select.Option value="user">User</Select.Option>
-      </Select>
+      <State store={store}>
+        {state => (
+          <Select
+            onToggle={onToggle}
+            onChange={value => {
+              onChangeAction(value);
+              store.set({ value });
+            }}
+            disabled={disabled}
+            resetValue={resetValue}
+            value={state.value}
+          >
+            <Select.Option value="home">
+              <StyledIcon
+                name="home"
+                width="1.5rem"
+                height="1.5rem"
+                color={Theme.palette.darkBlue}
+              />
+              <div>Home</div>
+            </Select.Option>
+            <Select.Option value="calendar">Calendar</Select.Option>
+            <Select.Option value="settings">Settings</Select.Option>
+            <Select.Option value="user">User</Select.Option>
+          </Select>
+        )}
+      </State>
     );
   });

--- a/src/Select/__tests__/Select.test.js
+++ b/src/Select/__tests__/Select.test.js
@@ -3,6 +3,8 @@ import { fireEvent, wait } from '@testing-library/react';
 
 import Select from '..';
 
+jest.mock('popper.js');
+
 describe('<Select />', () => {
   test('should render without a problem', () => {
     const props = { placeholder: 'placeholder' };
@@ -34,7 +36,7 @@ describe('<Select />', () => {
 
   test('should toggle the Select', done => {
     const props = { placeholder: 'placeholder' };
-    const { queryAllByText, getByText } = render(
+    const { container, queryAllByText } = render(
       <Select {...props}>
         <Select.Option value="1">Item</Select.Option>
         <Select.Option value="2">Item</Select.Option>
@@ -43,7 +45,7 @@ describe('<Select />', () => {
       </Select>,
     );
 
-    const button = getByText(props.placeholder);
+    const button = container.querySelector('button');
 
     expect(button).toHaveAttribute('aria-expanded', 'false');
     expect(button).toHaveAttribute('aria-haspopup', 'true');

--- a/src/Select/__tests__/__snapshots__/Select.test.js.snap
+++ b/src/Select/__tests__/__snapshots__/Select.test.js.snap
@@ -2,72 +2,10 @@
 
 exports[`<Select /> should render without a problem 1`] = `
 .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  height: 100%;
-  width: 100%;
-  padding: 0.8rem 1.2rem;
-  cursor: pointer;
-  text-align: left;
-  font-size: 1.4rem;
-  border: 1px solid hsl(207,22%,90%);
-  border-radius: 0.4rem;
-  background: linear-gradient( 180deg,hsl(0,100%,100%) 0%,hsl(240,33%,99%) 100% );
-  color: hsl(213,17%,20%);
-}
-
-.c1::after {
-  content: '';
-  position: absolute;
-  right: 1.4rem;
-  top: 37%;
-  width: 0;
-  height: 0;
-  border: 0 solid transparent;
-  border-right-width: 3px;
-  border-left-width: 3px;
-  border-bottom: 3px solid hsl(207,13%,45%);
-}
-
-.c1::before {
-  content: '';
-  position: absolute;
-  right: 1.4rem;
-  bottom: 37%;
-  width: 0;
-  height: 0;
-  border: 0 solid transparent;
-  border-left-width: 3px;
-  border-right-width: 3px;
-  border-top: 3px solid hsl(207,13%,45%);
-}
-
-.c0 {
-  position: relative;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
+  display: inline-block;
   width: auto;
-  height: 4rem;
 }
 
-<div
-  class="c0"
->
-  <button
-    aria-expanded="false"
-    aria-haspopup="true"
-    class="c1"
-  >
-    placeholder
-  </button>
-</div>
-`;
-
-exports[`<Select /> should render without a problem when disabled 1`] = `
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -75,7 +13,8 @@ exports[`<Select /> should render without a problem when disabled 1`] = `
   display: flex;
   height: 100%;
   width: 100%;
-  padding: 0.8rem 1.2rem;
+  position: relative;
+  padding: 0.8rem 1.6rem;
   cursor: pointer;
   text-align: left;
   font-size: 1.4rem;
@@ -102,13 +41,26 @@ exports[`<Select /> should render without a problem when disabled 1`] = `
   content: '';
   position: absolute;
   right: 1.4rem;
-  bottom: 37%;
+  bottom: 33%;
   width: 0;
   height: 0;
   border: 0 solid transparent;
   border-left-width: 3px;
   border-right-width: 3px;
   border-top: 3px solid hsl(207,13%,45%);
+}
+
+.c3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 2.2rem;
+  padding-right: 2rem;
 }
 
 .c0 {
@@ -121,7 +73,101 @@ exports[`<Select /> should render without a problem when disabled 1`] = `
   height: 4rem;
 }
 
-.c0 .c1 {
+<div
+  class="c0"
+>
+  <span
+    class="c1"
+  >
+    <button
+      aria-expanded="false"
+      aria-haspopup="true"
+      class="c2"
+    >
+      <div
+        class="c3"
+      >
+        placeholder
+      </div>
+    </button>
+  </span>
+</div>
+`;
+
+exports[`<Select /> should render without a problem when disabled 1`] = `
+.c1 {
+  display: inline-block;
+  width: auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  width: 100%;
+  position: relative;
+  padding: 0.8rem 1.6rem;
+  cursor: pointer;
+  text-align: left;
+  font-size: 1.4rem;
+  border: 1px solid hsl(207,22%,90%);
+  border-radius: 0.4rem;
+  background: linear-gradient( 180deg,hsl(0,100%,100%) 0%,hsl(240,33%,99%) 100% );
+  color: hsl(213,17%,20%);
+}
+
+.c3::after {
+  content: '';
+  position: absolute;
+  right: 1.4rem;
+  top: 37%;
+  width: 0;
+  height: 0;
+  border: 0 solid transparent;
+  border-right-width: 3px;
+  border-left-width: 3px;
+  border-bottom: 3px solid hsl(207,13%,45%);
+}
+
+.c3::before {
+  content: '';
+  position: absolute;
+  right: 1.4rem;
+  bottom: 33%;
+  width: 0;
+  height: 0;
+  border: 0 solid transparent;
+  border-left-width: 3px;
+  border-right-width: 3px;
+  border-top: 3px solid hsl(207,13%,45%);
+}
+
+.c4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 2.2rem;
+  padding-right: 2rem;
+}
+
+.c0 {
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: auto;
+  height: 4rem;
+}
+
+.c0 .c2 {
   cursor: not-allowed;
   opacity: 0.4;
 }
@@ -129,13 +175,21 @@ exports[`<Select /> should render without a problem when disabled 1`] = `
 <div
   class="c0"
 >
-  <button
-    aria-expanded="false"
-    aria-haspopup="true"
-    class="c1 c2"
-    disabled=""
+  <span
+    class="c1"
   >
-    placeholder
-  </button>
+    <button
+      aria-expanded="false"
+      aria-haspopup="true"
+      class="c2 c3"
+      disabled=""
+    >
+      <div
+        class="c4"
+      >
+        placeholder
+      </div>
+    </button>
+  </span>
 </div>
 `;

--- a/src/Select/__tests__/__snapshots__/Select.test.js.snap
+++ b/src/Select/__tests__/__snapshots__/Select.test.js.snap
@@ -3,7 +3,7 @@
 exports[`<Select /> should render without a problem 1`] = `
 .c1 {
   display: inline-block;
-  width: auto;
+  width: inherit;
 }
 
 .c2 {
@@ -97,7 +97,7 @@ exports[`<Select /> should render without a problem 1`] = `
 exports[`<Select /> should render without a problem when disabled 1`] = `
 .c1 {
   display: inline-block;
-  width: auto;
+  width: inherit;
 }
 
 .c3 {

--- a/src/Select/elements.js
+++ b/src/Select/elements.js
@@ -1,12 +1,14 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+import { transparentize } from 'polished';
 
 export const Header = styled.button`
   display: flex;
 
   height: 100%;
   width: 100%;
+  position: relative;
 
-  padding: 0.8rem 1.2rem;
+  padding: 0.8rem 1.6rem;
 
   cursor: pointer;
   text-align: left;
@@ -42,7 +44,7 @@ export const Header = styled.button`
 
     position: absolute;
     right: 1.4rem;
-    bottom: 37%;
+    bottom: 33%;
 
     width: 0;
     height: 0;
@@ -54,12 +56,14 @@ export const Header = styled.button`
   }
 `;
 
-export const Menu = styled.ul`
-  position: absolute;
-  top: calc(100% + 0.1rem);
-  left: 0;
-  z-index: 1;
+export const HeaderContent = styled.div`
+  align-items: center;
+  display: flex;
+  height: 2.2rem;
+  padding-right: 2rem;
+`;
 
+export const Menu = styled.ul`
   width: 100%;
   max-height: 28rem;
 
@@ -95,7 +99,15 @@ export const MenuItem = styled.li`
   }
 
   cursor: pointer;
-  :hover {
-    background: ${({ theme: { palette } }) => palette.veryLightBlue} 0%;
-  }
+
+  ${({ isSelected }) =>
+    isSelected
+      ? css`
+          background: ${({ theme: { palette } }) => palette.veryLightBlue};
+        `
+      : css`
+          :hover {
+            background: ${({ theme: { palette } }) => transparentize(0.5, palette.veryLightBlue)};
+          }
+        `};
 `;

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -244,6 +244,7 @@ class Select extends PureComponent {
                   key={child}
                   role="menuitem"
                   onClick={event => this.handleSelected(event, child.props.value)}
+                  isSelected={child.props.value === value}
                 >
                   {child}
                 </MenuItem>


### PR DESCRIPTION
- [ ] Feature
- [ ] Fix
- [x] Enhancement

## Brief
Use Popover component to display the Select and the Dropdown to make them overlap everything with their Portal. 
Outside clicks now closes the Select.
There is now a selected style for the selected item of the Select.

⚠️ Custom animation broke the Select so `animationProps` is not useful right now. I will create a followup issue for that.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
