### PR TITLE
refactor(doc): update docs and stories from storybook

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -2,4 +2,5 @@ import '@storybook/addon-knobs/register';
 import '@storybook/addon-actions/register';
 import '@storybook/addon-links/register';
 import '@storybook/addon-options/register';
+import '@storybook/addon-storysource/register';
 import 'storybook-readme/register';

--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,6 +1,5 @@
 import '@storybook/addon-knobs/register';
 import '@storybook/addon-actions/register';
 import '@storybook/addon-links/register';
-import '@storybook/addon-options/register';
 import '@storybook/addon-storysource/register';
 import 'storybook-readme/register';

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -13,15 +13,16 @@ import { Theme } from '../src';
 // Option defaults:
 addParameters({
   options: {
+    isFullscreen: false,
+    panelPosition: 'right',
+    showNav: true,
+    showPanel: true,
+    sidebarAnimations: true,
     theme: create({
       base: 'light',
       brandTitle: 'Stardust',
       brandUrl: 'http://stardust.tillersystems.com',
     }),
-    isFullscreen: false,
-    panelPosition: 'right',
-    showNav: true,
-    showPanel: true,
   },
   readme: {
     /**

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,11 +1,10 @@
 import '@babel/polyfill';
 
 import React from 'react';
-import styled from 'styled-components';
 import { configure, addDecorator, addParameters } from '@storybook/react';
 import { create } from '@storybook/theming';
 import { ThemeProvider } from 'styled-components';
-import { addReadme, configureReadme } from 'storybook-readme';
+import { addReadme } from 'storybook-readme';
 
 import GlobalStyles from './styles';
 import { Theme } from '../src';
@@ -13,7 +12,7 @@ import { Theme } from '../src';
 // Option defaults:
 addParameters({
   options: {
-    isFullscreen: false,
+    isFullScreen: false,
     panelPosition: 'right',
     showNav: true,
     showPanel: true,

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,0 +1,9 @@
+module.exports = function({ config }) {
+  config.module.rules.push({
+    test: /\.stories\.jsx?$/,
+    loaders: [require.resolve('@storybook/addon-storysource/loader')],
+    enforce: 'pre',
+  });
+
+  return config;
+};

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "@storybook/addon-info": "5.1.10",
     "@storybook/addon-knobs": "5.1.10",
     "@storybook/addon-links": "5.1.10",
-    "@storybook/addon-options": "5.1.10",
     "@storybook/addon-storysource": "5.1.10",
     "@storybook/addons": "5.1.10",
     "@storybook/react": "5.1.10",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@storybook/addon-knobs": "5.1.10",
     "@storybook/addon-links": "5.1.10",
     "@storybook/addon-options": "5.1.10",
+    "@storybook/addon-storysource": "5.1.10",
     "@storybook/addons": "5.1.10",
     "@storybook/react": "5.1.10",
     "@storybook/theming": "5.1.10",

--- a/src/Avatar/README.md
+++ b/src/Avatar/README.md
@@ -8,19 +8,21 @@ import { Avatar } from '@tillersystems/stardust';
 
 <!-- STORY -->
 
+### Description
+
+An Avatar depicts an user with an image if its path is provided.  
+It fallbacks to the initials of the person.
+
+<!-- PROPS -->
+
 ### Properties
 
-- `className` - className needed by styled component.
-- `name` - user name.
-- `size` - size of the avatar.
-- `src` - source image of a user.
-
-| propName    | propType | defaultValue | isRequired |
-| ----------- | :------: | :----------: | :--------: |
-| `className` | `string` |     `''`     |     -      |
-| `name`      | `string` |              |     \*     |
-| `size`      | `number` |    `3.1`     |     -      |
-| `src`       | `string` |    `null`    |     -      |
+| Name        | Required |   Type   | DefaultValue |                Description                 |
+| ----------- | :------: | :------: | :----------: | :----------------------------------------: |
+| `className` |    -     | `string` |     `''`     |    className needed by styled component    |
+| `name`      |    \*    | `string` |              | name that will form the displayed initials |
+| `size`      |    -     | `number` |    `3.1`     |             size of the avatar             |
+| `src`       |    -     | `string` |    `null`    |           source image of a user           |
 
 ### Example
 

--- a/src/Avatar/__stories__/Avatar.stories.js
+++ b/src/Avatar/__stories__/Avatar.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text, select } from '@storybook/addon-knobs';
+import { number, text, withKnobs } from '@storybook/addon-knobs';
 
 import { Avatar } from '../..';
 import AvatarReadme from '../README.md';
@@ -9,35 +9,55 @@ storiesOf('Avatar', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
+      includePropTables: [Avatar], // won't work right now because of wrapped styled-comp https://github.com/tuchk4/storybook-readme/issues/177
       // Show readme before story
       content: AvatarReadme,
     },
   })
-  .add('default', () => {
-    const name1 = text('Name 1', 'Thomas Roux', 'name');
-    const name2 = text('Name 2', 'Léopold Houdin', 'name');
-    const name3 = text('Name 3', 'Mickey Mouse', 'name');
+  .add('default with initials', () => {
+    const name1 = text('Name 1', 'Thomas Roux', 'Props');
+    const name2 = text('Name 2', 'Léopold Houdin', 'Props');
+    const name3 = text('Name 3', 'Mickey Mouse', 'Props');
+
+    const size = number(
+      'Size',
+      3,
+      {
+        range: true,
+        min: 1.5,
+        max: 10,
+        step: 0.5,
+      },
+      'Props',
+    );
 
     return (
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 40px)' }}>
-        <Avatar name={name1} />
-        <Avatar name={name2} />
-        <Avatar name={name3} />
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 120px)' }}>
+        <Avatar name={name1} size={size} />
+        <Avatar name={name2} size={size} />
+        <Avatar name={name3} size={size} />
       </div>
     );
   })
-  .add('with user image', () => {
-    const name = text('Name', 'Tony Starck', 'name');
+  .add('with an user image', () => {
+    const name = text('Name', 'Tony Starck', 'Props');
     const imageUrl = text(
       'Image',
       'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR9urBbQTr7erOXvN978IfXd5TzG5KYU4BRwTfqixgTPodK32ewfg',
-      'image',
+      'Props',
     );
-    const options = {
-      medium: 1.5,
-      big: 3.1,
-      huge: 4.1,
-    };
-    const size = select('Size', options, 3.1, 'size');
+
+    const size = number(
+      'Size',
+      3,
+      {
+        range: true,
+        min: 1.5,
+        max: 10,
+        step: 0.5,
+      },
+      'Props',
+    );
+
     return <Avatar name={name} src={imageUrl} size={size} />;
   });

--- a/src/Avatar/__stories__/Avatar.stories.js
+++ b/src/Avatar/__stories__/Avatar.stories.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { number, text, withKnobs } from '@storybook/addon-knobs';
 
+import Wrapper from '../../Wrapper';
 import { Avatar } from '../..';
 import AvatarReadme from '../README.md';
 
@@ -32,11 +33,11 @@ storiesOf('Avatar', module)
     );
 
     return (
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 120px)' }}>
+      <Wrapper style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 120px)' }}>
         <Avatar name={name1} size={size} />
         <Avatar name={name2} size={size} />
         <Avatar name={name3} size={size} />
-      </div>
+      </Wrapper>
     );
   })
   .add('with an user image', () => {
@@ -59,5 +60,9 @@ storiesOf('Avatar', module)
       'Props',
     );
 
-    return <Avatar name={name} src={imageUrl} size={size} />;
+    return (
+      <Wrapper>
+        <Avatar name={name} src={imageUrl} size={size} />
+      </Wrapper>
+    );
   });

--- a/src/Avatar/index.js
+++ b/src/Avatar/index.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import initials from 'initials';
@@ -19,7 +19,7 @@ const defaultColors = [
 /**
  * Sum Chars
  *
- * Do the sums of the carcatere of a string
+ * Do the sums of the caracteres of a string
  *
  * @return {jsx}
  */
@@ -33,50 +33,57 @@ function sumChars(str) {
 }
 
 /**
- * Avatar
- *
- * This component is in charge of displaying
- * an avatar of a user
+ * An Avatar depicts an user with an image if its path is provided.
+ * It fallbacks to the initials of the person.
  *
  * @return {jsx}
  */
 
-class Avatar extends PureComponent {
+const Avatar = ({ className, name, size, src }) => {
+  const abbr = initials(name);
+  const normalizeSize = size * 10;
+
+  return (
+    <div aria-label={name} className={className}>
+      {src && <Image src={src} width={normalizeSize} height={normalizeSize} alt={name} />}
+      {!src && <span>{abbr}</span>}
+    </div>
+  );
+};
+
+/**
+ * PropTypes validation
+ */
+Avatar.propTypes = {
   /**
-   * PropTypes validation
+   * className needed by styled component
    */
-  static propTypes = {
-    className: PropTypes.string, // className needed by styled component.
-    name: PropTypes.string.isRequired, // user name.
-    size: PropTypes.number, // size of the avatar.
-    src: PropTypes.string, // source image of a user.
-  };
+  className: PropTypes.string,
 
   /**
-   * Default propTypes
+   * name that will form the displayed initials
    */
-  static defaultProps = {
-    className: '',
-    size: Theme.dimensions.bigInt,
-    src: null,
-  };
+  name: PropTypes.string.isRequired,
 
   /**
-   * Render function
+   * size of the avatar
    */
-  render() {
-    const { className, name, size, src } = this.props;
-    const abbr = initials(name);
-    const normalizeSize = size * 10;
+  size: PropTypes.number,
 
-    return (
-      <div aria-label={name} className={className}>
-        {src && <Image src={src} width={normalizeSize} height={normalizeSize} alt={name} />}
-        {!src && <span>{abbr}</span>}
-      </div>
-    );
-  }
-}
+  /**
+   * source image of a user
+   */
+  src: PropTypes.string,
+};
+
+/**
+ * Default propTypes
+ */
+Avatar.defaultProps = {
+  className: '',
+  size: Theme.dimensions.bigInt,
+  src: null,
+};
 
 export default styled(Avatar)`
   display: flex;

--- a/src/Button/README.md
+++ b/src/Button/README.md
@@ -8,31 +8,30 @@ import { Button } from '@tillersystems/stardust';
 
 <!-- STORY -->
 
+### Description
+
+A Button comes in three possible sizes and six visual sizes.  
+An Icon component can be displayed next to the text label of the button, left or right side.
+For now, instance of the Icon must be passed to the Button so styling is rather free.
+
+Button can be a simple standalone button or part of a form.
+
+<!-- PROPS -->
+
 ### Properties
 
-- `appearance` - The base styling to apply to the button.
-- `children` - Anything that can be rendered: numbers, strings, elements or an array (or fragment).
-- `className` - ClassName needed by styled components.
-- `fluid` - Whether the button is fluid or not.
-- `disabled` - Whether the button is disabled or not.
-- `icon` - Add icon node here to illustrate the text aside.
-- `iconPosition` - Set the icon position compared to the text. It will be set to the left side by default.
-- `onClick` - Handler of click on the button.
-- `size` - Whether the button size is small, default or large. It will be set to default by default.
-- `type` - Whether it is a button or a form submission.
-
-| propName       |                                  propType                                   | defaultValue | isRequired |
-| -------------- | :-------------------------------------------------------------------------: | :----------: | :--------: |
-| `appearance`   | `oneOf(['default', 'primary', 'secondary', 'success', 'danger', 'google'])` |  `default`   |     -      |
-| `children`     |                                   `node`                                    |    `null`    |     -      |
-| `className`    |                                  `string`                                   |     `''`     |     -      |
-| `fluid`        |                                   `bool`                                    |   `false`    |     -      |
-| `disabled`     |                                   `bool`                                    |   `false`    |     -      |
-| `icon`         |                                   `node`                                    |    `null`    |     -      |
-| `iconPosition` |                                  `string`                                   |    `left`    |     -      |
-| `onClick`      |                                   `func`                                    |  `() = {}`   |     -      |
-| `size`         |                   `oneOf(['small', 'default', 'large'])`                    |  `default`   |     -      |
-| `type`         |                        `oneOf(['button', 'submit'])`                        |   `button`   |     -      |
+| Name           | Required |                                    Type                                     | DefaultValue |                                        Description                                         |
+| -------------- | :------: | :-------------------------------------------------------------------------: | :----------: | :----------------------------------------------------------------------------------------: |
+| `appearance`   |    -     | `oneOf(['default', 'primary', 'secondary', 'success', 'danger', 'google'])` |  `default`   |                          The base styling to apply to the button                           |
+| `children`     |    -     |                                   `node`                                    |    `null`    |    Anything that can be rendered: numbers, strings, elements or an array (or fragment)     |
+| `className`    |    -     |                                  `string`                                   |     `''`     |                           ClassName needed by styled components                            |
+| `fluid`        |    -     |                                   `bool`                                    |   `false`    |                             Whether the button is fluid or not                             |
+| `disabled`     |    -     |                                   `bool`                                    |   `false`    |                           Whether the button is disabled or not                            |
+| `icon`         |    -     |                                   `node`                                    |    `null`    |                     Adds icon next to the text button to illustrate it                     |
+| `iconPosition` |    -     |                                  `string`                                   |    `left`    |  Sets the icon position compared to the text. It will be set to the left side by default   |
+| `onClick`      |    -     |                                   `func`                                    |  `() = {}`   |                               Handler of click on the button                               |
+| `size`         |    -     |                   `oneOf(['small', 'default', 'large'])`                    |  `default`   | Whether the button size is small, default or large. It will be set to `default` by default |
+| `type`         |    -     |                        `oneOf(['button', 'submit'])`                        |   `button`   |                        Whether it is a button or a form submission                         |
 
 ### Example
 

--- a/src/Button/__stories__/Button.stories.js
+++ b/src/Button/__stories__/Button.stories.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, boolean, color, select } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
+import withDocs from 'storybook-readme/with-docs';
 
 import { Icon, Theme } from '../..';
 import Button from '..';
@@ -12,13 +13,13 @@ const getIconName = Object.keys(IconName).map(name => name);
 
 storiesOf('Button', module)
   .addDecorator(withKnobs)
+  .addDecorator(withDocs(ButtonReadme)) // Show readme around story
   .addParameters({
     readme: {
-      // Show readme before story
-      content: ButtonReadme,
+      includePropTables: [Button], // won't work right now because of wrapped styled-comp https://github.com/tuchk4/storybook-readme/issues/177
     },
   })
-  .add('with properties', () => {
+  .add('with customizable properties', () => {
     const onClickAction = action('onClick');
     const appearance = select(
       'Appearance',
@@ -30,8 +31,8 @@ storiesOf('Button', module)
         failure: 'failure',
         google: 'google',
       },
-      'default',
-      'State',
+      'secondary',
+      'Props',
     );
     const size = select(
       'Size',
@@ -41,9 +42,9 @@ storiesOf('Button', module)
         large: 'large',
       },
       'default',
-      'Layout',
+      'Props',
     );
-    const fluid = boolean('Fluid', false, 'Layout');
+    const fluid = boolean('Fluid', false, 'Props');
     const iconPosition = select(
       'Icon Position',
       {
@@ -51,10 +52,19 @@ storiesOf('Button', module)
         right: 'right',
       },
       'left',
-      'Layout',
+      'Props',
     );
-    const iconName = select('Icon Name', getIconName, 'calendar', 'Layout');
-    const disabled = boolean('Disabled', false, 'State');
+    const iconName = select('Icon Name', getIconName, 'calendar', 'Props');
+    const disabled = boolean('Disabled', false, 'Props');
+    const type = select(
+      'Type',
+      {
+        button: 'button',
+        submit: 'submit',
+      },
+      'button',
+      'Props',
+    );
     const withIcon = boolean('With Icon', false, 'Layout');
     const colorValue = color('Icon Color', Theme.palette.darkBlue, 'Layout');
 
@@ -67,6 +77,7 @@ storiesOf('Button', module)
         iconPosition={withIcon ? iconPosition : undefined}
         onClick={() => onClickAction(appearance)}
         size={size}
+        type={type}
       >
         Default
       </Button>

--- a/src/Button/__stories__/Button.stories.js
+++ b/src/Button/__stories__/Button.stories.js
@@ -4,6 +4,7 @@ import { withKnobs, boolean, color, select } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import withDocs from 'storybook-readme/with-docs';
 
+import Wrapper from '../../Wrapper';
 import { Icon, Theme } from '../..';
 import Button from '..';
 import { Data as IconName } from '../../Icon/data';
@@ -69,17 +70,19 @@ storiesOf('Button', module)
     const colorValue = color('Icon Color', Theme.palette.darkBlue, 'Layout');
 
     return (
-      <Button
-        appearance={appearance}
-        disabled={disabled}
-        fluid={fluid}
-        icon={withIcon ? <Icon color={colorValue} name={iconName} /> : undefined}
-        iconPosition={withIcon ? iconPosition : undefined}
-        onClick={() => onClickAction(appearance)}
-        size={size}
-        type={type}
-      >
-        Default
-      </Button>
+      <Wrapper>
+        <Button
+          appearance={appearance}
+          disabled={disabled}
+          fluid={fluid}
+          icon={withIcon ? <Icon color={colorValue} name={iconName} /> : undefined}
+          iconPosition={withIcon ? iconPosition : undefined}
+          onClick={() => onClickAction(appearance)}
+          size={size}
+          type={type}
+        >
+          Default
+        </Button>
+      </Wrapper>
     );
   });

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -5,21 +5,11 @@ import styled from 'styled-components';
 import { Container, ContainerIcon } from './elements';
 
 /**
- * Button
+ * A Button comes in three possible sizes and six visual sizes.
+ * An Icon component can be displayed next to the text label of the button, left or right side.
+ * For now, instance of the Icon must be passed to the Button so styling is rather free.
  *
- * This component is in charge of displaying
- * a button
- *
- * @param {string} appearance // The base styling to apply to the button.
- * @param {node} children // Anything that can be rendered: numbers, strings, elements or an array (or fragment).
- * @param {string} className // ClassName needed by styled components.
- * @param {bool} fluid // Whether the button is fluid or not.
- * @param {bool} disabled // Whether the button is disabled or not.
- * @param {node} icon // Add icon node here to illustrate the text aside.
- * @param {enum} iconPosition // Set the icon position compared to the text. It will be set to the left side by default.
- * @param {function} onClick // Handler of click on the button.
- * @param {enum} size // Whether the button size is small, default or large. It will be set to default by default.
- * @param {enum} type // Whether it is a button or a form submission.
+ * Button can be a simple standalone button or part of a form.
  *
  * @return {jsx}
  */
@@ -82,15 +72,54 @@ const displayIcon = (side, icon) => {
  */
 const { bool, func, node, oneOf, string } = PropTypes;
 Button.propTypes = {
+  /**
+   * The base styling to apply to the button
+   */
   appearance: oneOf(['default', 'primary', 'secondary', 'success', 'danger', 'google']),
+
+  /**
+   * Anything that can be rendered: numbers, strings, elements or an array (or fragment)
+   */
   children: node,
+
+  /**
+   * ClassName needed by styled components
+   */
   className: string,
+
+  /**
+   * Whether the button is disabled or not
+   */
   disabled: bool,
+
+  /**
+   * Whether the button is fluid or not
+   */
   fluid: bool,
+
+  /**
+   * Adds icon next to the text button to illustrate it
+   */
   icon: node,
+
+  /**
+   * Sets the icon position compared to the text. It will be set to the left side by default
+   */
   iconPosition: string,
+
+  /**
+   * Handler of click on the button
+   */
   onClick: func,
+
+  /**
+   * Whether the button size is small, default or large. It will be set to `default` by default
+   */
   size: oneOf(['small', 'default', 'large']),
+
+  /**
+   * Whether it is a button or a form submission
+   */
   type: oneOf(['button', 'submit']),
 };
 

--- a/src/ButtonGroup/README.md
+++ b/src/ButtonGroup/README.md
@@ -8,19 +8,21 @@ import { ButtonGroup } from '@tillersystems/stardust';
 
 <!-- STORY -->
 
+<!-- PROPS -->
+
+### Description
+
+A ButtonGroup wraps as much Buttons as it is given as children.  
+Only one Button is active at a time. Each Button is cloned as is, meaning you could provide Buttons with different styles.
+
 ### Properties
 
-- `children` - Anything that can be rendered: numbers, strings, elements or an array (or fragment).
-- `className` - Add a text aside in the select next the selected value.
-- `onChange` - Callback function called when a button is clicked.
-- `defaultActiveButton` - Specifies the initial state: witch button is selected.
-
-| propName              | propType | defaultValue | isRequired |
-| --------------------- | :------: | :----------: | :--------: |
-| `children`            |  `node`  |    `null`    |     -      |
-| `className`           | `string` |     `''`     |     -      |
-| `onChange`            |  `func`  |  `() => {}`  |     -      |
-| `defaultActiveButton` | `string` |     `''`     |     -      |
+| Name                      | Required |   Type   | DefaultValue |                                     Description                                     |
+| ------------------------- | :------: | :------: | :----------: | :---------------------------------------------------------------------------------: |
+| `children`                |    -     |  `node`  |    `null`    | Anything that can be rendered: numbers, strings, elements or an array (or fragment) |
+| `className`               |    -     | `string` |     `''`     |                        ClassName needed by styled components                        |
+| `defaultActiveButtonName` |    -     | `string` |     `''`     |                    Specifies which button is initially selected                     |
+| `onChange`                |    -     | `string` |     `''`     |                  Callback function called when a button is clicked                  |
 
 ### Example
 

--- a/src/ButtonGroup/__stories__/ButtonGroup.stories.js
+++ b/src/ButtonGroup/__stories__/ButtonGroup.stories.js
@@ -14,12 +14,25 @@ storiesOf('ButtonGroup', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-      // Show readme before story
+      // Show readme around story
       content: ButtonGroupReadme,
+      includePropTables: [ButtonGroup], // won't work right now because of wrapped styled-comp https://github.com/tuchk4/storybook-readme/issues/177
     },
   })
-  .add('with properties', () => {
-    const onClickAction = action('onClick');
+  .add('with customizable properties', () => {
+    const buttonGroupProps = {
+      onChange: action('onClick'),
+      defaultActiveButtonName: select(
+        'defaultActiveButtonName',
+        {
+          ON: 'ON',
+          OFF: 'OFF',
+        },
+        'ON',
+        'Props',
+      ),
+    };
+
     const appearance = select(
       'Appearance',
       {
@@ -30,8 +43,8 @@ storiesOf('ButtonGroup', module)
         failure: 'failure',
         google: 'google',
       },
-      'default',
-      'State',
+      'secondary',
+      'Button Props',
     );
     const iconPosition = select(
       'Icon Position',
@@ -40,30 +53,29 @@ storiesOf('ButtonGroup', module)
         right: 'right',
       },
       'left',
-      'Layout',
+      'Button Props',
     );
-    const withIcon = boolean('With Icon', false, 'Layout');
-    const iconName = select('Icon Name', getIconName, 'calendar', 'Layout');
+    const withIcon = boolean('With Icon', false, 'Button Props');
+    const iconName = select('Icon Name', getIconName, 'calendar', 'Button Props');
+
     return (
-      <div>
-        <ButtonGroup defaultActiveButtonName="ON" onChange={name => onClickAction(name)}>
-          <Button
-            name="ON"
-            appearance={appearance}
-            icon={withIcon ? <Icon color={Theme.palette.white} name={iconName} /> : undefined}
-            iconPosition={withIcon ? iconPosition : undefined}
-          >
-            ON
-          </Button>
-          <Button
-            name="OFF"
-            appearance={appearance}
-            icon={withIcon ? <Icon color={Theme.palette.white} name={iconName} /> : undefined}
-            iconPosition={withIcon ? iconPosition : undefined}
-          >
-            OFF
-          </Button>
-        </ButtonGroup>
-      </div>
+      <ButtonGroup {...buttonGroupProps}>
+        <Button
+          name="ON"
+          appearance={appearance}
+          icon={withIcon ? <Icon color={Theme.palette.white} name={iconName} /> : undefined}
+          iconPosition={withIcon ? iconPosition : undefined}
+        >
+          ON
+        </Button>
+        <Button
+          name="OFF"
+          appearance={appearance}
+          icon={withIcon ? <Icon color={Theme.palette.white} name={iconName} /> : undefined}
+          iconPosition={withIcon ? iconPosition : undefined}
+        >
+          OFF
+        </Button>
+      </ButtonGroup>
     );
   });

--- a/src/ButtonGroup/__stories__/ButtonGroup.stories.js
+++ b/src/ButtonGroup/__stories__/ButtonGroup.stories.js
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { withKnobs, boolean, select } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
+import Wrapper from '../../Wrapper';
 import { Button, Icon, Theme } from '../..';
 import ButtonGroup from '..';
 import { Data as IconName } from '../../Icon/data';
@@ -59,23 +60,25 @@ storiesOf('ButtonGroup', module)
     const iconName = select('Icon Name', getIconName, 'calendar', 'Button Props');
 
     return (
-      <ButtonGroup {...buttonGroupProps}>
-        <Button
-          name="ON"
-          appearance={appearance}
-          icon={withIcon ? <Icon color={Theme.palette.white} name={iconName} /> : undefined}
-          iconPosition={withIcon ? iconPosition : undefined}
-        >
-          ON
-        </Button>
-        <Button
-          name="OFF"
-          appearance={appearance}
-          icon={withIcon ? <Icon color={Theme.palette.white} name={iconName} /> : undefined}
-          iconPosition={withIcon ? iconPosition : undefined}
-        >
-          OFF
-        </Button>
-      </ButtonGroup>
+      <Wrapper>
+        <ButtonGroup {...buttonGroupProps}>
+          <Button
+            name="ON"
+            appearance={appearance}
+            icon={withIcon ? <Icon color={Theme.palette.white} name={iconName} /> : undefined}
+            iconPosition={withIcon ? iconPosition : undefined}
+          >
+            ON
+          </Button>
+          <Button
+            name="OFF"
+            appearance={appearance}
+            icon={withIcon ? <Icon color={Theme.palette.white} name={iconName} /> : undefined}
+            iconPosition={withIcon ? iconPosition : undefined}
+          >
+            OFF
+          </Button>
+        </ButtonGroup>
+      </Wrapper>
     );
   });

--- a/src/ButtonGroup/index.js
+++ b/src/ButtonGroup/index.js
@@ -5,43 +5,14 @@ import { transparentize } from 'polished';
 
 import Button from '../Button';
 
-const { func, node, string } = PropTypes;
-
 /**
- * Button Group
- *
- * This component is in charge of displaying
- * a button group
- *
- * @param {node} children // Anything that can be rendered: numbers, strings, elements or an array (or fragment).
- * @param {string} className // Add a text aside in the select next the selected value.
- * @param {function} onChange // Callback function called when a button is clicked.
- * @param {string} defaultActiveButton // Specifies the initial state: witch button is selected.
+ * A ButtonGroup wraps as much Buttons as it is given as children.
+ * Only one Button is active at a time. Each Button is cloned as is, meaning
+ * you could provide Buttons with different styles.
  *
  * @return {jsx}
  */
-
 class ButtonGroup extends PureComponent {
-  /**
-   * PropTypes Validation.
-   */
-  static propTypes = {
-    children: node,
-    className: string,
-    onChange: func,
-    defaultActiveButtonName: string,
-  };
-
-  /**
-   * Default props.
-   */
-  static defaultProps = {
-    children: null,
-    className: '',
-    onChange: () => {},
-    defaultActiveButtonName: '',
-  };
-
   /** Internal state. */
   state = {
     activeButton: this.props.defaultActiveButtonName, // eslint-disable-line react/destructuring-assignment
@@ -96,6 +67,43 @@ class ButtonGroup extends PureComponent {
     );
   }
 }
+
+const { func, node, string } = PropTypes;
+
+/**
+ * PropTypes Validation.
+ */
+ButtonGroup.propTypes = {
+  /**
+   * Anything that can be rendered: numbers, strings, elements or an array (or fragment)
+   */
+  children: node,
+
+  /**
+   * ClassName needed by styled components
+   */
+  className: string,
+
+  /**
+   * Specifies which button is initially selected
+   */
+  defaultActiveButtonName: string,
+
+  /**
+   * Callback function called when a button is clicked
+   */
+  onChange: func,
+};
+
+/**
+ * Default props.
+ */
+ButtonGroup.defaultProps = {
+  children: null,
+  className: '',
+  defaultActiveButtonName: '',
+  onChange: () => {},
+};
 
 export default styled(ButtonGroup)`
   display: flex;

--- a/src/CheckBox/README.md
+++ b/src/CheckBox/README.md
@@ -8,23 +8,24 @@ import { CheckBox } from '@tillersystems/stardust';
 
 <!-- STORY -->
 
+<!-- PROPS -->
+
+### Description
+
+A CheckBox depicts a binary state if used alone, just as a ToggleButton, the difference being
+that ToggleButton triggers the callback with the new state value, whereas the CheckBox
+just triggers the callback without any argument so the parent needs to keep track by itself.
+
 ### Properties
 
-- `children` - Anything that can be rendered: numbers, strings, elements or an array (or fragment).
-- `className` - Add a text aside in the select next the selected value.
-- `checked` - Specifies whether the checkbox is selected.
-- `disabled` - Specifies whether the checkbox is disabled.
-- `onChange` - Callback whence clicked.
-- `value` - The value to be used in the checkbox input. This is the value that will be returned on form submission.
-
-| propName    | propType | defaultValue | isRequired |
-| ----------- | :------: | :----------: | :--------: |
-| `children`  |  `node`  |    `null`    |     -      |
-| `className` | `string` |     `''`     |     -      |
-| `checked`   |  `bool`  | `undefined`  |     -      |
-| `disabled`  |  `bool`  |   `false`    |     -      |
-| `onChange`  |  `func`  |    `null`    |     -      |
-| `value`     | `string` |     `''`     |     -      |
+| Name        | Required |   Type   | DefaultValue |                                               Description                                               |
+| ----------- | :------: | :------: | :----------: | :-----------------------------------------------------------------------------------------------------: |
+| `children`  |    -     |  `node`  |    `null`    |           Anything that can be rendered: numbers, strings, elements or an array (or fragment)           |
+| `className` |    -     | `string` |     `''`     |                                  ClassName needed by styled components                                  |
+| `checked`   |    -     |  `bool`  | `undefined`  |                                Specifies whether the checkbox is checked                                |
+| `disabled`  |    -     |  `bool`  |   `false`    |                               Specifies whether the checkbox is disabled                                |
+| `onChange`  |    -     |  `func`  |    `null`    |                               Callback triggered on CheckBox state change                               |
+| `value`     |    -     | `string` |     `''`     | The value to be used in the checkbox input. This is the value that will be returned on form submission. |
 
 ### Example
 

--- a/src/CheckBox/__stories__/CheckBox.stories.js
+++ b/src/CheckBox/__stories__/CheckBox.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, boolean } from '@storybook/addon-knobs';
+import { boolean, text, withKnobs } from '@storybook/addon-knobs';
 import { State, Store } from '@sambego/storybook-state';
 import { action } from '@storybook/addon-actions';
 
@@ -19,33 +19,35 @@ storiesOf('CheckBox', module)
       content: CheckBoxReadme,
     },
   })
-  .add('default', () => {
-    const enabledValue = boolean('Enabled', true, 'state');
+  .add('uncontrolled state', () => {
+    const disabledValue = boolean('Disabled', false, 'Props');
+    const value = text('Value', 'I am a value', 'Props');
+
     const onChangeAction = action('onChange');
 
     return (
       <>
-        <CheckBox checked disabled={!enabledValue} onChange={() => onChangeAction()}>
+        <CheckBox checked disabled={disabledValue} onChange={() => onChangeAction()} value={value}>
           A really cool choice
         </CheckBox>
-        <CheckBox disabled={!enabledValue} onChange={() => onChangeAction()}>
+        <CheckBox disabled={disabledValue} onChange={() => onChangeAction()} value={value}>
           A really cool choice
         </CheckBox>
-        <CheckBox disabled={!enabledValue} onChange={() => onChangeAction()}>
+        <CheckBox disabled={disabledValue} onChange={() => onChangeAction()} value={value}>
           A really cool choice
         </CheckBox>
       </>
     );
   })
-  .add('controlled', () => {
-    const enabledValue = boolean('Enabled', true, 'state');
+  .add('controlled state', () => {
+    const disabledValue = boolean('Disabled', false, 'Props');
 
     return (
       <State store={store}>
         {state => (
           <CheckBox
             checked={state.checked}
-            disabled={!enabledValue}
+            disabled={disabledValue}
             onChange={() => store.set({ checked: !store.get('checked') })}
           >
             What?

--- a/src/CheckBox/__stories__/CheckBox.stories.js
+++ b/src/CheckBox/__stories__/CheckBox.stories.js
@@ -4,6 +4,7 @@ import { boolean, text, withKnobs } from '@storybook/addon-knobs';
 import { State, Store } from '@sambego/storybook-state';
 import { action } from '@storybook/addon-actions';
 
+import Wrapper from '../../Wrapper';
 import { CheckBox } from '../..';
 import CheckBoxReadme from '../README.md';
 
@@ -26,7 +27,7 @@ storiesOf('CheckBox', module)
     const onChangeAction = action('onChange');
 
     return (
-      <>
+      <Wrapper>
         <CheckBox checked disabled={disabledValue} onChange={() => onChangeAction()} value={value}>
           A really cool choice
         </CheckBox>
@@ -36,23 +37,25 @@ storiesOf('CheckBox', module)
         <CheckBox disabled={disabledValue} onChange={() => onChangeAction()} value={value}>
           A really cool choice
         </CheckBox>
-      </>
+      </Wrapper>
     );
   })
   .add('controlled state', () => {
     const disabledValue = boolean('Disabled', false, 'Props');
 
     return (
-      <State store={store}>
-        {state => (
-          <CheckBox
-            checked={state.checked}
-            disabled={disabledValue}
-            onChange={() => store.set({ checked: !store.get('checked') })}
-          >
-            What?
-          </CheckBox>
-        )}
-      </State>
+      <Wrapper>
+        <State store={store}>
+          {state => (
+            <CheckBox
+              checked={state.checked}
+              disabled={disabledValue}
+              onChange={() => store.set({ checked: !store.get('checked') })}
+            >
+              What?
+            </CheckBox>
+          )}
+        </State>
+      </Wrapper>
     );
   });

--- a/src/CheckBox/index.js
+++ b/src/CheckBox/index.js
@@ -7,42 +7,14 @@ import Theme from '../Theme';
 import { Label, HiddenCheckbox, StyledCheckbox } from './elements';
 
 /**
- * CheckBox
- *
- * This component is in charge of displaying
- * a checkBox
- *
- * @param {node} children // Anything that can be rendered: numbers, strings, elements or an array (or fragment).
- * @param {string} className // Add a text aside in the select next the selected value.
- * @param {boolean} checked // Specifies whether the checkbox is selected.
- * @param {boolean} disabled // Specifies whether the checkbox is disabled.
- * @param {function} onChange // Callback whence clicked.
- * @param {string} value // The value to be used in the checkbox input. This is the value that will be returned on form submission.
+ * A CheckBox depicts a binary state if used alone, just as a ToggleButton, the difference being
+ * that ToggleButton triggers the callback with the new state value, whereas the CheckBox
+ * just triggers the callback without any argument so the parent needs to keep track by itself.
  *
  * @return {jsx}
  */
 
 class CheckBox extends PureComponent {
-  /** Prop types. */
-  static propTypes = {
-    children: PropTypes.node,
-    className: PropTypes.string,
-    checked: PropTypes.bool,
-    disabled: PropTypes.bool,
-    onChange: PropTypes.func,
-    value: PropTypes.string,
-  };
-
-  /** Default props. */
-  static defaultProps = {
-    children: null,
-    className: '',
-    checked: false,
-    disabled: false,
-    onChange: null,
-    value: '',
-  };
-
   /** Internal state. */
   state = {
     checked: this.props.checked, // eslint-disable-line
@@ -55,7 +27,7 @@ class CheckBox extends PureComponent {
   componentDidUpdate(prevProps) {
     const { checked } = this.props;
 
-    // Update state only if props are changed
+    // Update state only if props have changed
     if (prevProps.checked !== checked) {
       this.setState({
         checked,
@@ -69,15 +41,17 @@ class CheckBox extends PureComponent {
    */
   handleChange = () => {
     const { onChange, disabled } = this.props;
-    const { checked } = this.state;
 
     if (disabled) {
       return;
     }
 
-    this.setState({ checked: !checked }, () => {
-      onChange;
-    });
+    this.setState(
+      prevState => ({ checked: !prevState.checked }),
+      () => {
+        onChange;
+      },
+    );
   };
 
   /**
@@ -109,6 +83,49 @@ class CheckBox extends PureComponent {
     );
   }
 }
+
+/** Prop types. */
+CheckBox.propTypes = {
+  /**
+   * Anything that can be rendered: numbers, strings, elements or an array (or fragment)
+   */
+  children: PropTypes.node,
+
+  /**
+   * ClassName needed by styled components
+   */
+  className: PropTypes.string,
+
+  /**
+   * Specifies whether the checkbox is checked
+   */
+  checked: PropTypes.bool,
+
+  /**
+   * Specifies whether the checkbox is disabled
+   */
+  disabled: PropTypes.bool,
+
+  /**
+   * Callback triggered on CheckBox state change
+   */
+  onChange: PropTypes.func,
+
+  /**
+   * The value to be used in the checkbox input. This is the value that will be returned on form submission.
+   */
+  value: PropTypes.string,
+};
+
+/** Default props. */
+CheckBox.defaultProps = {
+  children: null,
+  className: '',
+  checked: false,
+  disabled: false,
+  onChange: null,
+  value: '',
+};
 
 export default styled(CheckBox)`
   width: 100%;

--- a/src/Counter/README.md
+++ b/src/Counter/README.md
@@ -8,29 +8,25 @@ import { Counter } from '@tillersystems/stardust';
 
 <!-- STORY -->
 
+<!-- PROPS -->
+
+### Description
+
+A Counter is a number value that can be updated by two Buttons surrounding the displayed value.
+
 ### Properties
 
-- `appearance` - Button appareance.
-- `className` - className needed by styled component.
-- `max` - Maximum value allowed.
-- `min` - Minimum value allowed.
-- `onIncrement` - Callback function called on increment.
-- `onDecrement` - Callback function called on decrement.
-- `step` - step for increment/decrement value.
-- `value` - incremented/decremented value. The value is set to 0 if no value provided.
-- `width` - the width of the input.
-
-| propName      | propType | defaultValue | isRequired |
-| ------------- | :------: | :----------: | :--------: |
-| `appareance`  | `string` | `secondary`  |     -      |
-| `className`   | `string` |     `''`     |     -      |
-| `max`         | `number` |    `100`     |     -      |
-| `min`         | `number` |     `0`      |     -      |
-| `onIncrement` |  `func`  |  `() => {}`  |     -      |
-| `onDecrement` |  `func`  |  `() => {}`  |     -      |
-| `step`        | `number` |     `1`      |     -      |
-| `value`       | `number` |     `0`      |     -      |
-| `width`       | `string` |    `5rem`    |     -      |
+| Name          | Required |   Type   | DefaultValue |                               Description                               |
+| ------------- | :------: | :------: | :----------: | :---------------------------------------------------------------------: |
+| `appareance`  |    -     | `string` | `secondary`  |              Buttons appearance prop customizing the style              |
+| `className`   |    -     | `string` |     `''`     |                  ClassName needed by styled components                  |
+| `max`         |    -     | `number` |    `100`     |                          Maximum value allowed                          |
+| `min`         |    -     | `number` |     `0`      |                          Minimum value allowed                          |
+| `onIncrement` |    -     |  `func`  |  `() => {}`  |                  Callback function called on increment                  |
+| `onDecrement` |    -     |  `func`  |  `() => {}`  |                  Callback function called on decrement                  |
+| `step`        |    -     | `number` |     `1`      |                Step for incrementing/decrementing value                 |
+| `value`       |    -     | `number` |     `0`      | Value of counter. The value is set to 0 if no value is provided by prop |
+| `width`       |    -     | `string` |    `5rem`    |                         The width of the input                          |
 
 ### Example
 

--- a/src/Counter/__stories__/Counter.stories.js
+++ b/src/Counter/__stories__/Counter.stories.js
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { withKnobs, number, select } from '@storybook/addon-knobs';
 import { State, Store } from '@sambego/storybook-state';
 
+import Wrapper from '../../Wrapper';
 import { Counter } from '../..';
 import CounterReadme from '../README.md';
 
@@ -80,19 +81,21 @@ storiesOf('Counter', module)
     const OnDecrement = () => store.set({ count: store.get('count') - 1 });
 
     return (
-      <State store={store}>
-        {state => (
-          <Counter
-            step={step}
-            max={max}
-            min={min}
-            onIncrement={() => OnIncrement()}
-            onDecrement={() => OnDecrement()}
-            countValue={state.count}
-            appearance={appearance}
-            width={`${widthValue}rem`}
-          />
-        )}
-      </State>
+      <Wrapper>
+        <State store={store}>
+          {state => (
+            <Counter
+              step={step}
+              max={max}
+              min={min}
+              onIncrement={() => OnIncrement()}
+              onDecrement={() => OnDecrement()}
+              countValue={state.count}
+              appearance={appearance}
+              width={`${widthValue}rem`}
+            />
+          )}
+        </State>
+      </Wrapper>
     );
   });

--- a/src/Counter/__stories__/Counter.stories.js
+++ b/src/Counter/__stories__/Counter.stories.js
@@ -14,11 +14,11 @@ storiesOf('Counter', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-      // Show readme before story
+      // Show readme around story
       content: CounterReadme,
     },
   })
-  .add('default', () => {
+  .add('Uncontrolled state', () => {
     const step = number(
       'Step',
       1,
@@ -28,7 +28,7 @@ storiesOf('Counter', module)
         max: 100,
         step: 1,
       },
-      'step',
+      'Props',
     );
     const max = number(
       'Max value',
@@ -39,7 +39,7 @@ storiesOf('Counter', module)
         max: 100,
         step: 1,
       },
-      'max',
+      'Props',
     );
     const min = number(
       'Min value',
@@ -50,7 +50,7 @@ storiesOf('Counter', module)
         max: 100,
         step: 1,
       },
-      'min',
+      'Props',
     );
     const appearance = select(
       'Appearance',
@@ -63,7 +63,7 @@ storiesOf('Counter', module)
         google: 'google',
       },
       'secondary',
-      'State',
+      'Props',
     );
     const widthValue = number(
       'Width',
@@ -74,7 +74,7 @@ storiesOf('Counter', module)
         max: 50,
         step: 1,
       },
-      'Size',
+      'Props',
     );
     const OnIncrement = () => store.set({ count: store.get('count') + 1 });
     const OnDecrement = () => store.set({ count: store.get('count') - 1 });

--- a/src/Counter/index.js
+++ b/src/Counter/index.js
@@ -8,54 +8,11 @@ import { FakeInput } from './elements';
 const { func, number, string } = PropTypes;
 
 /**
- * Counter.
- *
- * This component is in charge of displaying
- * an Counter component.
- *
- * @param {string} appearance // Button appareance.
- * @param {string} className // className needed by styled component.
- * @param {number} max // Maximum value allowed.
- * @param {number} min // Minimum value allowed.
- * @param {func} onIncrement // Callback function called on increment.
- * @param {func} onDecrement // Callback function called on decrement.
- * @param {number} step // Step for increment / decrement value.
- * @param {number} value // incremented/decremented value. The value is set to 0 if no value provided.
- * @param {string} width // The width of the input.
+ * A Counter is a number value that can be updated by two Buttons surrounding the displayed value.
  *
  * @return {jsx}
  */
 class Counter extends PureComponent {
-  /**
-   * PropTypes Validation.
-   */
-  static propTypes = {
-    appearance: string,
-    className: string,
-    max: number,
-    min: number,
-    onIncrement: func,
-    onDecrement: func,
-    step: number,
-    value: number,
-    width: string,
-  };
-
-  /**
-   * Default props.
-   */
-  static defaultProps = {
-    className: '',
-    value: 0,
-    step: 1,
-    max: 1000,
-    min: 0,
-    width: '5rem',
-    appearance: 'secondary',
-    onIncrement: () => {},
-    onDecrement: () => {},
-  };
-
   state = {
     count: this.props.value, // eslint-disable-line react/destructuring-assignment,
   };
@@ -137,6 +94,71 @@ class Counter extends PureComponent {
     );
   }
 }
+
+/**
+ * PropTypes Validation.
+ */
+Counter.propTypes = {
+  /**
+   * Buttons appearance prop customizing the style
+   */
+  appearance: string,
+
+  /**
+   * ClassName needed by styled components
+   */
+  className: string,
+
+  /**
+   * Maximum value allowed
+   */
+  max: number,
+
+  /**
+   * Minimum value allowed
+   */
+  min: number,
+
+  /**
+   * Callback function called on increment
+   */
+  onIncrement: func,
+
+  /**
+   * Callback function called on decrement
+   */
+  onDecrement: func,
+
+  /**
+   * Step for incrementing/decrementing value
+   */
+  step: number,
+
+  /**
+   * Value of counter. The value is set to 0 if no value is provided by prop
+   */
+  value: number,
+
+  /**
+   * The width of the input
+   */
+  width: string,
+};
+
+/**
+ * Default props.
+ */
+Counter.defaultProps = {
+  appearance: 'secondary',
+  className: '',
+  max: 1000,
+  min: 0,
+  onIncrement: () => {},
+  onDecrement: () => {},
+  step: 1,
+  value: 0,
+  width: '5rem',
+};
 
 export default styled(Counter)`
   display: flex;

--- a/src/DatePicker/README.md
+++ b/src/DatePicker/README.md
@@ -8,35 +8,34 @@ import { DatePicker } from '@tillersystems/stardust';
 
 <!-- STORY -->
 
+<!-- PROPS -->
+
+### Description
+
+A DatePicker can display one or two months. It takes a value (`defaultValue` prop) to set its internal
+selected value state, or takes the date of today by default.
+The selected value can either be a date or an interval of Luxon.
+
 ### Properties
 
-- `className` - Class needed by styled component.
-- `locale` - The locale to display the weekday names.
-- `value` - The value of the selected date (controlled mode).
-- `minDate` - The minimum selectable date.
-- `maxDate` - The maximum selectable date.
-- `numberOfMonthsToDisplay` - The number of month to display (1 or 2).
-- `onDateChanged` - Handler of date change.
-- `rangePicker` - Whether it is a date picker or a date range picker.
-
-| `propName`                |     propType     | defaultValue | isRequired |
-| ------------------------- | :--------------: | :----------: | :--------: |
-| `className`               |     `string`     |     `''`     |     -      |
-| `locale`                  |     `string`     |     `en`     |     -      |
-| `value`                   | `luxon.DateTime` |    `null`    |     -      |
-| `minDate`                 | `luxon.DateTime` |    `null`    |     -      |
-| `maxDate`                 | `luxon.DateTime` |    `null`    |     -      |
-| `numberOfMonthsToDisplay` |     `number`     |     `1`      |     -      |
-| `onDateChanged`           |    `function`    |  `() => {}`  |     -      |
-| `rangePicker`             |    `boolean`     |   `false`    |     -      |
+| Name                      | Required |       Type       | DefaultValue |                    Description                     |
+| ------------------------- | :------: | :--------------: | :----------: | :------------------------------------------------: |
+| `className`               |    -     |     `string`     |     `''`     |            Styled component class name             |
+| `defaultValue`            |    -     | `luxon.DateTime` |    `null`    |           Controlled selected date value           |
+| `locale`                  |    -     |     `string`     |     `en`     |      Locale used to display the weekday names      |
+| `minDate`                 |    -     | `luxon.DateTime` |    `null`    |                Minimum allowed date                |
+| `maxDate`                 |    -     | `luxon.DateTime` |    `null`    |                Maximum allowed date                |
+| `numberOfMonthsToDisplay` |    -     |     `number`     |     `1`      |      The number of months to display (1 or 2)      |
+| `onDateChanged`           |    -     |    `function`    |  `() => {}`  |               Handler of date change               |
+| `rangePicker`             |    -     |    `boolean`     |   `false`    | Whether it is a date picker or a date range picker |
 
 ### Examples
 
 The `DatePicker` can be used in two modes, in either controlled or uncontrolled mode.
 In uncontrolled mode, the `DatePicker` manages the selected date internally (yet, the `onDateChanged`
-handler is called upon changes). In controlled mode, the selected date is based on the given `value`
+handler is called upon changes). In controlled mode, the selected date is based on the given `defaultValue`
 prop. The `onDateChanged` handler is called upon user changes, but the selected value won't be affected
-unless the `value` prop is updated.
+unless the `defaultValue` prop is updated.
 
 #### Uncontrolled example
 
@@ -59,6 +58,6 @@ let value = DateTime.locale();
 handleChange = date => value = date;
 
 render() {
-  return <DatePicker value={value} onChange={handleChange} />
+  return <DatePicker defaultValue={value} onChange={handleChange} />
 }
 ```

--- a/src/DatePicker/__stories__/DatePicker.stories.js
+++ b/src/DatePicker/__stories__/DatePicker.stories.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, select, date, boolean, number } from '@storybook/addon-knobs';
-import { State, Store } from '@sambego/storybook-state';
 import { action } from '@storybook/addon-actions';
 import { DateTime, Interval } from 'luxon';
 
@@ -11,10 +10,6 @@ import DatePickerReadme from '../README.md';
 const onChangeAction = action('onChange');
 const today = new Date();
 
-const store = new Store({
-  currentDate: DateTime.local(),
-});
-
 storiesOf('DatePicker', module)
   .addDecorator(withKnobs)
   .addParameters({
@@ -23,7 +18,7 @@ storiesOf('DatePicker', module)
       content: DatePickerReadme,
     },
   })
-  .add('default', () => {
+  .add('uncontrolled state', () => {
     const localeValue = select(
       'Locale',
       {
@@ -31,22 +26,22 @@ storiesOf('DatePicker', module)
         French: 'fr',
       },
       'English',
-      'Locale',
+      'Props',
     );
 
-    const withMinDate = boolean('With minimum date', false, 'Bounds');
-    const minDateValue = date('Minimum date', today, 'Bounds');
-    const withMaxDate = boolean('With maximum date', false, 'Bounds');
-    const maxDateValue = date('Maximum date', today, 'Bounds');
+    const withMinDate = boolean('With minimum date', false, 'Props');
+    const minDateValue = date('Minimum date', today, 'Props');
+    const withMaxDate = boolean('With maximum date', false, 'Props');
+    const maxDateValue = date('Maximum date', today, 'Props');
 
     const numberOfMonthsToDisplay = number(
-      'Number of month to display',
+      'Number of months to display',
       1,
       { range: true, min: 1, max: 2, step: 1 },
-      'Bounds',
+      'Props',
     );
 
-    const isRange = boolean('Range date picker', false, 'Type');
+    const isRange = boolean('Range date picker', false, 'Props');
 
     return (
       <div style={{ background: 'white', padding: '16px', borderRadius: '4px' }}>
@@ -61,7 +56,7 @@ storiesOf('DatePicker', module)
       </div>
     );
   })
-  .add('controlled', () => {
+  .add('controlled state', () => {
     const localeValue = select(
       'Locale',
       {
@@ -69,42 +64,39 @@ storiesOf('DatePicker', module)
         French: 'fr',
       },
       'English',
-      'Locale',
+      'Props',
     );
 
-    const withMinDate = boolean('With minimum date', false, 'Bounds');
-    const minDateValue = date('Minimum date', today, 'Bounds');
-    const withMaxDate = boolean('With maximum date', false, 'Bounds');
-    const maxDateValue = date('Maximum date', today, 'Bounds');
+    const defaultValue = date('Default date', today, 'Props');
+    const withMinDate = boolean('With minimum date', false, 'Props');
+    const minDateValue = date('Minimum date', today, 'Props');
+    const withMaxDate = boolean('With maximum date', false, 'Props');
+    const maxDateValue = date('Maximum date', today, 'Props');
 
     const numberOfMonthsToDisplay = number(
-      'Number of month to display',
+      'Number of months to display',
       1,
       { range: true, min: 1, max: 2, step: 1 },
-      'Bounds',
+      'Props',
     );
 
-    const isRange = boolean('Range date picker', false, 'Type');
+    const isRange = boolean('Range date picker', false, 'Props');
 
     return (
       <div style={{ background: 'white', padding: '16px', borderRadius: '4px' }}>
-        <State store={store}>
-          {state => (
-            <DatePicker
-              numberOfMonthsToDisplay={numberOfMonthsToDisplay}
-              rangePicker={isRange}
-              locale={localeValue}
-              defaultValue={state.currentDate}
-              minDate={withMinDate ? DateTime.fromMillis(minDateValue) : null}
-              maxDate={withMaxDate ? DateTime.fromMillis(maxDateValue) : null}
-              onDateChanged={date => onChangeAction(date)}
-            />
-          )}
-        </State>
+        <DatePicker
+          numberOfMonthsToDisplay={numberOfMonthsToDisplay}
+          rangePicker={isRange}
+          locale={localeValue}
+          defaultValue={DateTime.fromMillis(defaultValue)}
+          minDate={withMinDate ? DateTime.fromMillis(minDateValue) : null}
+          maxDate={withMaxDate ? DateTime.fromMillis(maxDateValue) : null}
+          onDateChanged={date => onChangeAction(date)}
+        />
       </div>
     );
   })
-  .add('controlled with an interval', () => {
+  .add('controlled state of an interval', () => {
     const localeValue = select(
       'Locale',
       {

--- a/src/DatePicker/__stories__/DatePicker.stories.js
+++ b/src/DatePicker/__stories__/DatePicker.stories.js
@@ -4,6 +4,7 @@ import { withKnobs, select, date, boolean, number } from '@storybook/addon-knobs
 import { action } from '@storybook/addon-actions';
 import { DateTime, Interval } from 'luxon';
 
+import Wrapper from '../../Wrapper';
 import DatePicker from '..';
 import DatePickerReadme from '../README.md';
 
@@ -44,7 +45,7 @@ storiesOf('DatePicker', module)
     const isRange = boolean('Range date picker', false, 'Props');
 
     return (
-      <div style={{ background: 'white', padding: '16px', borderRadius: '4px' }}>
+      <Wrapper style={{ background: 'white' }}>
         <DatePicker
           numberOfMonthsToDisplay={numberOfMonthsToDisplay}
           rangePicker={isRange}
@@ -53,7 +54,7 @@ storiesOf('DatePicker', module)
           maxDate={withMaxDate ? DateTime.fromMillis(maxDateValue) : null}
           onDateChanged={date => onChangeAction(date)}
         />
-      </div>
+      </Wrapper>
     );
   })
   .add('controlled state', () => {
@@ -83,7 +84,7 @@ storiesOf('DatePicker', module)
     const isRange = boolean('Range date picker', false, 'Props');
 
     return (
-      <div style={{ background: 'white', padding: '16px', borderRadius: '4px' }}>
+      <Wrapper style={{ background: 'white' }}>
         <DatePicker
           numberOfMonthsToDisplay={numberOfMonthsToDisplay}
           rangePicker={isRange}
@@ -93,7 +94,7 @@ storiesOf('DatePicker', module)
           maxDate={withMaxDate ? DateTime.fromMillis(maxDateValue) : null}
           onDateChanged={date => onChangeAction(date)}
         />
-      </div>
+      </Wrapper>
     );
   })
   .add('controlled state of an interval', () => {
@@ -127,7 +128,7 @@ storiesOf('DatePicker', module)
     );
 
     return (
-      <div style={{ background: 'white', padding: '16px', borderRadius: '4px' }}>
+      <Wrapper style={{ background: 'white' }}>
         <DatePicker
           numberOfMonthsToDisplay={numberOfMonthsToDisplay}
           rangePicker={isRange}
@@ -137,6 +138,6 @@ storiesOf('DatePicker', module)
           maxDate={withMaxDate ? DateTime.fromMillis(maxDateValue) : null}
           onDateChanged={date => onChangeAction(date)}
         />
-      </div>
+      </Wrapper>
     );
   });

--- a/src/DatePicker/index.js
+++ b/src/DatePicker/index.js
@@ -18,59 +18,29 @@ import {
 
 /* eslint-disable react/destructuring-assignment */
 
-const { bool, func, number, object, string } = PropTypes;
 const localDateTime = DateTime.local();
 
 /**
- * Date Picker
- *
- * This component is in charge of displaying a date picker.
- *
- * @param {string} className - Styled component class name.
- * @param {string} locale - Local to use to display the weekday names.
- * @param {luxon.DateTime} value - Controlled value (the selected date).
- * @param {luxon.DateTime} minDate - Minimum allowed date.
- * @param {luxon.DateTime} maxDate - Maximum allowed date.
- * @param {number} numberOfMonthsToDisplay - The number of month to display (1 or 2).
- * @param {function} onDateChanged - Handler of date change.
- * @param {bool} rangePicker - Whether it is a date picker or a date range picker.
+ * A DatePicker can display one or two months. It takes a value (`defaultValue` prop) to set its internal
+ * selected value state, or takes the date of today by default.
+ * The selected value can either be a date or an interval of Luxon.
  *
  * @return {jsx}
  */
 class DatePicker extends PureComponent {
-  /** Display name. */
-  static displayName = 'DatePicker';
-
-  /** Validation prop types. */
-  static propTypes = {
-    className: string,
-    defaultValue: object,
-    locale: string,
-    minDate: object,
-    maxDate: object,
-    numberOfMonthsToDisplay: number,
-    onDateChanged: func,
-    rangePicker: bool,
-  };
-
-  /** Default props. */
-  static defaultProps = {
-    className: '',
-    defaultValue: localDateTime,
-    locale: 'en',
-    minDate: null,
-    maxDate: null,
-    numberOfMonthsToDisplay: 1,
-    onDateChanged: () => {},
-    rangePicker: false,
-  };
-
   /** Internal state. */
   state = {
-    /** Initial Calendar date */
+    /**
+     * Initial Calendar date
+     * DatePicker month(s) display is based upon currentDate and will start
+     * from this to iterate through the months it has to display
+     */
     currentDate: localDateTime,
 
-    /** Selected Calendar date */
+    /**
+     * Selected Calendar date
+     * Value of selected date of the DatePicker
+     */
     selected: this.props.defaultValue,
 
     /** Start date value */
@@ -288,6 +258,66 @@ class DatePicker extends PureComponent {
     );
   }
 }
+
+/** Display name. */
+DatePicker.displayName = 'DatePicker';
+
+const { bool, func, number, object, string } = PropTypes;
+
+/** Validation prop types. */
+DatePicker.propTypes = {
+  /**
+   * Styled component class name
+   */
+  className: string,
+
+  /**
+   * Controlled selected date value
+   */
+  defaultValue: object,
+
+  /**
+   * Locale used to display the weekday names
+   */
+  locale: string,
+
+  /**
+   * Minimum allowed date
+   */
+  minDate: object,
+
+  /**
+   * Maximum allowed date
+   */
+  maxDate: object,
+
+  /**
+   * The number of months to display (1 or 2)
+   */
+  numberOfMonthsToDisplay: number,
+
+  /**
+   * Handler of date change
+   */
+  onDateChanged: func,
+
+  /**
+   * Whether it is a date picker or a date range picker
+   */
+  rangePicker: bool,
+};
+
+/** Default props. */
+DatePicker.defaultProps = {
+  className: '',
+  defaultValue: localDateTime,
+  locale: 'en',
+  minDate: null,
+  maxDate: null,
+  numberOfMonthsToDisplay: 1,
+  onDateChanged: () => {},
+  rangePicker: false,
+};
 
 export default styled(DatePicker)`
   display: flex;

--- a/src/Dropdown/README.md
+++ b/src/Dropdown/README.md
@@ -8,29 +8,28 @@ import { Dropdown } from '@tillersystems/stardust';
 
 <!-- STORY -->
 
+### Description
+
+A Dropdown displays content through its children prop that must be components wrapping text.  
+The trigger is a button displaying text provided by the prop `title`.
+
 ### Properties
 
-- `children` - Anything that can be rendered: numbers, strings, elements or an array (or fragment).
-- `className` - Add a text aside in the select next the selected value.
-- `itemCss` - Css provided to each item of the dropdown. Must use `css` method from styled-components.
-- `modifiers` - Customize popper behaviour. Plugins to alter the behaviour of the popper. See https://popper.js.org/popper-documentation.html
-- `noResultLabel` - Label to display when no result found.
-- `onToggle` - Callback called when Dropdown is toggled.
-- `searchable` - Whether the dropdown is searchable.
-- `searchBarPlaceholder` - SearchBar input placeholder.
-- `title` - Dropdown title.
-
-| propName               |  propType  | defaultValue | isRequired |
-| ---------------------- | :--------: | :----------: | :--------: |
-| `children`             |   `node`   |              |     \*     |
-| `className`            |  `string`  |    `null`    |     -      |
-| `itemCss`              |  `array`   |    `null`    |     -      |
-| `modifiers`            |  `object`  |    `null`    |     -      |
-| `noResultLabel`        |   `node`   |    `null`    |     -      |
-| `onToggle`             | `function` |  `() => {}`  |     -      |
-| `searchable`           |   `bool`   |   `false`    |     -      |
-| `searchBarPlaceholder` |  `string`  |     `''`     |     -      |
-| `title`                |   `node`   |              |     \*     |
+| Name                   | Required |    Type    | DefaultValue |                                                             Description                                                              |
+| ---------------------- | :------: | :--------: | :----------: | :----------------------------------------------------------------------------------------------------------------------------------: |
+| `children`             |    \*    |   `node`   |              |                         Anything that can be rendered: numbers, strings, elements or an array (or fragment)                          |
+| `className`            |    -     |  `string`  |    `null`    |                                       Adds a text aside in the select next the selected value                                        |
+| `contentRef`           |    -     | `function` | `undefined`  |                                                   Callback ref of content element                                                    |
+| `displayMenu`          |    -     |   `bool`   | `undefined`  | If the dropdown is open or not. If it is in a controlled state, this prop should be passed, otherwise it will rely on internal state |
+| `headerStyle`          |    -     |  `Object`  |    `null`    |                                                      Style for header component                                                      |
+| `itemCss`              |    -     |  `array`   |    `null`    |                       CSS provided to each item of the dropdown. Must use `css` method from styled-components                        |
+| `modifiers`            |    -     |  `object`  |    `null`    |    Customize popper behaviour. Plugins to alter the behaviour of the popper. See https://popper.js.org/popper-documentation.html     |
+| `noResultLabel`        |    -     |   `node`   |    `null`    |                                               Label to display when no result is found                                               |
+| `onToggle`             |    -     | `function` |  `() => {}`  |                                               Callback called when Dropdown is toggled                                               |
+| `searchable`           |    -     |   `bool`   |   `false`    |                                                  Whether the dropdown is searchable                                                  |
+| `searchBarPlaceholder` |    -     |  `string`  |     `''`     |                                                     SearchBar input placeholder                                                      |
+| `title`                |    \*    |   `node`   |              |                                                            Dropdown title                                                            |
+| `usePortal`            |    -     |   `bool`   |   `false`    |                                                   Display the content on a portal                                                    |
 
 ### Example
 

--- a/src/Dropdown/__stories__/Dropdown.stories.js
+++ b/src/Dropdown/__stories__/Dropdown.stories.js
@@ -45,14 +45,16 @@ storiesOf('Dropdown', module)
     readme: {
       // Show readme before story
       content: DropdownReadme,
+      includePropTables: [Dropdown], // won't work right now because of wrapped styled-comp https://github.com/tuchk4/storybook-readme/issues/177
     },
   })
-  .add('default', () => {
+  .add('uncontrolled displayMenu', () => {
     const onClickAction = action('onChange');
-    const Searchable = boolean('Searchable', false, 'State');
-    const NoresultLabel = text('No Result Label', 'No stores found ...', 'State');
-    const SearchBarPlaceholder = text('Search Bar Placholder', 'Search ...', 'State');
-    const Title = text('Title', 'All stores', 'State');
+    const Searchable = boolean('Searchable', false, 'Props');
+    const NoResultLabel = text('No Result Label', 'No stores found ...', 'Props');
+    const SearchBarPlaceholder = text('Search Bar Placholder', 'Search ...', 'Props');
+    const Title = text('Title', 'All stores', 'Props');
+    const usePortal = boolean('UsePortal', false, 'Props');
 
     return (
       <ScrollBox>
@@ -66,10 +68,117 @@ storiesOf('Dropdown', module)
                   escapeWithReference: true,
                 },
               }}
-              noResultLabel={NoresultLabel}
+              noResultLabel={NoResultLabel}
               title={Title}
               searchable={Searchable}
               searchBarPlaceholder={SearchBarPlaceholder}
+              usePortal={usePortal}
+            >
+              <CheckBox
+                checked={state.streetBangkokBastille}
+                value="Street Bangkok Bastille"
+                onChange={event =>
+                  onClickAction(event.target.value, event.target.checked) ||
+                  store.set({ streetBangkokBastille: !store.get('streetBangkokBastille') })
+                }
+              >
+                Street Bangkok Bastille
+              </CheckBox>
+              <CheckBox
+                checked={state.streetBangkokMarais}
+                value="Street Bangkok Marais"
+                onChange={event =>
+                  onClickAction(event.target.value, event.target.checked) ||
+                  store.set({ streetBangkokMarais: !store.get('streetBangkokMarais') })
+                }
+              >
+                Street Bangkok Marais
+              </CheckBox>
+              <CheckBox
+                checked={state.streetBangkokCanal}
+                value="Street Bangkok Canal"
+                onChange={event =>
+                  onClickAction(event.target.value, event.target.checked) ||
+                  store.set({ streetBangkokCanal: !store.get('streetBangkokCanal') })
+                }
+              >
+                Street Bangkok Canal
+              </CheckBox>
+              <CheckBox
+                checked={state.streetBangkokMontorgeuil}
+                value="Street Bangkok Montorgeuil"
+                onChange={event =>
+                  onClickAction(event.target.value, event.target.checked) ||
+                  store.set({ streetBangkokMontorgeuil: !store.get('streetBangkokMontorgeuil') })
+                }
+              >
+                Street Bangkok Montorgeuil
+              </CheckBox>
+              <CheckBox
+                checked={state.streetBangkokSentier}
+                value="Street Bangkok Sentier"
+                onChange={event =>
+                  onClickAction(event.target.value, event.target.checked) ||
+                  store.set({ streetBangkokSentier: !store.get('streetBangkokSentier') })
+                }
+              >
+                Street Bangkok Sentier
+              </CheckBox>
+              <CheckBox
+                checked={state.streetBangkokStlouis}
+                value="Street Bangkok St louis"
+                onChange={event =>
+                  onClickAction(event.target.value, event.target.checked) ||
+                  store.set({ streetBangkokStlouis: !store.get('streetBangkokStlouis') })
+                }
+              >
+                Street Bangkok St louis
+              </CheckBox>
+              <CheckBox
+                checked={state.streetBangkokStMichel}
+                value="Street Bangkok St Michel"
+                onChange={event =>
+                  onClickAction(event.target.value, event.target.checked) ||
+                  store.set({ streetBangkokStMichel: !store.get('streetBangkokStMichel') })
+                }
+              >
+                Street Bangkok St Michel
+              </CheckBox>
+              <CheckBox
+                checked={state.streetBangkokOberkampf}
+                value="Street Bangkok Oberkampf"
+                onChange={event =>
+                  onClickAction(event.target.value, event.target.checked) ||
+                  store.set({ streetBangkokOberkampf: !store.get('streetBangkokOberkampf') })
+                }
+              >
+                Street Bangkok Oberkampf
+              </CheckBox>
+            </Dropdown>
+          )}
+        </State>
+      </ScrollBox>
+    );
+  })
+  .add('controlled displayMenu', () => {
+    const onClickAction = action('onChange');
+    const Title = text('Title', 'All stores', 'Props');
+    const displayMenu = boolean('displayMenu', true, 'Props');
+
+    return (
+      <ScrollBox>
+        <State store={store}>
+          {state => (
+            <Dropdown
+              displayMenu={displayMenu}
+              headerStyle={{ width: '25rem' }}
+              itemCss={itemCss}
+              modifiers={{
+                preventOverflow: {
+                  escapeWithReference: true,
+                },
+              }}
+              title={Title}
             >
               <CheckBox
                 checked={state.streetBangkokBastille}

--- a/src/Dropdown/index.js
+++ b/src/Dropdown/index.js
@@ -241,6 +241,11 @@ Dropdown.propTypes = {
   children: node.isRequired,
 
   /**
+   * ClassName needed by styled components
+   */
+  className: string,
+
+  /**
    * Callback ref of content element
    */
   contentRef: func,
@@ -258,11 +263,6 @@ Dropdown.propTypes = {
   headerStyle: object,
 
   /**
-   * Adds a text aside in the select next the selected value
-   */
-  className: string,
-
-  /**
    * CSS provided to each item of the dropdown. Must use `css` method from styled-components
    */
   itemCss: array,
@@ -273,7 +273,7 @@ Dropdown.propTypes = {
   modifiers: object,
 
   /**
-   * Label to display when no result found
+   * Label to display when no result is found
    */
   noResultLabel: string,
 
@@ -283,12 +283,12 @@ Dropdown.propTypes = {
   onToggle: func,
 
   /**
-   * Whether the dropdown is searchable.
+   * Whether the dropdown is searchable
    */
   searchable: bool,
 
   /**
-   * SearchBar input placeholder.
+   * SearchBar input placeholder
    */
   searchBarPlaceholder: string,
 

--- a/src/ScrollBox/elements.js
+++ b/src/ScrollBox/elements.js
@@ -7,6 +7,7 @@ export const Recenter = styled.button`
 `;
 
 export const Root = styled.div`
+  margin: 3rem 0;
   position: relative;
 `;
 

--- a/src/Wrapper/index.js
+++ b/src/Wrapper/index.js
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+/**
+ * Wrapper used for stories of storybook
+ *
+ * @return {jsx}
+ */
+const Wrapper = styled.div`
+  margin: 3rem 0;
+  padding: 2rem;
+  background-color: #efefef;
+`;
+
+export default Wrapper;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1570,6 +1570,23 @@
     core-js "^3.0.1"
     util-deprecate "^1.0.2"
 
+"@storybook/addon-storysource@5.1.10":
+  version "5.1.10"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-storysource/-/addon-storysource-5.1.10.tgz#4698f6c735a41a065e9225264130cda4eda9f5cd"
+  integrity sha512-Er/29GVqonxsfX1hSNzq0bja1xkdxPAZoxIvnHh86bwhZAeQlo/CwXOsLeZoApeeez14WrvgRn/E+pg93TzsNg==
+  dependencies:
+    "@storybook/addons" "5.1.10"
+    "@storybook/components" "5.1.10"
+    "@storybook/router" "5.1.10"
+    "@storybook/theming" "5.1.10"
+    core-js "^3.0.1"
+    estraverse "^4.2.0"
+    loader-utils "^1.2.3"
+    prettier "^1.16.4"
+    prop-types "^15.7.2"
+    react-syntax-highlighter "^8.0.1"
+    regenerator-runtime "^0.12.1"
+
 "@storybook/addons@5.1.10":
   version "5.1.10"
   resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-5.1.10.tgz#2d8d8ca20b6d9b4652744f5fc00ead483f705435"
@@ -1672,10 +1689,17 @@
     recompose "^0.30.0"
     simplebar-react "^1.0.0-alpha.6"
 
-"@storybook/core-events@5.1.10", "@storybook/core-events@^5.0.6":
+"@storybook/core-events@5.1.10":
   version "5.1.10"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-5.1.10.tgz#5aed88c572036b6bd6dfff28976ee96e6e175d7a"
   integrity sha512-Lvu/rNcgS+XCkQKSGdNpUSWjpFF9AOSHPXsvkwHbRwJYdMDn3FznlXfDUiubOWtsziXHB6vl3wkKDlH+ckb32Q==
+  dependencies:
+    core-js "^3.0.1"
+
+"@storybook/core-events@^5.0.6":
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-5.1.8.tgz#048545d70e03f56eb4d35e3797f6efd9ffe4e541"
+  integrity sha512-fqam2Rm5aV8TxdBgC/eiHriY33O4wTUKw+odiH3sH0l5gZQhcAcFtnV2K2rtxrhgQnsdAzDZ5FNIKvv+xx5ZCg==
   dependencies:
     core-js "^3.0.1"
 
@@ -8918,7 +8942,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@1.18.2:
+prettier@1.18.2, prettier@^1.16.4:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,15 +1561,6 @@
     prop-types "^15.7.2"
     qs "^6.6.0"
 
-"@storybook/addon-options@5.1.10":
-  version "5.1.10"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-options/-/addon-options-5.1.10.tgz#ae6cf58744cee4ed161ffc537bc7e29a7c7337d0"
-  integrity sha512-DA6r84JYMJ5zACGdPQ7utpig8pUU1wywMMZt43k2IhxKBFcamw0Nmc80vvlTMM4mUu+mevH1ZiuzWxTZU7IcxA==
-  dependencies:
-    "@storybook/addons" "5.1.10"
-    core-js "^3.0.1"
-    util-deprecate "^1.0.2"
-
 "@storybook/addon-storysource@5.1.10":
   version "5.1.10"
   resolved "https://registry.yarnpkg.com/@storybook/addon-storysource/-/addon-storysource-5.1.10.tgz#4698f6c735a41a065e9225264130cda4eda9f5cd"


### PR DESCRIPTION
- [ ] Feature
- [ ] Fix
- [x] Enhancement

## Brief
First part of the ticket about doc rework.

In the end there are not much changes, as Storybook may be customizable with addons, but still something wired to work a certain way.
So I tried using addon-info, but with the readme addon there are some [problems](https://github.com/storybookjs/storybook/issues/6147) (also [here](https://github.com/tuchk4/storybook-readme/issues/136)) so this is still not used.

Automatic prop tables creation by the addon does not work if component is exported with as styled-component or an HOC so this is why prop tables are still hardcoded in the README.

## Related / Associated Jira Cards :
>  [[Stardust] Rework doc template and apply it on all components](https://tillersystems.atlassian.net/browse/BP-314)

## Requirements :
<!--- Eventually remove the following. -->
:warning: Requires running `yarn` command.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
