### PR TITLE
feat(Table): Add dropdown row

### DIFF
--- a/src/Table/README.md
+++ b/src/Table/README.md
@@ -3,7 +3,8 @@
 ### Usage
 
 A Table displays structured data through rows and columns.
-It can sort by column (asc, desc).
+It can be sorted by column (asc, desc). An object of data array can contain its own array of data through a `children` prop
+that must follow the same object structure as an object of `data`.
 
 ```jsx
 import { Table } from '@tillersystems/stardust';
@@ -15,17 +16,17 @@ import { Table } from '@tillersystems/stardust';
 
 #### Columns definition
 
-| Name          | Required |    Type    |                                     DefaultValue                                      |                                                                                                  Description                                                                                                  |
-| ------------- | :------: | :--------: | :-----------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-| `align`       |    -     |  `string`  |                                       `center`                                        |                                                                          Alignment of the cell's content (`left`, `center`, `right`)                                                                          |
-| `isRowHeader` |    -     | `boolean`  |                                        `false`                                        | Define if the column going to be a row header or not. In scrollable mode that column going to stick to the left side of the table. To avoid weird behaviour this parameter should be set on the first column. |
-| `filteredBy`  |    -     | `function` |                                        `null`                                         |                                                                                        Filters the object by the value                                                                                        |
-| `format`      |    -     | `function` |                                        `null`                                         |                                                                                         Format the value for display                                                                                          |
-| `isSortable`  |    -     | `boolean`  |                                        `false`                                        |                                                                                     Whether the column is sortable or not                                                                                     |
-| `title`       |    +     |  `string`  |                                        `null`                                         |                                                                                              Title of the colum                                                                                               |
-| `total`       |    +     | `function` |                                         `''`                                          |                                              Function to retrieve the total of a data for a given column. Use this parameter only if the dataTotal props is set.                                              |
-| `value`       |    +     | `function` |                                         `''`                                          |                                                                          Function to retrieve the value of a data for a given column                                                                          |
-| `width`       |    -     |  `string`  | `` | Width of the column (either a relative weight, or a fixed size in `rem` or `px`) |
+| Name          | Required |    Type    | DefaultValue |                                                                                                  Description                                                                                                  |
+| ------------- | :------: | :--------: | :----------: | :-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| `align`       |    -     |  `string`  |   `center`   |                                                                          Alignment of the cell's content (`left`, `center`, `right`)                                                                          |
+| `isRowHeader` |    -     | `boolean`  |   `false`    | Define if the column going to be a row header or not. In scrollable mode that column going to stick to the left side of the table. To avoid weird behaviour this parameter should be set on the first column. |
+| `filteredBy`  |    -     | `function` |    `null`    |                                                                                        Filters the object by the value                                                                                        |
+| `format`      |    -     | `function` |    `null`    |                                                                                         Format the value for display                                                                                          |
+| `isSortable`  |    -     | `boolean`  |   `false`    |                                                                                     Whether the column is sortable or not                                                                                     |
+| `title`       |    +     |  `string`  |    `null`    |                                                                                              Title of the colum                                                                                               |
+| `total`       |    +     | `function` |     `''`     |                                              Function to retrieve the total of a data for a given column. Use this parameter only if the dataTotal props is set.                                              |
+| `value`       |    +     | `function` |     `''`     |                                                                          Function to retrieve the value of a data for a given column                                                                          |
+| `width`       |    -     |  `string`  |      ``      |                                                               Width of the column (either a relative weight, or a fixed size in `rem` or `px`)                                                                |
 
 The difference between `value` and `format` mostly resides in the fact that `value` is the actual
 value used by the sorting. `format` is "only" used to display the given value to the user (it
@@ -89,6 +90,16 @@ const data = [
       fr: 10.0,
       en: 3.0,
     },
+    children: [
+      {
+        name: 'Oeufs pochés',
+        price: 11.0,
+        tax: {
+          fr: 9.0,
+          en: 7.0,
+        },
+      }
+    ]
   },
 ];
 

--- a/src/Table/__stories__/Table.stories.js
+++ b/src/Table/__stories__/Table.stories.js
@@ -104,6 +104,7 @@ storiesOf('Table', module)
     const striped = boolean('Striped', false, 'State');
     const isHoverable = boolean('Hoverable', false, 'State');
     const selectableRow = boolean('Selectable row', false, 'State');
+
     const dishRowSortable = boolean('Dish row is sortable', true, 'State');
     const priceRowSortable = boolean('Price row is sortable', true, 'State');
     const taxRowSortable = boolean('Tax row is sortable', true, 'State');
@@ -210,6 +211,32 @@ storiesOf('Table', module)
         tva: 20,
         profit: 4,
         discount: 15,
+        children: [
+          {
+            name: 'children',
+            price: 9.0,
+            tax: {
+              fr: 9.0,
+              en: 10.0,
+            },
+            quantity: 2,
+            tva: 20,
+            profit: 4,
+            discount: 10,
+          },
+          {
+            name: 'children',
+            price: 8.0,
+            tax: {
+              fr: 9.0,
+              en: 10.0,
+            },
+            quantity: 2,
+            tva: 20,
+            profit: 4,
+            discount: 10,
+          },
+        ],
       },
       {
         name: 'Salade caesar',
@@ -258,6 +285,32 @@ storiesOf('Table', module)
         tva: 14,
         profit: 5,
         discount: 3,
+        children: [
+          {
+            name: 'children',
+            price: 9.0,
+            tax: {
+              fr: 9.0,
+              en: 10.0,
+            },
+            quantity: 2,
+            tva: 20,
+            profit: 4,
+            discount: 10,
+          },
+          {
+            name: 'children',
+            price: 8.0,
+            tax: {
+              fr: 9.0,
+              en: 10.0,
+            },
+            quantity: 2,
+            tva: 20,
+            profit: 4,
+            discount: 10,
+          },
+        ],
       },
       {
         name: 'Omelette',

--- a/src/Table/__tests__/Table.test.js
+++ b/src/Table/__tests__/Table.test.js
@@ -241,7 +241,7 @@ describe('<Table />', () => {
     expect(footerRow).toHaveTextContent('Total');
   });
 
-  test('should table be scrollable', () => {
+  test('should be scrollable', () => {
     const { getByTestId } = render(
       <Table isScrollable height="10rem" colsDef={getColsDef()} data={data} striped />,
     );
@@ -265,5 +265,60 @@ describe('<Table />', () => {
     const tartareRow = getByText(/tartare de boeuf/i);
 
     expect(tartareRow).toHaveStyleRule(`background-color: ${Theme.palette.veryLightGrey}`);
+  });
+
+  test('should have rows with children clickable and display its children on click', () => {
+    const data = [
+      {
+        code: 'Tartare de boeuf',
+        value: 15.0,
+        tax: {
+          fr: 9.0,
+          en: 10.0,
+        },
+        children: [
+          {
+            code: 'child 1',
+            value: 9.0,
+            tax: {
+              fr: 9.0,
+              en: 10.0,
+            },
+          },
+          {
+            code: 'child 2',
+            value: 8.0,
+            tax: {
+              fr: 9.0,
+              en: 10.0,
+            },
+          },
+        ],
+      },
+      {
+        code: 'Oeuf cocotte',
+        value: 13.0,
+        tax: {
+          fr: 7.0,
+          en: 6.0,
+        },
+      },
+    ];
+
+    const { getByText, queryAllByText } = render(
+      <Table height="10rem" colsDef={getColsDef()} data={data} />,
+    );
+
+    const row = getByText(/tartare/i);
+
+    fireEvent.click(row);
+
+    const children = queryAllByText(/child/i);
+    expect(children).toHaveLength(2);
+
+    fireEvent.click(row);
+
+    const noChildren = queryAllByText(/child/i);
+    expect(noChildren).toHaveLength(0);
   });
 });

--- a/src/Table/elements.js
+++ b/src/Table/elements.js
@@ -12,7 +12,7 @@ const borderRight = height => css`
     ** To avoid this behaviour here we need to set a height to the border when a height is set to the element.
     */
     height: ${height ? height : '100%'};
-    border-right: 1px solid ${({ theme: { palette } }) => palette.veryLightBlue};
+    border-right: 1px dotted ${({ theme: { palette } }) => palette.veryLightBlue};
   }
 `;
 
@@ -196,7 +196,7 @@ export const RowHeader = styled.th`
   white-space: nowrap;
   overflow: hidden;
 
-  padding: 0 0.5rem 0 3rem;
+  padding: 0 0.5rem 0 2rem;
   max-width: 30rem;
   min-width: 15rem;
   background-color: ${({ theme: { palette } }) => palette.white};
@@ -250,7 +250,7 @@ export const Footer = styled.tfoot`
         ${borderRight('5.2rem')}
       `}
 
-    padding: 0 0.5rem 0 3rem;
+    padding: 0 0.5rem 0 2rem;
   }
 
   td:last-of-type {

--- a/src/Table/elements.js
+++ b/src/Table/elements.js
@@ -75,7 +75,7 @@ export const TableHeaderCell = styled.th`
   }
 
   &:first-child {
-    padding-left: 3rem;
+    padding-left: 2rem;
     padding-right: 0.5rem;
     z-index: 2;
     left: 0;
@@ -83,7 +83,7 @@ export const TableHeaderCell = styled.th`
   }
 
   &:last-child {
-    padding-right: 3rem;
+    padding-right: 2.2rem;
     padding-left: 0.5rem;
   }
 
@@ -124,15 +124,15 @@ export const Body = styled.tbody`
     min-width: 10rem;
 
     &:first-child {
-      padding-left: 3rem;
+      padding-left: 2rem;
     }
     &:last-child {
-      padding-right: 3rem;
+      padding-right: 2.2rem;
     }
   }
 `;
 
-export const BodyRow = styled(Row)`
+export const ChildRow = styled(Row)`
   position: relative;
 
   ${({ selectable }) =>
@@ -173,9 +173,14 @@ export const BodyRow = styled(Row)`
     `}
 `;
 
-export const RowHeader = styled.th`
+export const BodyRow = styled(ChildRow)`
+  font-weight: ${({ theme: { fonts } }) => fonts.weight.thick};
+`;
 
+export const RowHeader = styled.th`
   height: 5.2rem;
+  display: flex;
+  align-items: center;
 
   ${({ isScrollable }) =>
     isScrollable &&

--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -207,7 +207,12 @@ class Table extends PureComponent {
             >
               {colsDef.map(({ isRowHeader, value, format, align }, columnIndex) =>
                 isRowHeader ? (
-                  <RowHeader align={align} isScrollable={isScrollable} key={`row-header-${index}`}>
+                  <RowHeader
+                    align={align}
+                    isScrollable={isScrollable}
+                    key={`row-header-${index}`}
+                    {...(item.children ? { style: { cursor: 'pointer' } } : {})}
+                  >
                     {item.children && (
                       <Icon
                         name={selectedRows.includes(key) ? 'chevron-down' : 'chevron-right'}
@@ -242,6 +247,10 @@ class Table extends PureComponent {
                         isRowHeader ? (
                           <RowHeader
                             align={align}
+                            css={`
+                              padding: 1.8rem 4rem;
+                              font-weight: ${({ theme: { fonts } }) => fonts.weight.normal};
+                            `}
                             isScrollable={isScrollable}
                             key={`row-header-${key}-${index}`}
                           >


### PR DESCRIPTION
- [x] Feature
- [ ] Fix
- [ ] Enhancement

## Description
We want to have extendable row with under-categories in it. Check the [design](https://app.zeplin.io/project/5c08e7dab171cd2fd787d7d6/screen/5d4acbc4e8ad4751ff453b28) for visual overview.

To use the dropdown row you need to add `children` key to `data` prop. `children` structure is the same as `data` one, an object's array.

eg:

```javascript
const data = [
      {
        ...
        children: [
          {
            name: 'children',
            price: 9.0,
            tax: {
              fr: 9.0,
              en: 10.0,
            },
            quantity: 2,
            tva: 20,
            profit: 4,
            discount: 10,
          },
         ...
        ]
      },
     ...
    ];
```


## Related / Associated Jira Cards :
>  ([BP-369](https://tillersystems.atlassian.net/browse/BP-369))
> [BP-486](https://tillersystems.atlassian.net/browse/BP-486)

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
