### PR TITLE
feat(Select): add customizable displayed value

### DIFF
--- a/src/Select/README.md
+++ b/src/Select/README.md
@@ -2,7 +2,12 @@
 
 ### Usage
 
-Select component displays a button as header holding one value at a time amongst a list of values (children)
+Select component displays a button as header holding one value at a time amongst a list of values (children).
+What is displayed inside the button is, by order of priority:
+- the placeholder prop if provided
+- the displayedValue prop if also provided,
+- the value prop if provided (controlled state)
+- the first value amongst the children
 
 ```jsx
 import { Select } from '@tillersystems/stardust';

--- a/src/Select/__stories__/Select.stories.js
+++ b/src/Select/__stories__/Select.stories.js
@@ -132,6 +132,7 @@ storiesOf('Select', module)
                 store.set({ value });
               }}
               disabled={disabled}
+              displayedValue={`This is the current value: ${state.value}`}
               resetValue={resetValue}
               value={state.value}
             >

--- a/src/Select/__stories__/Select.stories.js
+++ b/src/Select/__stories__/Select.stories.js
@@ -21,7 +21,6 @@ storiesOf('Select', module)
     const onToggle = action('onToggle');
     const onChange = action('onChange');
     const disabled = boolean('Disabled', false, 'State');
-    const resetValue = boolean('Reset value', false, 'State');
     const usePortal = boolean('usePortal', false, 'State');
 
     return (
@@ -36,7 +35,6 @@ storiesOf('Select', module)
           placeholder={placeholder}
           onChange={onChange}
           onToggle={onToggle}
-          resetValue={resetValue}
           usePortal={usePortal}
         >
           <Select.Option value="home">Home</Select.Option>
@@ -51,7 +49,6 @@ storiesOf('Select', module)
     const onToggle = action('onToggle');
     const onChange = action('onChange');
     const disabled = boolean('Disabled', false, 'State');
-    const resetValue = boolean('Reset value', false, 'State');
 
     const StyledIcon = styled(Icon)`
       vertical-align: middle;
@@ -60,7 +57,7 @@ storiesOf('Select', module)
 
     return (
       <ScrollBox>
-        <Select onToggle={onToggle} onChange={onChange} disabled={disabled} resetValue={resetValue}>
+        <Select onToggle={onToggle} onChange={onChange} disabled={disabled}>
           <Select.Option value="home">
             <StyledIcon name="home" width="1.5rem" height="1.5rem" color={Theme.palette.darkBlue} />
             <div>Home</div>
@@ -76,7 +73,6 @@ storiesOf('Select', module)
     const onToggle = action('onToggle');
     const onChange = action('onChange');
     const disabled = boolean('Disabled', false, 'State');
-    const resetValue = boolean('Reset value', false, 'State');
     const widthValue = number(
       'Width',
       200,
@@ -95,7 +91,6 @@ storiesOf('Select', module)
           onToggle={onToggle}
           onChange={onChange}
           disabled={disabled}
-          resetValue={resetValue}
           width={`${widthValue.toString()}px`}
         >
           <Select.Option value="home">Home</Select.Option>
@@ -114,7 +109,6 @@ storiesOf('Select', module)
     const onToggle = action('onToggle');
     const onChangeAction = action('onChange');
     const disabled = boolean('Disabled', false, 'Props');
-    const resetValue = boolean('Reset value', false, 'Props');
 
     const StyledIcon = styled(Icon)`
       vertical-align: middle;
@@ -132,8 +126,50 @@ storiesOf('Select', module)
                 store.set({ value });
               }}
               disabled={disabled}
+              value={state.value}
+            >
+              <Select.Option value="home">
+                <StyledIcon
+                  name="home"
+                  width="1.5rem"
+                  height="1.5rem"
+                  color={Theme.palette.darkBlue}
+                />
+                <div>Home</div>
+              </Select.Option>
+              <Select.Option value="calendar">Calendar</Select.Option>
+              <Select.Option value="settings">Settings</Select.Option>
+              <Select.Option value="user">User</Select.Option>
+            </Select>
+          )}
+        </State>
+      </ScrollBox>
+    );
+  })
+  .add('with custom displayed value', () => {
+    const store = new Store({
+      value: 'settings',
+    });
+
+    const onToggle = action('onToggle');
+    const onChangeAction = action('onChange');
+
+    const StyledIcon = styled(Icon)`
+      vertical-align: middle;
+      margin: auto 0.5rem auto auto;
+    `;
+
+    return (
+      <ScrollBox>
+        <State store={store}>
+          {state => (
+            <Select
+              onToggle={onToggle}
+              onChange={value => {
+                onChangeAction(value);
+                store.set({ value });
+              }}
               displayedValue={`This is the current value: ${state.value}`}
-              resetValue={resetValue}
               value={state.value}
             >
               <Select.Option value="home">

--- a/src/Select/__tests__/Select.test.js
+++ b/src/Select/__tests__/Select.test.js
@@ -267,4 +267,19 @@ describe('<Select />', () => {
     const displayedOption = getByText('Item 3');
     expect(displayedOption).toBeInTheDocument();
   });
+
+  test('should display displayedValue prop', () => {
+    const props = { value: '3', displayedValue: 'The current value is 3' };
+    const { getByText } = render(
+      <Select {...props}>
+        <Select.Option value="1">Item 1</Select.Option>
+        <Select.Option value="2">Item 2</Select.Option>
+        <Select.Option value="3">Item 3</Select.Option>
+        <Select.Option value="4">Item 4</Select.Option>
+      </Select>,
+    );
+
+    const displayedText = getByText('The current value is 3');
+    expect(displayedText).toBeInTheDocument();
+  });
 });

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -247,6 +247,7 @@ class Select extends PureComponent {
       className,
       contentRef,
       disabled,
+      displayedValue,
       modifiers,
       placeholder,
       triggerWrapperCss,
@@ -295,6 +296,8 @@ class Select extends PureComponent {
               {/* if placeholder is defined display it, otherwise use the value of the first option */}
               {hasPlaceholder && !value
                 ? placeholder
+                : displayedValue
+                ? displayedValue
                 : Children.map(children, child => (child.props.value === value ? child : null))}
             </HeaderContent>
           </Header>
@@ -330,6 +333,11 @@ Select.propTypes = {
   disabled: bool,
 
   /**
+   * What the select should display in its button. Different from placeholder, it will be used if a value has been set
+   */
+  displayedValue: node,
+
+  /**
    * CSS height of the component
    */
   // https://github.com/yannickcr/eslint-plugin-react/issues/1520
@@ -352,7 +360,7 @@ Select.propTypes = {
   onToggle: func,
 
   /**
-   * Placeholder of the <Select /> component in the header
+   * Placeholder of the <Select /> component in the header. Displayed only if no value has been set yet.
    */
   placeholder: string,
 

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -23,30 +23,11 @@ class Select extends PureComponent {
     super(props);
     this.select = React.createRef();
   }
-  /**
-   * getDerivedStateFromProps
-   *
-   * @param {object} props
-   * @param {object} state
-   *
-   * @return {object}
-   */
-  static getDerivedStateFromProps(props, state) {
-    if (props.resetValue !== state.resetValue) {
-      return {
-        resetValue: props.resetValue,
-        ...(props.resetValue ? { value: null } : {}),
-      };
-    }
-
-    return null;
-  }
 
   /** Internal state. */
   state = {
     displayMenu: false,
     value: null,
-    resetValue: this.props.resetValue, // eslint-disable-line react/destructuring-assignment
     portalPosition: { left: '0px', top: '0px' },
   };
 
@@ -365,11 +346,6 @@ Select.propTypes = {
   placeholder: string,
 
   /**
-   * If select value should be reset to null
-   */
-  resetValue: bool,
-
-  /**
    * css provided to the trigger wrapper. Must use `css` method from styled-components.
    */
   triggerWrapperCss: array,
@@ -400,7 +376,6 @@ Select.defaultProps = {
   className: '',
   disabled: false,
   height: '3.8rem',
-  resetValue: false,
   triggerWrapperCss: null,
   usePortal: false,
   width: '100%',

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -45,7 +45,6 @@ class Select extends PureComponent {
   /** Internal state. */
   state = {
     displayMenu: false,
-    placeholder: this.props.placeholder, // eslint-disable-line react/destructuring-assignment
     value: null,
     resetValue: this.props.resetValue, // eslint-disable-line react/destructuring-assignment
     portalPosition: { left: '0px', top: '0px' },
@@ -60,7 +59,7 @@ class Select extends PureComponent {
    * the placeholder at the render.
    */
   componentDidMount() {
-    const { children } = this.props;
+    const { children, placeholder } = this.props;
 
     if (this.isControlled('value')) {
       const value = this.getControllableValue('value');
@@ -71,7 +70,7 @@ class Select extends PureComponent {
       } else {
         this.initializeValue();
       }
-    } else if (!this.isControlled('placeholder')) {
+    } else if (placeholder === undefined) {
       this.initializeValue();
     }
 
@@ -249,11 +248,12 @@ class Select extends PureComponent {
       contentRef,
       disabled,
       modifiers,
+      placeholder,
       triggerWrapperCss,
       usePortal,
     } = this.props;
     const { contentWidth, displayMenu, portalPosition } = this.state;
-    const hasPlaceholder = this.isControlled('placeholder');
+    const hasPlaceholder = placeholder !== undefined;
     const value = this.getControllableValue('value');
 
     return (
@@ -294,7 +294,7 @@ class Select extends PureComponent {
             <HeaderContent>
               {/* if placeholder is defined display it, otherwise use the value of the first option */}
               {hasPlaceholder && !value
-                ? this.getControllableValue('placeholder')
+                ? placeholder
                 : Children.map(children, child => (child.props.value === value ? child : null))}
             </HeaderContent>
           </Header>


### PR DESCRIPTION
- [x] Feature
- [ ] Fix
- [ ] Enhancement

## Description
In order to add the select for type aggregate in sales-analysis page of Sonar, our Select component needs to be able to display more than just the selected value (see design on Zeplin):
<img width="193" alt="Screenshot 2019-10-28 at 18 09 54" src="https://user-images.githubusercontent.com/6019103/67700399-2f051a00-f9ae-11e9-86c6-cc46b61e0069.png">
<img width="201" alt="Screenshot 2019-10-28 at 18 10 02" src="https://user-images.githubusercontent.com/6019103/67700400-2f051a00-f9ae-11e9-8241-67dbb004ee95.png">

## Related / Associated Jira Cards :
>  <!--- [BP-411](https://tillersystems.atlassian.net/browse/BP-411) -->

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
