### PR TITLE
fix(Select): allow percentage values for width

### DIFF
--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -380,7 +380,7 @@ Select.defaultProps = {
 export default styled(Select)`
   position: relative;
   user-select: none;
-  width: ${({ width }) => (/^\d+(rem|px)$/.test(width) ? width : 'auto')};
+  width: ${({ width }) => (/^\d+(rem|px|%)$/.test(width) ? width : 'auto')};
   height: 4rem;
 
   /* Disabled */


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Brief
`100%` value was never put on the component since the regex fallback to `auto`

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
