### PR TITLE
fix: update outside click trigger on Popover and update style of Popover and Select

### DIFF
--- a/src/Dropdown/elements.js
+++ b/src/Dropdown/elements.js
@@ -63,11 +63,7 @@ export const HeaderContent = styled.div`
 `;
 
 export const Menu = styled.ul`
-  position: absolute;
-  top: ${({ position: { top } }) => `${top}px`};
-  left: ${({ position: { left } }) => `${left}px`};
-
-  width: ${({ position: { width } }) => `${width}px`};
+  width: 100%;
   max-height: 28rem;
 
   border: 1px solid ${({ theme: { palette } }) => palette.lightGrey};
@@ -75,12 +71,6 @@ export const Menu = styled.ul`
 
   list-style: none;
   overflow-y: auto;
-
-  background: linear-gradient(
-    180deg,
-    ${({ theme: { palette } }) => palette.white} 0%,
-    ${({ theme: { palette } }) => palette.paleGrey} 100%
-  );
 
   color: ${({ theme: { palette } }) => palette.spaceGrey};
 

--- a/src/Dropdown/index.js
+++ b/src/Dropdown/index.js
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 
 import Popover from '../Popover';
 import SearchBar from './SearchBar';
-import { Header, HeaderContent, MenuItem, SearchInputContainer } from './elements';
+import { Header, HeaderContent, Menu, MenuItem, SearchInputContainer } from './elements';
 
 /**
  * A Dropdown displays content through its children prop that must be components wrapping text.
@@ -164,7 +164,7 @@ class Dropdown extends PureComponent {
       <div className={className} data-testid="dropdown">
         <Popover
           content={
-            <>
+            <Menu>
               {searchable && (
                 <SearchInputContainer>
                   <SearchBar
@@ -198,7 +198,7 @@ class Dropdown extends PureComponent {
                     {child}
                   </MenuItem>
                 ))}
-            </>
+            </Menu>
           }
           contentRef={contentRef}
           contentWrapperStyle={{

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -70,7 +70,6 @@ class Popover extends PureComponent {
   handleDocumentClick = event => {
     if (
       event.target &&
-      event.target instanceof HTMLElement &&
       this.popoverContent &&
       !this.popoverContent.contains(event.target) &&
       this.popoverTrigger &&

--- a/src/Select/elements.js
+++ b/src/Select/elements.js
@@ -73,12 +73,6 @@ export const Menu = styled.ul`
   list-style: none;
   overflow-y: auto;
 
-  background: linear-gradient(
-    180deg,
-    ${({ theme: { palette } }) => palette.white} 0%,
-    ${({ theme: { palette } }) => palette.paleGrey} 100%
-  );
-
   color: ${({ theme: { palette } }) => palette.spaceGrey};
 
   transform-origin: 50% 0%;


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Brief
Small adjustments, when clicking on an svg element, the callback was not being triggered because of the type check. Also I put back the Menu on Dropdown and removed the gradient as per request of Arthur.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
