### PR TITLE
refactor(Notification): Add key in addNotification options

### DIFF
--- a/src/Notification/__stories__/Notifications.stories.js
+++ b/src/Notification/__stories__/Notifications.stories.js
@@ -7,21 +7,65 @@ import Button from '../../Button';
 import Message from '../../Message';
 import Wrapper from '../../Wrapper';
 import NotificationReadme from '../README.md';
+import styled from 'styled-components';
+
+const StyledButton = styled(Button)`
+  margin-bottom: 1rem;
+`;
+
+const FlexContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
 
 /*eslint react/prop-types:0*/
 const NotificationComponent = ({ autoDismiss, autoDismissTimeout, pauseOnHover }) => {
-  const { addNotification } = useNotifications();
+  const { addNotification, dismissNotification } = useNotifications();
   const Component = ({ onClose }) => (
     <Message description="this is a message" type="success" onClose={onClose} />
   );
 
+  const ComponentWithKey = ({ onClose }) => (
+    <Message
+      description="I'm an identified notification with key: 'stardust'"
+      type="info"
+      onClose={onClose}
+    />
+  );
+
   return (
-    <Button
-      appearance="primary"
-      onClick={() => addNotification(Component, { autoDismiss, autoDismissTimeout, pauseOnHover })}
-    >
-      Add Notification
-    </Button>
+    <FlexContainer>
+      <StyledButton
+        appearance="primary"
+        size="small"
+        onClick={() =>
+          addNotification(Component, { autoDismiss, autoDismissTimeout, pauseOnHover })
+        }
+      >
+        Add Notification
+      </StyledButton>
+      <StyledButton
+        appearance="primary"
+        size="small"
+        onClick={() =>
+          addNotification(ComponentWithKey, {
+            key: 'stardust',
+            autoDismiss,
+            autoDismissTimeout,
+            pauseOnHover,
+          })
+        }
+      >
+        Add Notification with key "stardust"
+      </StyledButton>
+      <StyledButton
+        appearance="primary"
+        size="small"
+        onClick={() => dismissNotification('stardust')}
+      >
+        Remove Notification with key "stardust"
+      </StyledButton>
+    </FlexContainer>
   );
 };
 

--- a/src/Notification/__tests__/provider.test.js
+++ b/src/Notification/__tests__/provider.test.js
@@ -24,6 +24,43 @@ const NotificationComponent = ({ autoDismiss, autoDismissTimeout, pauseOnHover }
     </button>
   );
 };
+const NotificationComponentWithKey = ({
+  autoDismiss,
+  autoDismissTimeout,
+  pauseOnHover,
+  notifKey,
+}) => {
+  const { addNotification, dismissNotification } = useNotifications();
+  const Component = ({ onClose }) => (
+    <div>
+      This is a notification
+      <button type="button" onClick={onClose}>
+        close
+      </button>
+    </div>
+  );
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() =>
+          addNotification(Component, {
+            autoDismiss,
+            autoDismissTimeout,
+            pauseOnHover,
+            key: notifKey,
+          })
+        }
+      >
+        Add Notification
+      </button>
+      <button type="button" onClick={() => dismissNotification(notifKey)}>
+        Dismiss Notification
+      </button>
+    </div>
+  );
+};
 
 describe('<NotificationProvider />', () => {
   test('should render without a problem', () => {
@@ -125,6 +162,39 @@ describe('<NotificationProvider />', () => {
     });
 
     wait(() => expect(queryByText(/This is a notification/i)).not.toBeInTheDocument());
+  });
+
+  test('should add and remove a notification with specific key', async () => {
+    const { getByText, queryByText } = render(
+      <NotificationProvider>
+        <NotificationComponentWithKey autoDismiss={false} pauseOnHover={false} notifKey="test" />
+      </NotificationProvider>,
+    );
+
+    const ButtonNode = getByText(/Add Notification/i);
+
+    fireEvent.click(ButtonNode);
+    expect(getByText(/This is a notification/i)).toBeInTheDocument();
+
+    const CloseButtonNode = getByText(/Dismiss Notification/i);
+
+    fireEvent.click(CloseButtonNode);
+    await wait(() => expect(queryByText(/This is a notification/i)).not.toBeInTheDocument());
+  });
+
+  test('should not add two notifications with same key', async () => {
+    const { getByText, getAllByText } = render(
+      <NotificationProvider>
+        <NotificationComponentWithKey autoDismiss={false} pauseOnHover={false} notifKey="test" />
+      </NotificationProvider>,
+    );
+
+    const ButtonNode = getByText(/Add Notification/i);
+
+    fireEvent.click(ButtonNode);
+    fireEvent.click(ButtonNode);
+
+    expect(getAllByText(/This is a notification/i)).toHaveLength(1);
   });
 
   test('should pause the notification timeout when hovered', async () => {

--- a/src/Notification/provider.js
+++ b/src/Notification/provider.js
@@ -34,25 +34,34 @@ export const NotificationProvider = ({
   };
   const [state, dispatch] = useReducer(notificationReducer, initialState);
 
+  const { notifications } = state;
+
   /**
    * Add notification
    *
    * @param {function} component - Presentational component for displaying message.
    * @param {object} options - Options passed to heance notification.
    */
-  const addNotification = useCallback((component, options = state.options) => {
-    dispatch({ type: ADD_NOTIFICATION, component, options });
-  }, []);
+  const addNotification = useCallback(
+    (component, options = state.options) => {
+      const exists = notifications.find(n => n.key === options.key);
+      if (!exists) dispatch({ type: ADD_NOTIFICATION, component, options });
+    },
+    [notifications],
+  );
 
   /**
    * Dismiss notification
    * @param {string} key - unique key to retrieve notification.
    */
-  const dismissNotification = useCallback(key => {
-    dispatch({ type: REMOVE_NOTIFICATION, key });
-  }, []);
+  const dismissNotification = useCallback(
+    key => {
+      const exists = notifications.find(n => n.key === key);
+      if (exists) dispatch({ type: REMOVE_NOTIFICATION, key });
+    },
+    [notifications],
+  );
 
-  const { notifications } = state;
   return (
     <NotificationContext.Provider value={{ addNotification, dismissNotification }}>
       {children}

--- a/src/Notification/reducer.js
+++ b/src/Notification/reducer.js
@@ -18,7 +18,7 @@ const notificationReducer = (state, action) => {
           ...state.notifications,
           {
             component: action.component,
-            key: `notif-component-${state.notificationsCount}`,
+            key: action.options.key || `notif-component-${state.notificationsCount}`,
             options: {
               autoDismiss: action.options.autoDismiss
                 ? action.options.autoDismiss


### PR DESCRIPTION
- [ ] Feature
- [ ] Fix
- [x] Enhancement

## Brief
Change notification provider to specify a key on `addNotification`. You can dismiss it with the same key.

## Description
I modify the component to add a key in `addNotification` options.

```javascript
addNotification(Component, { 
    autoDismiss={false}, 
    pauseOnHover={false}, 
    key: "report-notification"
});
```

You can dismiss the notification using this method :

```javascript
dismissNotification("report-notification");
```

## Related / Associated Jira Cards :
[BP-398](https://tillersystems.atlassian.net/jira/software/projects/BP/boards/57?selectedIssue=BP-398)

## How Has This Been Tested?
Add tests to check the add/dismiss with specific key.

## Todo - Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
