### PR TITLE
refactor(Popover): replace react-pose by framer-motion for the animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "prop-types": "^15.x",
     "react": "^16.x",
     "react-dom": "^16.x",
-    "react-pose": "^4.x",
     "styled-components": "^4.x"
   },
   "dependencies": {
@@ -121,7 +120,6 @@
     "prop-types": "15.7.2",
     "react": "16.11.0",
     "react-dom": "16.11.0",
-    "react-pose": "4.0.9",
     "storybook-readme": "5.0.8",
     "styled-components": "4.4.0"
   },

--- a/src/Dropdown/__tests__/Dropdown.test.js
+++ b/src/Dropdown/__tests__/Dropdown.test.js
@@ -19,6 +19,19 @@ describe('<Dropdown />', () => {
 
     expect(container.firstChild).toMatchSnapshot();
   });
+  test('should render without a problem using portal', () => {
+    const props = { title: 'title' };
+    const { getByTestId } = render(
+      <Dropdown usePortal {...props}>
+        <div>Item1</div>
+        <div>Item2</div>
+        <div>Item3</div>
+      </Dropdown>,
+    );
+
+    const node = getByTestId('positioned-portal');
+    expect(node).toBeInTheDocument();
+  });
 
   test('should toggle the dropdown', async () => {
     const props = { title: 'title' };

--- a/src/Dropdown/__tests__/Dropdown.test.js
+++ b/src/Dropdown/__tests__/Dropdown.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, waitForElementToBeRemoved } from '@testing-library/react';
 import { css } from 'styled-components';
 
 import Dropdown from '..';
@@ -20,7 +20,7 @@ describe('<Dropdown />', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('should toggle the dropdown', done => {
+  test('should toggle the dropdown', async () => {
     const props = { title: 'title' };
     const { container, queryAllByText } = render(
       <Dropdown {...props}>
@@ -40,8 +40,7 @@ describe('<Dropdown />', () => {
     expect(button).toHaveAttribute('aria-expanded', 'true');
     expect(button).toHaveAttribute('aria-haspopup', 'true');
 
-    let ItemNode;
-    ItemNode = queryAllByText(/Item/);
+    const ItemNode = queryAllByText(/Item/);
 
     expect(ItemNode).toHaveLength(3);
     expect(ItemNode[0]).toBeInTheDocument();
@@ -51,15 +50,13 @@ describe('<Dropdown />', () => {
     // Close Dropdown
     fireEvent.click(button);
 
-    setTimeout(() => {
-      ItemNode = queryAllByText(/Item/);
-      expect(button).toHaveAttribute('aria-expanded', 'false');
-      expect(button).toHaveAttribute('aria-haspopup', 'true');
-      expect(ItemNode[0]).toBeUndefined();
-      expect(ItemNode[1]).toBeUndefined();
-      expect(ItemNode[2]).toBeUndefined();
-      done();
-    }, 500);
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(button).toHaveAttribute('aria-haspopup', 'true');
+
+    const ItemNodeRemoved = await waitForElementToBeRemoved(() => queryAllByText(/Item/));
+    expect(ItemNodeRemoved[0]).toBeUndefined();
+    expect(ItemNodeRemoved[1]).toBeUndefined();
+    expect(ItemNodeRemoved[2]).toBeUndefined();
   });
 
   test('should filter items', () => {
@@ -146,7 +143,7 @@ describe('<Dropdown />', () => {
         }
       `,
     };
-    const { container, getAllByRole, getByText } = render(
+    const { container, getAllByRole } = render(
       <Dropdown {...props}>
         <div>Item1</div>
         <div>Item2</div>

--- a/src/Dropdown/animation.js
+++ b/src/Dropdown/animation.js
@@ -1,0 +1,25 @@
+/**
+ * Define animation variants for modal animation
+ * https://www.framer.com/api/motion/
+ */
+export const animationVariants = {
+  visible: {
+    opacity: 1,
+    scaleY: 1,
+    originX: '50%',
+    originY: '0%',
+    transition: {
+      ease: 'anticipate',
+      duration: 0.15,
+    },
+  },
+  hidden: {
+    opacity: 0,
+    scaleY: 0,
+    originX: '50%',
+    originY: '0%',
+    transition: {
+      duration: 0.15,
+    },
+  },
+};

--- a/src/Dropdown/index.js
+++ b/src/Dropdown/index.js
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import Popover from '../Popover';
 import SearchBar from './SearchBar';
 import { Header, HeaderContent, Menu, MenuItem, SearchInputContainer } from './elements';
+import { animationVariants } from './animation';
 
 /**
  * A Dropdown displays content through its children prop that must be components wrapping text.
@@ -164,6 +165,7 @@ class Dropdown extends PureComponent {
     return (
       <div className={className} data-testid="dropdown">
         <Popover
+          animationVariants={animationVariants}
           content={
             <Menu>
               {searchable && (
@@ -202,6 +204,7 @@ class Dropdown extends PureComponent {
             </Menu>
           }
           contentRef={contentRef}
+          contentWrapperStyle={{ marginTop: '4rem' }}
           isOpen={displayMenu}
           modifiers={modifiers}
           onClickOutside={this.onClickOutside}

--- a/src/Dropdown/index.js
+++ b/src/Dropdown/index.js
@@ -122,6 +122,8 @@ class Dropdown extends PureComponent {
     const displayMenu = this.getControllableValue('displayMenu');
     const { onToggle } = this.props;
 
+    this.updatePosition();
+
     if (this.isControlled('displayMenu')) {
       onToggle && onToggle(event);
     } else {

--- a/src/Dropdown/index.js
+++ b/src/Dropdown/index.js
@@ -8,6 +8,7 @@ import Popover from '../Popover';
 import SearchBar from './SearchBar';
 import { Header, HeaderContent, Menu, MenuItem, SearchInputContainer } from './elements';
 import { animationVariants } from './animation';
+import { offset } from './utils';
 
 /**
  * A Dropdown displays content through its children prop that must be components wrapping text.
@@ -23,10 +24,29 @@ class Dropdown extends PureComponent {
   state = {
     displayMenu: false,
     searchKeyword: '',
+    portalPosition: { left: '0px', top: '0px' },
   };
 
   /** preserve the initial state in a new object. */
   baseState = this.state;
+
+  constructor(props) {
+    super(props);
+    this.dropdown = React.createRef();
+  }
+
+  componentDidMount() {
+    // listen for resize and mousewheel to handle portal position
+    setTimeout(this.updatePosition.bind(this), 0);
+    window.addEventListener('resize', this.updatePosition.bind(this));
+    document.body.addEventListener('mousewheel', this.updatePosition.bind(this));
+  }
+
+  componentWillUnmount() {
+    // will remove resize and mousewheel event on dismount
+    window.removeEventListener('resize', this.updatePosition.bind(this));
+    document.body.removeEventListener('mousewheel', this.updatePosition.bind(this));
+  }
 
   /**
    * Handle Search
@@ -89,7 +109,8 @@ class Dropdown extends PureComponent {
    *
    */
   resetSearchInput = () => {
-    this.setState(this.baseState);
+    const { portalPosition } = this.state;
+    this.setState({ ...this.baseState, portalPosition });
   };
 
   /**
@@ -131,6 +152,15 @@ class Dropdown extends PureComponent {
   };
 
   /**
+   * Save current dropdown position in state for portal
+   */
+  updatePosition() {
+    if (this.dropdown.current) {
+      this.setState({ portalPosition: offset(this.dropdown.current) });
+    }
+  }
+
+  /**
    * Renders the component.
    *
    * @return {jsx}
@@ -149,7 +179,12 @@ class Dropdown extends PureComponent {
       title,
       usePortal,
     } = this.props;
-    const { contentWidth, displayMenu: displayMenuState, searchKeyword } = this.state;
+    const {
+      contentWidth,
+      displayMenu: displayMenuState,
+      portalPosition,
+      searchKeyword,
+    } = this.state;
     const { displayMenu: displayMenuProp } = this.props;
     const displayMenu = this.isControlled('displayMenu') ? displayMenuProp : displayMenuState;
 
@@ -163,7 +198,7 @@ class Dropdown extends PureComponent {
       : [];
 
     return (
-      <div className={className} data-testid="dropdown">
+      <div ref={this.dropdown} className={className} data-testid="dropdown">
         <Popover
           animationVariants={animationVariants}
           content={
@@ -208,6 +243,7 @@ class Dropdown extends PureComponent {
           isOpen={displayMenu}
           modifiers={modifiers}
           onClickOutside={this.onClickOutside}
+          portalPosition={portalPosition}
           triggerRef={this.triggerRef}
           usePortal={usePortal}
           width={contentWidth}

--- a/src/Dropdown/utils.js
+++ b/src/Dropdown/utils.js
@@ -1,0 +1,13 @@
+/**
+ * Return the offset position of a DOM element
+ * @param {*} node DOM element
+ *
+ * @returns {object} offset position
+ */
+export const offset = node => {
+  const rect = node.getBoundingClientRect();
+  const scrollLeft = window.pageXOffset || document.documentElement.scrollLeft;
+  const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+
+  return { top: rect.top + scrollTop, left: rect.left + scrollLeft };
+};

--- a/src/Popover/__tests__/Popover.test.js
+++ b/src/Popover/__tests__/Popover.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, fireEvent } from '@testing-library/react';
+import { cleanup, fireEvent, findByTestId } from '@testing-library/react';
 
 import Popover from '..';
 
@@ -21,6 +21,26 @@ describe('<Popover />', () => {
     const popoverNode = getByTestId('popover');
 
     expect(popoverNode).toBeInTheDocument();
+  });
+
+  test('should render open popover using portal without a problem', () => {
+    const { queryByTestId } = render(
+      <Popover usePortal content="content" isOpen>
+        Trigger
+      </Popover>,
+    );
+
+    expect(queryByTestId('positioned-portal')).toBeNull();
+  });
+
+  test('should render open popover using portal and custom position without a problem', () => {
+    const { queryByTestId } = render(
+      <Popover usePortal portalPosition={{ top: '10px', left: '10px' }} content="content" isOpen>
+        Trigger
+      </Popover>,
+    );
+
+    expect(queryByTestId('positioned-portal')).toBeInTheDocument();
   });
 
   test('should render with a different width', () => {

--- a/src/Popover/animation.js
+++ b/src/Popover/animation.js
@@ -1,0 +1,18 @@
+/**
+ * Define animation variants for modal animation
+ * https://www.framer.com/api/motion/
+ */
+export const popoverVariants = {
+  visible: {
+    opacity: 1,
+    transition: {
+      duration: 0.15,
+    },
+  },
+  hidden: {
+    opacity: 0,
+    transition: {
+      duration: 0.15,
+    },
+  },
+};

--- a/src/Popover/elements.js
+++ b/src/Popover/elements.js
@@ -1,5 +1,6 @@
 import styled, { css } from 'styled-components';
 import { transparentize } from 'polished';
+import { motion } from 'framer-motion';
 
 export const ARROW_SIZE = 8;
 export const CONTENT_PADDING = 1.8;
@@ -57,7 +58,7 @@ export const Arrow = styled.span`
     `}
 `;
 
-export const PopoverContentWrapper = styled.div`
+export const PopoverContentWrapper = styled(motion.div)`
   background: ${({ theme: { palette } }) => palette.white};
   border-radius: ${({ theme: { dimensions } }) => dimensions.radius};
 

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -1,11 +1,12 @@
 import React, { Children, cloneElement, PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import posed, { PoseGroup } from 'react-pose';
+import { AnimatePresence } from 'framer-motion';
 import { Portal } from 'react-portal';
 import { Manager, Popper, Reference } from 'react-popper';
 
 import EventListener from '../EventListener';
 import { Arrow, PopoverContentWrapper, PopoverTriggerWrapper } from './elements';
+import { popoverVariants } from './animation';
 
 /**
  * Popover using popperjs and portal
@@ -86,7 +87,7 @@ class Popover extends PureComponent {
    */
   renderContent = () => {
     const {
-      animationProps,
+      animationVariants,
       content,
       contentWrapperStyle,
       hasArrow,
@@ -99,18 +100,20 @@ class Popover extends PureComponent {
     } = this.props;
 
     let popoverContent;
-
     const popper = (
       <Popper modifiers={modifiers} placement={placement} positionFixed={positionFixed}>
         {({ arrowProps, outOfBoundaries, placement, ref: popperRef, style }) => (
-          <PoseGroup flipMove={false}>
+          <AnimatePresence>
             {isOpen && (
-              <PopoverContentWrapperAnimation
+              <PopoverContentWrapper
                 key="popover"
                 data-testid="popover"
+                initial="hidden"
+                animate="visible"
+                exit="hidden"
+                variants={animationVariants}
                 data-out-of-boundaries={outOfBoundaries || undefined}
                 data-placement={placement}
-                animationProps={animationProps}
                 ref={node => {
                   this.setContentRef(node);
                   popperRef(node);
@@ -124,9 +127,9 @@ class Popover extends PureComponent {
                     ▲
                   </Arrow>
                 )}
-              </PopoverContentWrapperAnimation>
+              </PopoverContentWrapper>
             )}
-          </PoseGroup>
+          </AnimatePresence>
         )}
       </Popper>
     );
@@ -191,9 +194,9 @@ class Popover extends PureComponent {
 const { array, bool, func, node, object, oneOfType, string } = PropTypes;
 Popover.propTypes = {
   /**
-   * Custom animation options to pass to PopoverContentWrapperAnimation
+   * Custom variants animation from framer motion (https://www.framer.com/api/motion/) options to pass to our popover
    */
-  animationProps: object,
+  animationVariants: object,
 
   /**
    * Must be a single element that will be the trigger of the popover
@@ -270,7 +273,7 @@ Popover.propTypes = {
  * Default props
  */
 Popover.defaultProps = {
-  animationProps: null,
+  animationVariants: popoverVariants,
   contentWrapperStyle: null,
   contentRef: null,
   hasArrow: false,
@@ -284,22 +287,5 @@ Popover.defaultProps = {
   usePortal: false,
   width: 'auto',
 };
-
-/**
- * Animation
- */
-const PopoverContentWrapperAnimation = posed(PopoverContentWrapper)({
-  enter: {
-    opacity: 1,
-    transition: {
-      y: { type: 'spring', stiffness: 900, damping: 30 },
-      default: { duration: 150 },
-    },
-  },
-  exit: {
-    opacity: 0,
-    transition: { duration: 150 },
-  },
-});
 
 export default Popover;

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -94,6 +94,7 @@ class Popover extends PureComponent {
       isOpen,
       modifiers,
       placement,
+      portalPosition,
       positionFixed,
       usePortal,
       width,
@@ -135,7 +136,21 @@ class Popover extends PureComponent {
     );
 
     if (usePortal) {
-      popoverContent = <Portal>{popper}</Portal>;
+      if (portalPosition) {
+        const { left, top } = portalPosition;
+        popoverContent = (
+          <Portal>
+            <div
+              data-testid="positioned-portal"
+              style={{ position: 'absolute', left: `${left}px`, top: `${top}px` }}
+            >
+              {popper}
+            </div>
+          </Portal>
+        );
+      } else {
+        popoverContent = <Portal>{popper}</Portal>;
+      }
     } else {
       popoverContent = popper;
     }
@@ -244,6 +259,11 @@ Popover.propTypes = {
   placement: string,
 
   /**
+   * Custom portal position
+   */
+  portalPosition: object,
+
+  /**
    * Popper option. Put the popper in "fixed" mode. See https://popper.js.org/popper-documentation.html
    */
   positionFixed: bool,
@@ -281,6 +301,7 @@ Popover.defaultProps = {
   modifiers: {},
   onClickOutside: null,
   placement: 'bottom',
+  portalPosition: null,
   positionFixed: false,
   triggerRef: null,
   triggerWrapperCss: null,

--- a/src/Select/__stories__/Select.stories.js
+++ b/src/Select/__stories__/Select.stories.js
@@ -22,6 +22,7 @@ storiesOf('Select', module)
     const onChange = action('onChange');
     const disabled = boolean('Disabled', false, 'State');
     const resetValue = boolean('Reset value', false, 'State');
+    const usePortal = boolean('usePortal', false, 'State');
 
     return (
       <ScrollBox>
@@ -36,6 +37,7 @@ storiesOf('Select', module)
           onChange={onChange}
           onToggle={onToggle}
           resetValue={resetValue}
+          usePortal={usePortal}
         >
           <Select.Option value="home">Home</Select.Option>
           <Select.Option value="calendar">Calendar</Select.Option>

--- a/src/Select/__tests__/Select.test.js
+++ b/src/Select/__tests__/Select.test.js
@@ -20,6 +20,21 @@ describe('<Select />', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('should render using portal without a problem', () => {
+    const props = { placeholder: 'placeholder' };
+    const { getByTestId } = render(
+      <Select usePortal {...props}>
+        <Select.Option value="1">Item</Select.Option>
+        <Select.Option value="2">Item</Select.Option>
+        <Select.Option value="3">Item</Select.Option>
+        <Select.Option value="4">Item</Select.Option>
+      </Select>,
+    );
+
+    const node = getByTestId('positioned-portal');
+    expect(node).toBeInTheDocument();
+  });
+
   test('should render without a problem when disabled', () => {
     const props = { placeholder: 'placeholder', disabled: true };
     const { container } = render(

--- a/src/Select/__tests__/Select.test.js
+++ b/src/Select/__tests__/Select.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, wait } from '@testing-library/react';
+import { fireEvent, waitForElement, waitForElementToBeRemoved } from '@testing-library/react';
 
 import Select from '..';
 
@@ -34,9 +34,9 @@ describe('<Select />', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('should toggle the Select', done => {
+  test('should toggle the Select', async () => {
     const props = { placeholder: 'placeholder' };
-    const { container, queryAllByText } = render(
+    const { container, queryAllByText, getAllByText } = render(
       <Select {...props}>
         <Select.Option value="1">Item</Select.Option>
         <Select.Option value="2">Item</Select.Option>
@@ -56,8 +56,7 @@ describe('<Select />', () => {
     expect(button).toHaveAttribute('aria-expanded', 'true');
     expect(button).toHaveAttribute('aria-haspopup', 'true');
 
-    let ItemNode;
-    ItemNode = queryAllByText(/Item/);
+    let ItemNode = queryAllByText(/Item/);
 
     expect(ItemNode).toHaveLength(4);
     expect(ItemNode[0]).toBeInTheDocument();
@@ -67,15 +66,70 @@ describe('<Select />', () => {
     // Close Select
     fireEvent.click(button);
 
-    setTimeout(() => {
-      ItemNode = queryAllByText(/Item/);
-      expect(button).toHaveAttribute('aria-expanded', 'false');
-      expect(button).toHaveAttribute('aria-haspopup', 'true');
-      expect(ItemNode[0]).toBeUndefined();
-      expect(ItemNode[1]).toBeUndefined();
-      expect(ItemNode[2]).toBeUndefined();
-      done();
-    }, 500);
+    await waitForElementToBeRemoved(() => getAllByText(/Item/));
+
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(button).toHaveAttribute('aria-haspopup', 'true');
+
+    ItemNode = queryAllByText(/Item/);
+
+    expect(ItemNode[0]).toBeUndefined();
+    expect(ItemNode[1]).toBeUndefined();
+    expect(ItemNode[2]).toBeUndefined();
+  });
+
+  test('should update its value accordingly', async () => {
+    const { container, queryByText, getByText } = render(
+      <Select>
+        <Select.Option value="1">Item 1</Select.Option>
+        <Select.Option value="2">Item 2</Select.Option>
+        <Select.Option value="3">Item 3</Select.Option>
+        <Select.Option value="4">Item 4</Select.Option>
+      </Select>,
+    );
+
+    const buttonNode = container.querySelector('button');
+    expect(buttonNode).toHaveAttribute('aria-expanded', 'false');
+
+    let Item1 = getByText('Item 1');
+    let Item2 = queryByText('Item 3');
+    expect(Item1).toBeInTheDocument();
+    expect(Item2).not.toBeInTheDocument();
+
+    // open select and pick another option
+    fireEvent.click(buttonNode);
+
+    // Wait for the select to open
+    let Item3 = await waitForElement(() => getByText('Item 3'));
+
+    // Select the third items
+    fireEvent.click(Item3);
+
+    // Wait for the select to close
+    await waitForElementToBeRemoved(() => getByText('Item 1'));
+
+    Item1 = queryByText('Item 1');
+    Item3 = getByText('Item 3');
+
+    expect(Item1).not.toBeInTheDocument();
+    expect(Item3).toBeInTheDocument();
+
+    // open select and pick another option
+    fireEvent.click(buttonNode);
+
+    Item2 = await waitForElement(() => getByText('Item 2'));
+
+    // Select the second items
+    fireEvent.click(Item2);
+
+    // Wait for the select to close
+    await waitForElementToBeRemoved(() => getByText('Item 3'));
+
+    Item3 = queryByText('Item 3');
+    Item2 = getByText('Item 2');
+
+    expect(Item3).not.toBeInTheDocument();
+    expect(Item2).toBeInTheDocument();
   });
 
   test('should call onToggle when Select is toggled', () => {
@@ -197,54 +251,5 @@ describe('<Select />', () => {
 
     const displayedOption = getByText('Item 3');
     expect(displayedOption).toBeInTheDocument();
-  });
-
-  test('should update its value accordingly', async () => {
-    const { container, queryByText, getByText, rerender } = render(
-      <Select>
-        <Select.Option value="1">Item 1</Select.Option>
-        <Select.Option value="2">Item 2</Select.Option>
-        <Select.Option value="3">Item 3</Select.Option>
-        <Select.Option value="4">Item 4</Select.Option>
-      </Select>,
-    );
-
-    const buttonNode = container.querySelector('button');
-    expect(buttonNode).toHaveAttribute('aria-expanded', 'false');
-
-    let firstOption = getByText('Item 1');
-    let thirdOption = queryByText('Item 3');
-    expect(firstOption).toBeInTheDocument();
-    expect(thirdOption).not.toBeInTheDocument();
-
-    // open select and pick another option
-    fireEvent.click(buttonNode);
-    thirdOption = getByText('Item 3');
-    fireEvent.click(thirdOption);
-
-    await wait(() => {
-      firstOption = queryByText('Item 1');
-      expect(firstOption).not.toBeInTheDocument();
-      // get current option displayed in the button
-      thirdOption = getByText('Item 3');
-      expect(thirdOption).toBeInTheDocument();
-
-      const props = { value: '2' };
-      rerender(
-        <Select {...props}>
-          <Select.Option value="1">Item 1</Select.Option>
-          <Select.Option value="2">Item 2</Select.Option>
-          <Select.Option value="3">Item 3</Select.Option>
-          <Select.Option value="4">Item 4</Select.Option>
-        </Select>,
-      );
-
-      const secondOption = getByText('Item 2');
-      expect(secondOption).toBeInTheDocument();
-      firstOption = queryByText('Item 1');
-      expect(firstOption).not.toBeInTheDocument();
-      thirdOption = queryByText('Item 3');
-      expect(thirdOption).not.toBeInTheDocument();
-    });
   });
 });

--- a/src/Select/animation.js
+++ b/src/Select/animation.js
@@ -1,0 +1,25 @@
+/**
+ * Define animation variants for modal animation
+ * https://www.framer.com/api/motion/
+ */
+export const animationVariants = {
+  visible: {
+    opacity: 1,
+    scaleY: 1,
+    originX: '50%',
+    originY: '0%',
+    transition: {
+      ease: 'anticipate',
+      duration: 0.15,
+    },
+  },
+  hidden: {
+    opacity: 0,
+    scaleY: 0,
+    originX: '50%',
+    originY: '0%',
+    transition: {
+      duration: 0.15,
+    },
+  },
+};

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -7,6 +7,7 @@ import styled, { css } from 'styled-components';
 import { Popover } from '..';
 import { Header, HeaderContent, Menu, MenuItem } from './elements';
 import Option from './Option';
+import { animationVariants } from './animation';
 
 /**
  * Select component displays a button as header holding one value at a time amongst
@@ -230,21 +231,7 @@ class Select extends PureComponent {
     return (
       <div className={className}>
         <Popover
-          animationProps={{
-            enter: {
-              opacity: 1,
-              scaleY: 1,
-              transition: {
-                scaleY: { ease: 'anticipate', duration: 150 },
-                default: { duration: 150 },
-              },
-            },
-            exit: {
-              opacity: 0,
-              scaleY: 0,
-              transition: { duration: 150 },
-            },
-          }}
+          animationVariants={animationVariants}
           content={
             <Menu>
               {Children.map(children, child => (
@@ -265,6 +252,7 @@ class Select extends PureComponent {
           onClickOutside={this.onClickOutside}
           triggerRef={this.triggerRef}
           triggerWrapperCss={triggerWrapperCss}
+          contentWrapperStyle={{ marginTop: '4rem' }}
           usePortal={usePortal}
           width={contentWidth}
         >

--- a/src/Select/utils.js
+++ b/src/Select/utils.js
@@ -1,0 +1,13 @@
+/**
+ * Return the offset position of a DOM element
+ * @param {*} node DOM element
+ *
+ * @returns {object} offset position
+ */
+export const offset = node => {
+  const rect = node.getBoundingClientRect();
+  const scrollLeft = window.pageXOffset || document.documentElement.scrollLeft;
+  const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+
+  return { top: rect.top + scrollTop, left: rect.left + scrollLeft };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1018,18 +1018,6 @@
   dependencies:
     "@emotion/memoize" "0.7.3"
 
-"@emotion/is-prop-valid@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz#a6bf4fa5387cbba59d44e698a4680f481a8da6cc"
-  integrity sha512-uxJqm/sqwXw3YPA5GXX365OBcJGFtxUVkB6WyezqFHlNe9jqUWH5ur2O2M8dGBz61kn1g3ZBlzUunFQXQIClhA==
-  dependencies:
-    "@emotion/memoize" "0.7.1"
-
-"@emotion/memoize@0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.1.tgz#e93c13942592cf5ef01aa8297444dc192beee52f"
-  integrity sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg==
-
 "@emotion/memoize@0.7.3":
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.3.tgz#5b6b1c11d6a6dddf1f2fc996f74cf3b219644d78"
@@ -1929,11 +1917,6 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.3.tgz#856c99cdc1551d22c22b18b5402719affec9839a"
   integrity sha512-cS5owqtwzLN5kY+l+KgKdRJ/Cee8tlmQoGQuIE9tWnSmS3JMKzmxo2HIAk2wODMifGwO20d62xZQLYz+RLfXmw==
 
-"@types/invariant@^2.2.29":
-  version "2.2.30"
-  resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.30.tgz#20efa342807606ada5483731a8137cb1561e5fe9"
-  integrity sha512-98fB+yo7imSD2F7PF7GIpELNgtLNgo5wjivu0W5V4jx+KVVJxo6p/qN4zdzSTBWy4/sN3pPyXwnhRSD28QX+ag==
-
 "@types/is-function@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/is-function/-/is-function-1.0.0.tgz#1b0b819b1636c7baf0d6785d030d12edf70c3e83"
@@ -1963,11 +1946,6 @@
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
-
-"@types/node@^10.0.5":
-  version "10.14.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.18.tgz#b7d45fc950e6ffd7edc685e890d13aa7b8535dce"
-  integrity sha512-ryO3Q3++yZC/+b8j8BdKd/dn9JlzlHBPdm80656xwYUdmPkpTGTjkAdt6BByiNupGPE8w0FhBgvYy/fX9hRNGQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -9381,20 +9359,7 @@ polished@3.4.1, polished@^3.3.1:
   dependencies:
     "@babel/runtime" "^7.4.5"
 
-popmotion-pose@^3.4.0:
-  version "3.4.8"
-  resolved "https://registry.yarnpkg.com/popmotion-pose/-/popmotion-pose-3.4.8.tgz#a50d7d2e91014405402f23400b08994fd148b5ce"
-  integrity sha512-/dkEhDiTYkbLb15dkrU3Okh58KU5I8z3f18V7kciN/cJmSc8ZD8tWgOc8U9yJf3lUHnf/va5PMCX4/4RnVeUiQ==
-  dependencies:
-    "@popmotion/easing" "^1.0.1"
-    hey-listen "^1.0.5"
-    popmotion "^8.6.2"
-    pose-core "^2.1.0"
-    style-value-types "^3.0.6"
-    ts-essentials "^1.0.3"
-    tslib "^1.9.1"
-
-popmotion@8.7.0, popmotion@^8.6.2:
+popmotion@8.7.0:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-8.7.0.tgz#83e03a14dc1f24e73b9488c6d9d7b14e5ac0947d"
   integrity sha512-RnJMbWN+TEBT0tgG+3WS0O1i9LAq+senXSAcKw+srGviT1c9G+iKUXrp24D2w6Og0mDd61rEfKz3pFrFCdKn5Q==
@@ -9423,16 +9388,6 @@ popper.js@^1.14.4, popper.js@^1.14.7, popper.js@^1.15.0:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.15.0.tgz#5560b99bbad7647e9faa475c6b8056621f5a4ff2"
   integrity sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA==
-
-pose-core@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/pose-core/-/pose-core-2.1.0.tgz#653c85a9a06f924611b909b4a2180ce102bbb258"
-  integrity sha512-36mVAnIgbM6jfyRug8EqqFbazHUAk9dxwVRpX61FlVw3amI/j7AFegtVU56N0Dht2aYDJIhgYPUYraT1CzjHDw==
-  dependencies:
-    "@types/invariant" "^2.2.29"
-    "@types/node" "^10.0.5"
-    hey-listen "^1.0.5"
-    tslib "^1.9.1"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -10063,16 +10018,6 @@ react-portal@4.2.0:
   integrity sha512-Zf+vGQ/VEAb5XAy+muKEn48yhdCNYPZaB1BWg1xc8sAZWD8pXTgPtQT4ihBdmWzsfCq8p8/kqf0GWydSBqc+Eg==
   dependencies:
     prop-types "^15.5.8"
-
-react-pose@4.0.9:
-  version "4.0.9"
-  resolved "https://registry.yarnpkg.com/react-pose/-/react-pose-4.0.9.tgz#e65025b2df1759101790adaba2ec68361556ae6d"
-  integrity sha512-NCAgAIzH8MkNYhW+M6Dnps88lOo8nr08SoKbB7PfZH9ztbql9jRzlJxH9A5x3zLxahya6nsyxjCsi5+qLZV7ng==
-  dependencies:
-    "@emotion/is-prop-valid" "^0.7.3"
-    hey-listen "^1.0.5"
-    popmotion-pose "^3.4.0"
-    tslib "^1.9.1"
 
 react-select@^3.0.0:
   version "3.0.4"
@@ -11375,7 +11320,7 @@ style-loader@^0.23.1:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
 
-style-value-types@^3.0.6, style-value-types@^3.1.4, style-value-types@^3.1.6:
+style-value-types@^3.1.4, style-value-types@^3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-3.1.6.tgz#6b1da918214d92c74dc7fc2d074013f372b47d76"
   integrity sha512-AxcfUr/06AHyyyxkNB1O8ypvwa8/qK+sxwelxEN5x+jxW+RXutRE2TuHEQbFq9OBY7ym83CPKvVIsGd6lvKb0Q==
@@ -11755,11 +11700,6 @@ trim-off-newlines@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
-
-ts-essentials@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-1.0.4.tgz#ce3b5dade5f5d97cf69889c11bf7d2da8555b15a"
-  integrity sha512-q3N1xS4vZpRouhYHDPwO0bDW3EZ6SK9CrrDHxi/D6BPReSjpVgWIOpLS2o0gSBZm+7q/wyKp6RVM1AeeW7uyfQ==
 
 ts-pnp@^1.1.2:
   version "1.1.4"


### PR DESCRIPTION
- [ ] Feature
- [ ] Fix
- [x] Enhancement

## Description
Replace react-pose by framer-motion for the animation.
This PR also remove react-pose dependecy

## Requirements :
<!--- Eventually remove the following. -->
:warning: Requires running `yarn` command.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
