### PR TITLE
fix(Radios): add className to custom with styled-components

### DIFF
--- a/src/RadioButton/index.js
+++ b/src/RadioButton/index.js
@@ -4,18 +4,23 @@ import PropTypes from 'prop-types';
 import { Wrapper, Container, Label } from './elements';
 
 /**
- * Defines a checkbox component.
+ * Defines a radio button component.
+ *
+ * @return {jsx}
  */
-function RadioButton(props) {
-  /**
-   * Renders the component.
-   *
-   * @return {jsx}
-   */
-  const { children, id, value, selectedValue, name, onChange, disabled } = props;
+const RadioButton = ({
+  children,
+  className,
+  disabled,
+  id,
+  name,
+  onChange,
+  selectedValue,
+  value,
+}) => {
   const checked = selectedValue === value;
   return (
-    <Wrapper disabled={disabled} onClick={() => onChange(value)}>
+    <Wrapper disabled={disabled} onClick={() => onChange(value)} className={className}>
       <Container checked={checked} disabled={disabled}>
         <input
           defaultChecked={checked}
@@ -31,28 +36,32 @@ function RadioButton(props) {
       </Label>
     </Wrapper>
   );
-}
+};
+
+const { bool, func, node, string } = PropTypes;
 
 /** Prop types. */
 RadioButton.propTypes = {
-  children: PropTypes.node,
-  id: PropTypes.string,
-  value: PropTypes.string,
-  selectedValue: PropTypes.string,
-  name: PropTypes.string,
-  onChange: PropTypes.func,
-  disabled: PropTypes.bool,
+  children: node,
+  className: string,
+  disabled: bool,
+  id: string,
+  name: string,
+  onChange: func,
+  selectedValue: string,
+  value: string,
 };
 
 /** Default props. */
 RadioButton.defaultProps = {
   children: null,
+  className: '',
+  disabled: false,
   id: null,
-  value: '',
-  selectedValue: null,
   name: null,
   onChange: () => {},
-  disabled: false,
+  selectedValue: null,
+  value: '',
 };
 
 export default RadioButton;

--- a/src/RadioGroup/index.js
+++ b/src/RadioGroup/index.js
@@ -3,31 +3,11 @@ import PropTypes from 'prop-types';
 
 import { Wrapper } from './elements';
 
-const { bool, func, node, string } = PropTypes;
-
 /**
  * A RadioGroup component groups radio buttons.
  *
  */
 class RadioGroup extends PureComponent {
-  /** Prop types. */
-  static propTypes = {
-    children: node,
-    groupName: string,
-    isRow: bool,
-    onChange: func,
-    selectedValue: string,
-  };
-
-  /** Default props. */
-  static defaultProps = {
-    children: null,
-    groupName: null,
-    isRow: false,
-    onChange: null,
-    selectedValue: null,
-  };
-
   /** Internal state. */
   constructor() {
     super();
@@ -81,7 +61,7 @@ class RadioGroup extends PureComponent {
    */
   render() {
     const { selectedValue } = this.state;
-    const { children, groupName, isRow } = this.props;
+    const { children, className, groupName, isRow } = this.props;
 
     const radios = React.Children.map(children, radio =>
       React.cloneElement(radio, {
@@ -90,8 +70,34 @@ class RadioGroup extends PureComponent {
         name: groupName,
       }),
     );
-    return <Wrapper isRow={isRow}>{radios}</Wrapper>;
+    return (
+      <Wrapper isRow={isRow} className={className}>
+        {radios}
+      </Wrapper>
+    );
   }
 }
+
+const { bool, func, node, string } = PropTypes;
+
+/** Prop types. */
+RadioGroup.propTypes = {
+  children: node,
+  className: string,
+  groupName: string,
+  isRow: bool,
+  onChange: func,
+  selectedValue: string,
+};
+
+/** Default props. */
+RadioGroup.defaultProps = {
+  children: null,
+  className: '',
+  groupName: null,
+  isRow: false,
+  onChange: null,
+  selectedValue: null,
+};
 
 export default RadioGroup;


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Brief
Just adding className prop of styled components to allow styled-components to customize style.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
