### PR TITLE
fix(Card): makes overflowing content visible

### DIFF
--- a/src/Card/__test__/__snapshots__/Card.test.js.snap
+++ b/src/Card/__test__/__snapshots__/Card.test.js.snap
@@ -15,7 +15,6 @@ exports[`Card should render without a problem 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  overflow: hidden;
 }
 
 <div

--- a/src/Card/index.js
+++ b/src/Card/index.js
@@ -27,8 +27,6 @@ const Card = styled.div`
 
   display: flex;
   flex-direction: column;
-
-  overflow: hidden;
 `;
 
 Card.Header = Header;


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Brief
As a chart can be displayed inside a card, an overflowing Tooltip would be hidden if used as is.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
