### PR TITLE
refactor(Notification): Rework of the component to stack notification

### DIFF
--- a/src/Notification/Container.js
+++ b/src/Notification/Container.js
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect } from 'react';
+import React, { forwardRef, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { Container } from './elements';
@@ -10,11 +10,8 @@ import { Timer } from './helpers';
  * @return {jsx}
  */
 const NotificationContainer = forwardRef(
-  (
-    { autoDismiss, autoDismissTimeout, component: Component, onDismiss, pauseOnHover, placement },
-    ref,
-  ) => {
-    let timeout;
+  ({ autoDismiss, autoDismissTimeout, component: Component, onDismiss, pauseOnHover }, ref) => {
+    const [timer, setTimer] = useState(null);
 
     /**
      * Start Timer
@@ -22,8 +19,7 @@ const NotificationContainer = forwardRef(
      */
     const startTimer = () => {
       if (!autoDismiss) return;
-
-      timeout = new Timer(onDismiss, autoDismissTimeout);
+      setTimer(new Timer(onDismiss, autoDismissTimeout));
     };
 
     /**
@@ -31,9 +27,7 @@ const NotificationContainer = forwardRef(
      *
      */
     const clearTimer = () => {
-      if (!autoDismiss) return;
-
-      if (timeout) timeout.clear();
+      timer.clear();
     };
 
     /**
@@ -41,7 +35,7 @@ const NotificationContainer = forwardRef(
      *
      */
     const onMouseEnter = () => {
-      if (timeout) timeout.pause();
+      timer.pause();
     };
 
     /**
@@ -49,7 +43,7 @@ const NotificationContainer = forwardRef(
      *
      */
     const onMouseLeave = () => {
-      if (timeout) timeout.resume();
+      timer.resume();
     };
 
     /**
@@ -57,12 +51,12 @@ const NotificationContainer = forwardRef(
      *
      */
     useEffect(() => {
-      startTimer();
-      // Specify how to clean up after this effect:
-      return function cleanup() {
-        clearTimer();
+      if (!timer) startTimer();
+
+      return () => {
+        if (timer) clearTimer();
       };
-    }, []);
+    }, [timer]);
 
     const hasMouseEvents = pauseOnHover && autoDismiss;
 
@@ -72,13 +66,12 @@ const NotificationContainer = forwardRef(
 
     return (
       <Container
-        position={placement}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
         data-testid="notification-container"
         ref={ref}
       >
-        <Component />
+        <Component onClose={onDismiss} />
       </Container>
     );
   },
@@ -87,7 +80,7 @@ const NotificationContainer = forwardRef(
 /**
  * PropTypes Validation
  */
-const { bool, func, number, oneOf } = PropTypes;
+const { bool, func, number } = PropTypes;
 
 NotificationContainer.propTypes = {
   /**
@@ -109,18 +102,6 @@ NotificationContainer.propTypes = {
    * Callback function to call when notification is dismissed
    */
   onDismiss: func.isRequired,
-
-  /**
-   * Placement of the notification on the screen
-   */
-  placement: oneOf([
-    'top-left',
-    'top-center',
-    'top-right',
-    'bottom-left',
-    'bottom-center',
-    'bottom-right',
-  ]).isRequired,
 
   /**
    * Whether or not to pause the timeout when hovered

--- a/src/Notification/NotificationsList.js
+++ b/src/Notification/NotificationsList.js
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { NotificationsList } from './elements';
+
+/**
+ * Notification list container
+ * @param {string} children - Component containing notifications
+ *
+ * @return {jsx}
+ */
+const NotificationsListContainer = ({ children, ...rest }) => (
+  <NotificationsList {...rest}>{children}</NotificationsList>
+);
+
+/**
+ * PropTypes Validation
+ */
+const { oneOf, oneOfType, node, arrayOf } = PropTypes;
+
+NotificationsListContainer.propTypes = {
+  /**
+   * Position on the screen
+   */
+  placement: oneOf([
+    'top-left',
+    'top-center',
+    'top-right',
+    'bottom-left',
+    'bottom-center',
+    'bottom-right',
+  ]).isRequired,
+
+  /**
+   * Inner content
+   */
+  children: oneOfType([arrayOf(node), node]).isRequired,
+};
+
+NotificationsListContainer.displayName = 'NotificationsListContainer';
+
+export default NotificationsListContainer;

--- a/src/Notification/README.md
+++ b/src/Notification/README.md
@@ -46,3 +46,17 @@ The `addNotification` method has 2 arguments:
 ```jsx
 <Button onClick={onClick={() => addNotification(Component, { autoDismiss: true, autoDismissTimeout: 3000, pauseOnHover: true })}} />
 ```
+
+The `dismissNotification` has 1 argument: `key` to remove a specific notification on screen.
+
+```jsx
+dismissNotification(key);
+```
+
+The notifcation can be manually closed by calling the `onClose` method injected by the NotificationContainer in the inner component props.
+
+```jsx
+const Component = ({ onClose }) => (
+  <Message description="I'm a notification component" type="success" onClose={onClose} />
+);
+```

--- a/src/Notification/__stories__/Notifications.stories.js
+++ b/src/Notification/__stories__/Notifications.stories.js
@@ -10,9 +10,9 @@ import NotificationReadme from '../README.md';
 
 /*eslint react/prop-types:0*/
 const NotificationComponent = ({ autoDismiss, autoDismissTimeout, pauseOnHover }) => {
-  const { addNotification, dismissNotification } = useNotifications();
-  const Component = () => (
-    <Message description="this is a message" type="success" onClose={dismissNotification} />
+  const { addNotification } = useNotifications();
+  const Component = ({ onClose }) => (
+    <Message description="this is a message" type="success" onClose={onClose} />
   );
 
   return (
@@ -38,7 +38,7 @@ storiesOf('Notification', module)
     const pauseOnHover = boolean('pauseOnHover', false, 'Options');
     const placement = select(
       'placement',
-      ['top-left', 'top-center', 'top-right', 'bottom-left', 'bottom-center', 'bottom-left'],
+      ['top-left', 'top-center', 'top-right', 'bottom-left', 'bottom-center', 'bottom-right'],
       'bottom-right',
       'Options',
     );

--- a/src/Notification/__tests__/__snapshots__/helpers.test.js.snap
+++ b/src/Notification/__tests__/__snapshots__/helpers.test.js.snap
@@ -2,18 +2,30 @@
 
 exports[`<Notification /> -- helpers getAlertPosition should return notification Css Position 1`] = `
 Array [
-  "left:0;top:4rem;",
+  "left:1rem;top:4rem;",
 ]
+`;
+
+exports[`<Notification /> -- helpers getListDirection should return valid flex direction for bottom-left placement 1`] = `
+Object {
+  "flex-direction": "column",
+}
+`;
+
+exports[`<Notification /> -- helpers getListDirection should return valid flex direction for top-center placement 1`] = `
+Object {
+  "flex-direction": "column-reverse",
+}
 `;
 
 exports[`<Notification /> -- helpers getPositionAnimation should return Animation position 1`] = `
 Object {
   "enter": Object {
-    "x": "-50%",
+    "x": "0%",
     "y": "0%",
   },
   "exit": Object {
-    "x": "-50%",
+    "x": "0%",
     "y": "-100%",
   },
 }

--- a/src/Notification/__tests__/__snapshots__/reducer.test.js.snap
+++ b/src/Notification/__tests__/__snapshots__/reducer.test.js.snap
@@ -2,20 +2,30 @@
 
 exports[`<NotificationProvider /> should handle ADD_NOTIFICATION 1`] = `
 Object {
-  "component": [MockFunction],
-  "isActive": true,
+  "notifications": Array [
+    Object {
+      "component": [MockFunction],
+      "key": "notif-component-0",
+      "options": Object {
+        "autoDismiss": true,
+        "autoDismissTimeout": 5000,
+        "pauseOnHover": true,
+      },
+    },
+  ],
+  "notificationsCount": 1,
   "options": Object {
-    "autoDismiss": true,
-    "autoDismissTimeout": 5000,
-    "pauseOnHover": true,
+    "autoDismiss": false,
+    "autoDismissTimeout": 1000,
+    "pauseOnHover": false,
   },
 }
 `;
 
 exports[`<NotificationProvider /> should handle REMOVE_NOTIFICATION 1`] = `
 Object {
-  "component": null,
-  "isActive": false,
+  "notifications": Array [],
+  "notificationsCount": 0,
   "options": Object {
     "autoDismiss": false,
     "autoDismissTimeout": 1000,

--- a/src/Notification/__tests__/helpers.test.js
+++ b/src/Notification/__tests__/helpers.test.js
@@ -1,4 +1,4 @@
-import { getNotificationPosition, getPositionAnimation } from '../helpers';
+import { getNotificationPosition, getPositionAnimation, getListDirection } from '../helpers';
 
 describe('<Notification /> -- helpers', () => {
   describe('getAlertPosition', () => {
@@ -12,6 +12,22 @@ describe('<Notification /> -- helpers', () => {
   describe('getPositionAnimation', () => {
     test('should return Animation position', () => {
       const expected = getPositionAnimation('top-center');
+
+      expect(expected).toMatchSnapshot();
+    });
+  });
+
+  describe('getListDirection', () => {
+    test('should return valid flex direction for top-center placement', () => {
+      const expected = getListDirection('top-center');
+
+      expect(expected).toMatchSnapshot();
+    });
+  });
+
+  describe('getListDirection', () => {
+    test('should return valid flex direction for bottom-left placement', () => {
+      const expected = getListDirection('bottom-left');
 
       expect(expected).toMatchSnapshot();
     });

--- a/src/Notification/__tests__/reducer.test.js
+++ b/src/Notification/__tests__/reducer.test.js
@@ -2,8 +2,8 @@ import notificationReducer from '../reducer';
 import { ADD_NOTIFICATION, REMOVE_NOTIFICATION } from '../constants';
 
 const previousState = {
-  isActive: false,
-  component: null,
+  notificationsCount: 0,
+  notifications: [],
   options: {
     autoDismiss: false,
     autoDismissTimeout: 1000,
@@ -13,11 +13,10 @@ const previousState = {
 
 describe('<NotificationProvider />', () => {
   test('should throw an error if incorrect type is passed', () => {
-    const type = 'INCORECT_TYPE';
+    const type = 'INCORRECT_TYPE';
     expect(() => {
       notificationReducer(previousState, {
         type,
-        component: jest.fn(),
         options: {
           autoDismiss: true,
           autoDismissTimeout: 5000,

--- a/src/Notification/elements.js
+++ b/src/Notification/elements.js
@@ -1,10 +1,15 @@
 import styled from 'styled-components';
 
-import { getNotificationPosition } from './helpers';
+import { getNotificationPosition, getListDirection } from './helpers';
 
 export const Container = styled.div`
-  position: fixed;
-  ${({ position }) => getNotificationPosition(position)};
+  margin-bottom: 1rem;
+`;
 
+export const NotificationsList = styled.div`
+  position: fixed;
+  display: flex;
   width: 32rem;
+  ${({ placement }) => getListDirection(placement)};
+  ${({ placement }) => getNotificationPosition(placement)};
 `;

--- a/src/Notification/helpers.js
+++ b/src/Notification/helpers.js
@@ -11,27 +11,29 @@ import { css } from 'styled-components';
 export function getNotificationPosition(placement) {
   return {
     'top-left': css`
-      left: 0;
+      left: 1rem;
       top: 4rem;
     `,
     'top-center': css`
       left: 50%;
       top: 0;
+      margin-left: -16rem;
     `,
     'top-right': css`
-      right: 0;
+      right: 1rem;
       top: 4rem;
     `,
     'bottom-left': css`
-      left: 0;
+      left: 1rem;
       bottom: 4rem;
     `,
     'bottom-center': css`
       left: 50%;
       bottom: 0;
+      margin-left: -16rem;
     `,
     'bottom-right': css`
-      right: 0;
+      right: 1rem;
       bottom: 4rem;
     `,
   }[placement];
@@ -58,11 +60,11 @@ export function getPositionAnimation(placement) {
     },
     'top-center': {
       enter: {
-        x: '-50%',
+        x: '0%',
         y: '0%',
       },
       exit: {
-        x: '-50%',
+        x: '0%',
         y: '-100%',
       },
     },
@@ -88,11 +90,11 @@ export function getPositionAnimation(placement) {
     },
     'bottom-center': {
       enter: {
-        x: '-50%',
+        x: '0%',
         y: '0%',
       },
       exit: {
-        x: '-50%',
+        x: '0%',
         y: '100%',
       },
     },
@@ -107,6 +109,14 @@ export function getPositionAnimation(placement) {
       },
     },
   }[placement];
+}
+
+export function getListDirection(placement) {
+  let direction = 'column';
+  if (placement.indexOf('top') === 0) {
+    direction = 'column-reverse';
+  }
+  return { 'flex-direction': direction };
 }
 
 /**

--- a/src/Notification/reducer.js
+++ b/src/Notification/reducer.js
@@ -13,26 +13,31 @@ const notificationReducer = (state, action) => {
     case ADD_NOTIFICATION:
       return {
         ...state,
-        isActive: true,
-        component: action.component,
-        options: {
-          autoDismiss: action.options.autoDismiss
-            ? action.options.autoDismiss
-            : state.options.autoDismiss,
-          autoDismissTimeout: action.options.autoDismissTimeout
-            ? action.options.autoDismissTimeout
-            : state.options.autoDismissTimeout,
-          pauseOnHover: action.options.pauseOnHover
-            ? action.options.pauseOnHover
-            : state.options.pauseOnHover,
-        },
+        notificationsCount: state.notificationsCount + 1,
+        notifications: [
+          ...state.notifications,
+          {
+            component: action.component,
+            key: `notif-component-${state.notificationsCount}`,
+            options: {
+              autoDismiss: action.options.autoDismiss
+                ? action.options.autoDismiss
+                : state.options.autoDismiss,
+              autoDismissTimeout: action.options.autoDismissTimeout
+                ? action.options.autoDismissTimeout
+                : state.options.autoDismissTimeout,
+              pauseOnHover: action.options.pauseOnHover
+                ? action.options.pauseOnHover
+                : state.options.pauseOnHover,
+            },
+          },
+        ],
       };
 
     case REMOVE_NOTIFICATION:
       return {
         ...state,
-        isActive: false,
-        component: null,
+        notifications: state.notifications.filter(n => n.key !== action.key),
       };
 
     default: {


### PR DESCRIPTION
- [ ] Feature
- [ ] Fix
- [x] Enhancement

## Brief
Change notifications provider to display multiple notifications.

## Description
I modified the component so that it can display multiple notifications. They are now recorded in an array and keep their autoDismiss and pauseOnHover functionality. The provider's signature has evolved so that a notification can be dismissed through its key.

dismissNotification has been modified to accept a key parameter :
```javascript
dismissNotification(key)
```

The notifcation can be manually closed by calling the onClose method injected by the NotificationContainer in the inner component props.
```javascript
const Component = ({ onClose }) => (
  <Message description="I'm a notification component" type="success" onClose={onClose} />
);
```

## Related / Associated Jira Cards :
[BP-398](https://tillersystems.atlassian.net/jira/software/projects/BP/boards/57?selectedIssue=BP-398)

## How Has This Been Tested?
Add tests to check the add/dismiss of multiples notifications + adaptations of old tests.

## Todo - Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
