### PR TITLE
fix(Popover): make Portal optional, adjust style, raise refs to parents

### DIFF
--- a/src/Dropdown/index.js
+++ b/src/Dropdown/index.js
@@ -146,6 +146,7 @@ class Dropdown extends PureComponent {
       searchable,
       searchBarPlaceholder,
       title,
+      usePortal,
     } = this.props;
     const { contentWidth, searchKeyword } = this.state;
     const displayMenu = this.getControllableValue('displayMenu');
@@ -208,6 +209,7 @@ class Dropdown extends PureComponent {
           modifiers={modifiers}
           onClickOutside={this.onClickOutside}
           triggerRef={this.triggerRef}
+          usePortal={usePortal}
           width={contentWidth}
         >
           <Header
@@ -293,6 +295,11 @@ Dropdown.propTypes = {
    * Dropdown title
    */
   title: node.isRequired,
+
+  /**
+   * Display the content on a portal
+   */
+  usePortal: bool,
 };
 
 /**
@@ -307,6 +314,7 @@ Dropdown.defaultProps = {
   onToggle: () => {},
   searchable: false,
   searchBarPlaceholder: '',
+  usePortal: false,
 };
 
 export default styled(Dropdown)`

--- a/src/Dropdown/index.js
+++ b/src/Dropdown/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/require-default-props */
+
 import React, { Children, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
@@ -33,20 +35,51 @@ class Dropdown extends PureComponent {
   };
 
   /**
+   * Returns true if requested prop exists
+   *
+   * @param {string} prop - requested property name
+   *
+   * @return {boolean}
+   */
+  isControlled = prop => {
+    const props = this.props;
+
+    return props.hasOwnProperty(prop);
+  };
+
+  /**
+   * Returns the value a property from props if prop exists and from state otherwise
+   *
+   * @param {string} key - requested property name
+   *
+   * @return {*} value of the property
+   */
+  getControllableValue = key => {
+    const props = this.props;
+    const state = this.state;
+
+    return this.isControlled(key) ? props[key] : state[key];
+  };
+
+  /**
    * Closes the select on outside click and triggers callback of parent
    *
    */
-  onClickOutside = () => {
+  onClickOutside = event => {
     const { onToggle } = this.props;
 
-    this.setState(
-      {
-        displayMenu: false,
-      },
-      () => {
-        onToggle && onToggle(false);
-      },
-    );
+    if (this.isControlled('displayMenu')) {
+      onToggle && onToggle(event);
+    } else {
+      this.setState(
+        {
+          displayMenu: false,
+        },
+        () => {
+          onToggle && onToggle(false);
+        },
+      );
+    }
   };
 
   /**
@@ -64,21 +97,25 @@ class Dropdown extends PureComponent {
    *
    */
   toggleMenu = () => {
-    const { displayMenu } = this.state;
+    const displayMenu = this.getControllableValue('displayMenu');
     const { onToggle } = this.props;
 
-    this.setState(
-      prevState => ({
-        displayMenu: !prevState.displayMenu,
-      }),
-      () => {
-        // Clear input value if menu is open
-        if (displayMenu) {
-          this.resetSearchInput();
-        }
-        onToggle && onToggle(!displayMenu);
-      },
-    );
+    if (this.isControlled('displayMenu')) {
+      onToggle && onToggle(event);
+    } else {
+      this.setState(
+        prevState => ({
+          displayMenu: !prevState.displayMenu,
+        }),
+        () => {
+          // Clear input value if menu is open
+          if (displayMenu) {
+            this.resetSearchInput();
+          }
+          onToggle && onToggle(!displayMenu);
+        },
+      );
+    }
   };
 
   /**
@@ -101,6 +138,7 @@ class Dropdown extends PureComponent {
     const {
       children,
       className,
+      contentRef,
       headerStyle,
       itemCss,
       modifiers,
@@ -109,7 +147,8 @@ class Dropdown extends PureComponent {
       searchBarPlaceholder,
       title,
     } = this.props;
-    const { contentWidth, displayMenu, searchKeyword } = this.state;
+    const { contentWidth, searchKeyword } = this.state;
+    const displayMenu = this.getControllableValue('displayMenu');
 
     // Filter items based on search key word
     // TODO: when need to refactor this later, children may have some children
@@ -160,7 +199,9 @@ class Dropdown extends PureComponent {
                 ))}
             </>
           }
+          contentRef={contentRef}
           contentWrapperStyle={{
+            marginBottom: '0.4rem',
             marginTop: '0.4rem',
           }}
           isOpen={displayMenu}
@@ -195,6 +236,18 @@ Dropdown.propTypes = {
    * Anything that can be rendered: numbers, strings, elements or an array (or fragment)
    */
   children: node.isRequired,
+
+  /**
+   * Callback ref of content element
+   */
+  contentRef: func,
+
+  /**
+   * If the dropdown is open or not. If it is in a controlled state, this prop should be passed
+   * otherwise it will rely on internal state
+   */
+  // eslint-disable-next-line react/no-unused-prop-types
+  displayMenu: bool,
 
   /**
    * Style for header component

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -19,11 +19,16 @@ class Popover extends PureComponent {
   /**
    * Saves the reference to the content of the popover. Allows us to keep the reference
    * somewhere when needed (check if click is inside the element)
+   * Also call a callback if provided by the parent to move up the reference, allowing the parent
+   * to have the reference too
    *
    * @param {HTMLElement} node - node of content element
    */
   setContentRef = node => {
+    const { contentRef } = this.props;
+
     this.popoverContent = node;
+    contentRef && contentRef(node);
   };
 
   /**
@@ -180,6 +185,11 @@ Popover.propTypes = {
    * Displayed in a portal according to `isOpen` value
    */
   content: oneOfType([string, node]).isRequired,
+
+  /**
+   * Callback ref of content element
+   */
+  contentRef: func,
 
   /**
    * Custom style for content wrapper

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -214,7 +214,15 @@ class Select extends PureComponent {
    * @return {jsx}
    */
   render() {
-    const { children, className, contentRef, disabled, modifiers, triggerWrapperCss } = this.props;
+    const {
+      children,
+      className,
+      contentRef,
+      disabled,
+      modifiers,
+      triggerWrapperCss,
+      usePortal,
+    } = this.props;
     const { contentWidth, displayMenu } = this.state;
     const hasPlaceholder = this.isControlled('placeholder');
     const value = this.getControllableValue('value');
@@ -261,6 +269,7 @@ class Select extends PureComponent {
           onClickOutside={this.onClickOutside}
           triggerRef={this.triggerRef}
           triggerWrapperCss={triggerWrapperCss}
+          usePortal={usePortal}
           width={contentWidth}
         >
           <Header
@@ -338,6 +347,11 @@ Select.propTypes = {
   triggerWrapperCss: array,
 
   /**
+   * Display the content on a portal
+   */
+  usePortal: bool,
+
+  /**
    * Selected value identifier
    */
   value: string,
@@ -359,6 +373,7 @@ Select.defaultProps = {
   disabled: false,
   resetValue: false,
   triggerWrapperCss: null,
+  usePortal: false,
   width: '100%',
 };
 

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -214,7 +214,7 @@ class Select extends PureComponent {
    * @return {jsx}
    */
   render() {
-    const { children, className, disabled, modifiers, triggerWrapperCss } = this.props;
+    const { children, className, contentRef, disabled, modifiers, triggerWrapperCss } = this.props;
     const { contentWidth, displayMenu } = this.state;
     const hasPlaceholder = this.isControlled('placeholder');
     const value = this.getControllableValue('value');
@@ -251,6 +251,7 @@ class Select extends PureComponent {
               ))}
             </Menu>
           }
+          contentRef={contentRef}
           contentWrapperStyle={{
             marginBottom: '0.4rem',
             marginTop: '0.4rem',
@@ -295,6 +296,11 @@ Select.propTypes = {
    * Prop needed by styled components
    */
   className: string,
+
+  /**
+   * Callback ref of content element
+   */
+  contentRef: func,
 
   /**
    * If the select should be disabled or not

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -214,7 +214,7 @@ class Select extends PureComponent {
    * @return {jsx}
    */
   render() {
-    const { children, className, disabled, modifiers } = this.props;
+    const { children, className, disabled, modifiers, triggerWrapperCss } = this.props;
     const { contentWidth, displayMenu } = this.state;
     const hasPlaceholder = this.isControlled('placeholder');
     const value = this.getControllableValue('value');
@@ -252,12 +252,14 @@ class Select extends PureComponent {
             </Menu>
           }
           contentWrapperStyle={{
+            marginBottom: '0.4rem',
             marginTop: '0.4rem',
           }}
           isOpen={displayMenu}
           modifiers={modifiers}
           onClickOutside={this.onClickOutside}
           triggerRef={this.triggerRef}
+          triggerWrapperCss={triggerWrapperCss}
           width={contentWidth}
         >
           <Header
@@ -282,7 +284,7 @@ class Select extends PureComponent {
 /**
  * PropTypes Validation
  */
-const { bool, func, node, object, string } = PropTypes;
+const { array, bool, func, node, object, string } = PropTypes;
 Select.propTypes = {
   /**
    * Anything that can be rendered: numbers, strings, elements or an array (or fragment)
@@ -325,6 +327,11 @@ Select.propTypes = {
   resetValue: bool,
 
   /**
+   * css provided to the trigger wrapper. Must use `css` method from styled-components.
+   */
+  triggerWrapperCss: array,
+
+  /**
    * Selected value identifier
    */
   value: string,
@@ -345,6 +352,7 @@ Select.defaultProps = {
   className: '',
   disabled: false,
   resetValue: false,
+  triggerWrapperCss: null,
   width: '100%',
 };
 


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Brief
By using the components in Sonar I stumbled upon some problems.
Having nested Portaled components did this:
![scroll](https://user-images.githubusercontent.com/6019103/61643338-f107a400-aca2-11e9-968f-cf20e18f2be1.gif)

Plus, having the displayMenu uncontrolled on the Dropdown was triggering unwanted behaviour so now passing the prop `displayMenu` makes it controllable by the parent.

Now:
![scroll2](https://user-images.githubusercontent.com/6019103/61643469-3deb7a80-aca3-11e9-914b-f5553ce0320b.gif)

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
