### PR TITLE
fix(Dropdown): retrieve both state and props for displayMenu to trigger rerender

### DIFF
--- a/src/Dropdown/index.js
+++ b/src/Dropdown/index.js
@@ -148,8 +148,9 @@ class Dropdown extends PureComponent {
       title,
       usePortal,
     } = this.props;
-    const { contentWidth, searchKeyword } = this.state;
-    const displayMenu = this.getControllableValue('displayMenu');
+    const { contentWidth, displayMenu: displayMenuState, searchKeyword } = this.state;
+    const { displayMenu: displayMenuProp } = this.props;
+    const displayMenu = this.isControlled('displayMenu') ? displayMenuProp : displayMenuState;
 
     // Filter items based on search key word
     // TODO: when need to refactor this later, children may have some children


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Brief
`displayMenu` did not seem to trigger rerender despite being updated in the internal state, turns out I think it's because the way the variable was being retrieved would not trigger a rerender.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
