### PR TITLE
fix(Table): Change hover cell to hover row

### DIFF
--- a/src/Table/__stories__/Table.stories.js
+++ b/src/Table/__stories__/Table.stories.js
@@ -17,6 +17,7 @@ storiesOf('Table', module)
   })
   .add('default', () => {
     const striped = boolean('Striped', false, 'State');
+    const isHoverable = boolean('Hoverable', false, 'State');
     const selectableRow = boolean('Selectable row', false, 'State');
     const dishRowSortable = boolean('Dish row is sortable', true, 'State');
     const priceRowSortable = boolean('Price row is sortable', true, 'State');
@@ -94,12 +95,14 @@ storiesOf('Table', module)
           colsDef={getColsDef(taxCountryCodeValue)}
           rowsDef={rowsDef}
           striped={striped}
+          isHoverable={isHoverable}
         />
       </Wrapper>
     );
   })
   .add('Scrollable table', () => {
     const striped = boolean('Striped', false, 'State');
+    const isHoverable = boolean('Hoverable', false, 'State');
     const selectableRow = boolean('Selectable row', false, 'State');
     const dishRowSortable = boolean('Dish row is sortable', true, 'State');
     const priceRowSortable = boolean('Price row is sortable', true, 'State');
@@ -287,6 +290,7 @@ storiesOf('Table', module)
       <Wrapper>
         <Table
           isScrollable
+          isHoverable={isHoverable}
           height="40rem"
           data={data}
           dataTotal={dataTotal}

--- a/src/Table/__tests__/Table.test.js
+++ b/src/Table/__tests__/Table.test.js
@@ -11,6 +11,7 @@ StubComponent.displayName = 'StubComponent';
 const getColsDef = (taxCountryCode = 'fr') => [
   {
     title: 'DISH',
+    isRowHeader: true,
     value: d => d.code,
     isSortable: true,
     align: 'left',
@@ -248,5 +249,21 @@ describe('<Table />', () => {
     const tableContainer = getByTestId('table-container');
 
     expect(tableContainer).toHaveStyleRule('overflow', 'scroll');
+  });
+
+  test('should table be hoverable', () => {
+    const { getByText, getAllByTestId } = render(
+      <Table isHoverable height="10rem" colsDef={getColsDef()} data={data} />,
+    );
+
+    const sortedBodyRows = getAllByTestId('body-row');
+
+    expect(sortedBodyRows[0]).toHaveTextContent(/tartare de boeuf/i);
+
+    fireEvent.mouseOver(sortedBodyRows[0]);
+
+    const tartareRow = getByText(/tartare de boeuf/i);
+
+    expect(tartareRow).toHaveStyleRule(`background-color: ${Theme.palette.veryLightGrey}`);
   });
 });

--- a/src/Table/elements.js
+++ b/src/Table/elements.js
@@ -224,6 +224,7 @@ export const Footer = styled.tfoot`
       top: 0;
       width: 100%;
       border-top: 1px solid ${({ theme: { palette } }) => palette.veryLightBlue};
+      box-sizing: border-box;
     }
 
     height: 5.2rem;

--- a/src/Table/elements.js
+++ b/src/Table/elements.js
@@ -130,12 +130,6 @@ export const Body = styled.tbody`
       padding-right: 3rem;
     }
   }
-  tr:hover {
-    & > th,
-    & > td {
-      background-color: ${({ theme: { palette } }) => palette.veryLightGrey};
-    }
-  }
 `;
 
 export const BodyRow = styled(Row)`
@@ -166,6 +160,17 @@ export const BodyRow = styled(Row)`
         box-shadow: inset 3px 0px 0 0px ${({ theme: { palette } }) => palette.primary.default};
       }
     `};
+
+  ${({ isHoverable }) =>
+    isHoverable &&
+    css`
+      &:hover {
+        & > th,
+        & > td {
+          background-color: ${({ theme: { palette } }) => palette.veryLightGrey};
+        }
+      }
+    `}
 `;
 
 export const RowHeader = styled.th`
@@ -246,12 +251,16 @@ export const Footer = styled.tfoot`
     padding: 0 3rem 0 0.5rem;
   }
 
-  tr:hover {
-    & > th,
-    & > td {
-      background-color: ${({ theme: { palette } }) => palette.veryLightGrey};
-    }
-  }
+  ${({ isHoverable }) =>
+    isHoverable &&
+    css`
+      tr:hover {
+        & > th,
+        & > td {
+          background-color: ${({ theme: { palette } }) => palette.veryLightGrey};
+        }
+      }
+    `}
 `;
 
 // Table Container

--- a/src/Table/elements.js
+++ b/src/Table/elements.js
@@ -129,7 +129,10 @@ export const Body = styled.tbody`
     &:last-child {
       padding-right: 3rem;
     }
-    &:hover {
+  }
+  tr:hover {
+    & > th,
+    & > td {
       background-color: ${({ theme: { palette } }) => palette.veryLightGrey};
     }
   }
@@ -198,10 +201,6 @@ export const Footer = styled.tfoot`
 
   td {
     font-feature-settings: 'tnum';
-
-    &:hover {
-      background-color: ${({ theme: { palette } }) => palette.veryLightGrey};
-    }
   }
 
   th,
@@ -245,6 +244,13 @@ export const Footer = styled.tfoot`
 
   td:last-of-type {
     padding: 0 3rem 0 0.5rem;
+  }
+
+  tr:hover {
+    & > th,
+    & > td {
+      background-color: ${({ theme: { palette } }) => palette.veryLightGrey};
+    }
   }
 `;
 

--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -134,6 +134,7 @@ class Table extends PureComponent {
       colsDef,
       data,
       isScrollable,
+      isHoverable,
       rowsDef: { selectable },
       striped,
     } = this.props;
@@ -184,6 +185,7 @@ class Table extends PureComponent {
             selected={selected === key}
             striped={striped}
             onClick={() => this.handleRowSelect(item, key)}
+            isHoverable={isHoverable}
           >
             {colsDef.map(({ isRowHeader, value, format, align }, columnIndex) =>
               isRowHeader ? (
@@ -212,10 +214,10 @@ class Table extends PureComponent {
    * @return {jsx}
    */
   renderFooter() {
-    const { colsDef, dataTotal, isScrollable } = this.props;
+    const { colsDef, dataTotal, isScrollable, isHoverable } = this.props;
 
     return (
-      <Footer data-testid="footer-row" isScrollable={isScrollable}>
+      <Footer data-testid="footer-row" isScrollable={isScrollable} isHoverable={isHoverable}>
         <tr>
           {colsDef.map(({ isRowHeader, total, format, align }, columnIndex) =>
             isRowHeader ? (
@@ -303,6 +305,12 @@ Table.propTypes = {
    **/
   isScrollable: bool,
 
+  /**
+   * Define if the table is isHoverable or not.
+   * When the table is isHoverable if a user hover a row it background change increasing contrast with others improving readability.
+   **/
+  isHoverable: bool,
+
   /** Rows definition */
   rowsDef: shape({
     onSelect: func,
@@ -321,6 +329,7 @@ Table.defaultProps = {
   dataTotal: null,
   height: 'initial',
   isScrollable: false,
+  isHoverable: false,
   rowsDef: {
     onSelect: () => {},
     selectable: false,


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description

Quick fix to change the hoverable element. I change this behaviour to be optional with the props `isHoverable`. Tests done 👍

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
