### PR TITLE
refactor(Modal): replace react-pose by framer-motion for the animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     }
   },
   "peerDependencies": {
+    "framer-motion": "^1.x",
     "prop-types": "^15.x",
     "react": "^16.x",
     "react-dom": "^16.x",
@@ -59,7 +60,6 @@
     "cuid": "2.1.6",
     "dom-helpers": "^2.4.0 || ^3.0.0",
     "exenv": "1.2.2",
-    "framer-motion": "^1.6.12",
     "initials": "3.0.1",
     "luxon": "1.19.3",
     "polished": "3.4.1",
@@ -108,6 +108,7 @@
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-prettier": "3.1.1",
     "eslint-plugin-react": "7.14.3",
+    "framer-motion": "1.6.12",
     "husky": "3.0.9",
     "jest": "24.9.0",
     "jest-dom": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "cuid": "2.1.6",
     "dom-helpers": "^2.4.0 || ^3.0.0",
     "exenv": "1.2.2",
+    "framer-motion": "^1.6.12",
     "initials": "3.0.1",
     "luxon": "1.19.3",
     "polished": "3.4.1",

--- a/src/Modal/Footer/__tests__/Footer.test.js
+++ b/src/Modal/Footer/__tests__/Footer.test.js
@@ -9,9 +9,15 @@ describe('<Modal.Footer />', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('should render with another alignment', () => {
-    const { container } = render(<Footer alignment="center">Footer</Footer>);
+  test.each`
+    value              | props
+    ${'flex-start'}    | ${'left'}
+    ${'flex-end'}      | ${'right'}
+    ${'center'}        | ${'center'}
+    ${'space-between'} | ${'spaced'}
+  `('should render with $props alignment', ({ value, props }) => {
+    const { container } = render(<Footer alignment={props}>Footer</Footer>);
 
-    expect(container.firstChild).toHaveStyleRule('justify-content', 'center');
+    expect(container.firstChild).toHaveStyleRule('justify-content', value);
   });
 });

--- a/src/Modal/animation.js
+++ b/src/Modal/animation.js
@@ -1,0 +1,43 @@
+/**
+ * Define animation variants for modal animation
+ */
+export const containerVariants = {
+  visible: {
+    transition: {
+      when: 'beforeChildren',
+    },
+  },
+  hidden: {
+    transition: {
+      when: 'afterChildren',
+    },
+  },
+};
+
+export const overlayVariants = {
+  visible: { opacity: 1 },
+  hidden: {
+    opacity: 0,
+    transition: {
+      delay: 0.15,
+    },
+  },
+};
+
+export const dialogVariants = {
+  visible: {
+    y: 0,
+    opacity: 1,
+    transition: {
+      delay: 0.15,
+      duration: 0.15,
+    },
+  },
+  hidden: {
+    y: 50,
+    opacity: 0,
+    transition: {
+      duration: 0.15,
+    },
+  },
+};

--- a/src/Modal/elements.js
+++ b/src/Modal/elements.js
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
 import breakpoint from 'styled-components-breakpoint';
+import { motion } from 'framer-motion';
 
-export const Container = styled.div`
+export const Container = styled(motion.div)`
   position: fixed;
   display: grid;
   justify-content: center;
@@ -20,7 +21,7 @@ export const Container = styled.div`
   `};
 `;
 
-export const Overlay = styled.div`
+export const Overlay = styled(motion.div)`
   position: fixed;
   min-width: 100%;
   min-height: 100%;
@@ -28,7 +29,7 @@ export const Overlay = styled.div`
   z-index: 99;
 `;
 
-export const Dialog = styled.dialog`
+export const Dialog = styled(motion.dialog)`
   position: relative;
   width: ${({ width }) => width};
   height: ${({ height }) => height};

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -1,8 +1,10 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import posed, { PoseGroup } from 'react-pose';
+import { AnimatePresence } from 'framer-motion';
 import { Portal } from 'react-portal';
+
 import Theme from '../Theme';
+import { containerVariants, overlayVariants, dialogVariants } from './animation';
 
 /**
  * A Modal is displayed through a Portal added at the end of the body element. An overlay hides
@@ -34,16 +36,33 @@ class Modal extends PureComponent {
     const { active, width, height, padding, onOverlayClick, children } = this.props;
     return (
       <Portal>
-        <PoseGroup>
+        <AnimatePresence>
           {active && (
-            <ContainerAnimation key="Container">
-              <OverlayAnimation onClick={onOverlayClick} key="Overlay" data-testid="overlay" />
-              <DialogAnimation width={width} height={height} padding={padding} key="Dialog">
+            <Container
+              key="Container"
+              initial="hidden"
+              animate="visible"
+              exit="hidden"
+              variants={containerVariants}
+            >
+              <Overlay
+                onClick={onOverlayClick}
+                variants={overlayVariants}
+                key="Overlay"
+                data-testid="overlay"
+              />
+              <Dialog
+                width={width}
+                height={height}
+                padding={padding}
+                key="Dialog"
+                variants={dialogVariants}
+              >
                 {children}
-              </DialogAnimation>
-            </ContainerAnimation>
+              </Dialog>
+            </Container>
           )}
-        </PoseGroup>
+        </AnimatePresence>
       </Portal>
     );
   }
@@ -95,43 +114,5 @@ Modal.defaultProps = {
   padding: Theme.dimensions.medium,
   width: '48rem',
 };
-
-/**
- * Animation
- */
-const ContainerAnimation = posed(Container)({
-  enter: {
-    opacity: 1,
-  },
-  exit: {
-    opacity: 0,
-  },
-});
-
-const OverlayAnimation = posed(Overlay)({
-  enter: {
-    opacity: 1,
-  },
-  exit: {
-    opacity: 0,
-  },
-});
-
-const DialogAnimation = posed(Dialog)({
-  enter: {
-    y: 0,
-    opacity: 1,
-    delay: 150,
-    transition: {
-      y: { type: 'spring', stiffness: 900, damping: 28 },
-      default: { duration: 150 },
-    },
-  },
-  exit: {
-    y: 50,
-    opacity: 0,
-    transition: { duration: 150 },
-  },
-});
 
 export default Modal;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1011,7 +1011,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.3.tgz#a166882c81c0c6040975dd30df24fae8549bd96f"
   integrity sha512-14ZVlsB9akwvydAdaEnVnvqu6J2P6ySv39hYyl/aoB6w/V+bXX0tay8cF6paqbgZsN2n5Xh15uF4pE+GvE+itw==
 
-"@emotion/is-prop-valid@0.8.3", "@emotion/is-prop-valid@^0.8.1":
+"@emotion/is-prop-valid@0.8.3", "@emotion/is-prop-valid@^0.8.1", "@emotion/is-prop-valid@^0.8.2":
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.3.tgz#cbe62ddbea08aa022cdf72da3971570a33190d29"
   integrity sha512-We7VBiltAJ70KQA0dWkdPMXnYoizlxOXpvtjmu5/MBnExd+u0PGgV27WCYanmLAbCwAU30Le/xA0CQs/F/Otig==
@@ -1307,12 +1307,12 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@popmotion/easing@^1.0.1":
+"@popmotion/easing@^1.0.1", "@popmotion/easing@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@popmotion/easing/-/easing-1.0.2.tgz#17d925c45b4bf44189e5a38038d149df42d8c0b4"
   integrity sha512-IkdW0TNmRnWTeWI7aGQIVDbKXPWHVEYdGgd5ZR4SH/Ty/61p63jCjrPxX1XrR7IGkl08bjhJROStD7j+RKgoIw==
 
-"@popmotion/popcorn@^0.4.0":
+"@popmotion/popcorn@^0.4.0", "@popmotion/popcorn@^0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@popmotion/popcorn/-/popcorn-0.4.2.tgz#ff9f5334e8e808ed02237b7b9c928619d1eb68ff"
   integrity sha512-wu0tEwK3KUZ9BoqfcqC3DfdfRDws/oHXwZKJMVtuhXSrF/PtqvilsPjAk93nh8M+orAnbe8ZyxQmop9+4oJs2g==
@@ -6057,7 +6057,23 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-framesync@^4.0.0, framesync@^4.0.1:
+framer-motion@^1.6.12:
+  version "1.6.12"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-1.6.12.tgz#e1928044594ca1b2ed7515f99dccf98f66c5ccde"
+  integrity sha512-ooF5lnD8rMQxCT7zekzZIOIpAtX439PEYD1hyq8Rc6cx6+a7n9jg47uc54p/oG3w/aV7yANDDoD7uYkMvB9tnA==
+  dependencies:
+    "@popmotion/easing" "^1.0.2"
+    "@popmotion/popcorn" "^0.4.2"
+    framesync "^4.0.4"
+    hey-listen "^1.0.8"
+    popmotion "9.0.0-beta-8"
+    style-value-types "^3.1.6"
+    stylefire "^7.0.0"
+    tslib "^1.10.0"
+  optionalDependencies:
+    "@emotion/is-prop-valid" "^0.8.2"
+
+framesync@^4.0.0, framesync@^4.0.1, framesync@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/framesync/-/framesync-4.0.4.tgz#79c42c0118f26821c078570db0ff81fb863516a2"
   integrity sha512-mdP0WvVHe0/qA62KG2LFUAOiWLng5GLpscRlwzBxu2VXOp6B8hNs5C5XlFigsMgrfDrr2YbqTsgdWZTc4RXRMQ==
@@ -9383,6 +9399,18 @@ popmotion@8.7.0, popmotion@^8.6.2:
     stylefire "^4.1.3"
     tslib "^1.9.1"
 
+popmotion@9.0.0-beta-8:
+  version "9.0.0-beta-8"
+  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.0.0-beta-8.tgz#f5a709f11737734e84f2a6b73f9bcf25ee30c388"
+  integrity sha512-6eQzqursPvnP7ePvdfPeY4wFHmS3OLzNP8rJRvmfFfEIfpFqrQgLsM50Gd9AOvGKJtYJOFknNG+dsnzCpgIdAA==
+  dependencies:
+    "@popmotion/easing" "^1.0.1"
+    "@popmotion/popcorn" "^0.4.2"
+    framesync "^4.0.4"
+    hey-listen "^1.0.8"
+    style-value-types "^3.1.6"
+    tslib "^1.10.0"
+
 popper.js@^1.14.4, popper.js@^1.14.7:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.15.0.tgz#5560b99bbad7647e9faa475c6b8056621f5a4ff2"
@@ -11406,6 +11434,16 @@ stylefire@^4.1.3:
     framesync "^4.0.0"
     hey-listen "^1.0.8"
     style-value-types "^3.1.4"
+
+stylefire@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/stylefire/-/stylefire-7.0.0.tgz#2ae16a97f41b8664f2501252ee40c19baba0ea22"
+  integrity sha512-Ea1knZTN5KmbUKSilTsjFEtHcGs+Vl+cQWNnvWQwqRVG+W6J/WgkWjo620hf4II/PTH8uSIF17vGrkpHC41nAA==
+  dependencies:
+    "@popmotion/popcorn" "^0.4.2"
+    framesync "^4.0.0"
+    hey-listen "^1.0.8"
+    style-value-types "^3.1.6"
 
 stylis-rule-sheet@^0.0.10:
   version "0.0.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6057,7 +6057,7 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-framer-motion@^1.6.12:
+framer-motion@1.6.12:
   version "1.6.12"
   resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-1.6.12.tgz#e1928044594ca1b2ed7515f99dccf98f66c5ccde"
   integrity sha512-ooF5lnD8rMQxCT7zekzZIOIpAtX439PEYD1hyq8Rc6cx6+a7n9jg47uc54p/oG3w/aV7yANDDoD7uYkMvB9tnA==


### PR DESCRIPTION
- [ ] Feature
- [ ] Fix
- [x] Enhancement

## Description
This PR is the first of a series. We need to replace [react-pose](https://popmotion.io/pose/) by [framer-motion](https://www.framer.com/api/motion/) since the first one is deprecated.

## Requirements :
<!--- Eventually remove the following. -->
:warning: Requires running `yarn` command.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
