### PR TITLE
test: mock document.createRange

### DIFF
--- a/internal/jest/index.js
+++ b/internal/jest/index.js
@@ -24,3 +24,13 @@ console.error = message => {
 
 // Sets the globals for easier access.
 global.render = render;
+
+// Mock document.createRange, createTange actually won't work inside JSDOM
+global.document.createRange = () => ({
+  setStart: () => {},
+  setEnd: () => {},
+  commonAncestorContainer: {
+    nodeName: 'BODY',
+    ownerDocument: document,
+  },
+});


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description
Mock `document.createRange` in test to avoid error, document.createRange is not available in JSDOM

<img width="811" alt="Screenshot 2019-07-22 at 15 41 10" src="https://user-images.githubusercontent.com/531935/61637319-94eb5280-ac97-11e9-9b91-459d65ea3996.png">


## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
