### PR TITLE
feat(List): add List component

### DIFF
--- a/src/List/Item/__tests__/Item.test.js
+++ b/src/List/Item/__tests__/Item.test.js
@@ -16,22 +16,11 @@ describe('<Item />', () => {
 
     const labelNode = getByText('Pavé de saumon');
     expect(labelNode).toBeInTheDocument();
-    const amountNode = getByText(/1,829/);
+    const amountNode = getByText(/1829/);
     expect(amountNode).toBeInTheDocument();
   });
 
-  test('should render with currency', () => {
-    const { getByText } = render(
-      <Item {...props} currency="EUR">
-        Pavé de saumon
-      </Item>,
-    );
-
-    const amountNode = getByText(/€18.29/);
-    expect(amountNode).toBeInTheDocument();
-  });
-
-  test('should render ', () => {
+  test('should render label with custom style', () => {
     const Main = styled.span`
       font-size: ${({ theme: { fonts } }) => fonts.size.medium};
     `;

--- a/src/List/Item/__tests__/Item.test.js
+++ b/src/List/Item/__tests__/Item.test.js
@@ -1,0 +1,60 @@
+/* eslint-disable react/display-name */
+import React from 'react';
+import styled from 'styled-components';
+
+import Item from '..';
+import Theme from '../../../Theme';
+
+const props = {
+  amount: 1829,
+  locale: 'en',
+};
+
+describe('<Item />', () => {
+  test('should render without a problem', () => {
+    const { getByText } = render(<Item {...props}>Pavé de saumon</Item>);
+
+    const labelNode = getByText('Pavé de saumon');
+    expect(labelNode).toBeInTheDocument();
+    const amountNode = getByText(/1,829/);
+    expect(amountNode).toBeInTheDocument();
+  });
+
+  test('should render with currency', () => {
+    const { getByText } = render(
+      <Item {...props} currency="EUR">
+        Pavé de saumon
+      </Item>,
+    );
+
+    const amountNode = getByText(/€18.29/);
+    expect(amountNode).toBeInTheDocument();
+  });
+
+  test('should render ', () => {
+    const Main = styled.span`
+      font-size: ${({ theme: { fonts } }) => fonts.size.medium};
+    `;
+
+    const { getByText } = render(
+      <Item {...props}>
+        <Main>Pavé de saumon</Main>
+      </Item>,
+    );
+
+    const labelNode = getByText('Pavé de saumon');
+
+    expect(labelNode).toHaveStyleRule('font-size', Theme.fonts.size.medium);
+  });
+
+  test('should render with extra information', () => {
+    const { getByText } = render(
+      <Item {...props} evolution={0.03}>
+        Pavé de saumon
+      </Item>,
+    );
+
+    const evolutionNode = getByText(/3%/);
+    expect(evolutionNode).toBeInTheDocument();
+  });
+});

--- a/src/List/Item/elements.js
+++ b/src/List/Item/elements.js
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+
+export const Amount = styled.td`
+  color: ${({ theme: { palette } }) => palette.primary.default};
+  text-align: end;
+`;
+
+export const Container = styled.div`
+  align-items: center;
+  background-color: white;
+  display: flex;
+  height: 5.2rem;
+  padding: 0 2rem;
+
+  &:not(:first-child) {
+    border-top: 1px solid hsl(210, 11%, 93%);
+  }
+`;
+
+export const Evolution = styled.td`
+  color: ${({ evolution, theme: { palette } }) =>
+    evolution > 0
+      ? palette.success.default
+      : evolution < 0
+      ? palette.failure.default
+      : palette.mediumGrey};
+  font-weight: ${({ theme: { fonts } }) => fonts.weight.normal};
+  text-align: end;
+`;
+
+export const Label = styled.span`
+  color: ${({ theme: { palette } }) => palette.darkBlue};
+  font-weight: ${({ theme: { fonts } }) => fonts.weight.thick};
+`;

--- a/src/List/Item/elements.js
+++ b/src/List/Item/elements.js
@@ -1,15 +1,16 @@
 import styled from 'styled-components';
 
-export const Amount = styled.td`
+export const Amount = styled.div`
   color: ${({ theme: { palette } }) => palette.primary.default};
   text-align: end;
 `;
 
-export const Container = styled.div`
+export const Container = styled.li`
   align-items: center;
   background-color: white;
   display: flex;
   height: 5.2rem;
+  justify-content: space-between;
   padding: 0 2rem;
 
   &:not(:first-child) {
@@ -17,13 +18,14 @@ export const Container = styled.div`
   }
 `;
 
-export const Evolution = styled.td`
+export const Evolution = styled.div`
   color: ${({ evolution, theme: { palette } }) =>
     evolution > 0
       ? palette.success.default
       : evolution < 0
       ? palette.failure.default
       : palette.mediumGrey};
+  font-size: ${({ theme: { fonts } }) => fonts.size.default};
   font-weight: ${({ theme: { fonts } }) => fonts.weight.normal};
   text-align: end;
 `;
@@ -31,4 +33,9 @@ export const Evolution = styled.td`
 export const Label = styled.span`
   color: ${({ theme: { palette } }) => palette.darkBlue};
   font-weight: ${({ theme: { fonts } }) => fonts.weight.thick};
+`;
+
+export const SideWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
 `;

--- a/src/List/Item/index.js
+++ b/src/List/Item/index.js
@@ -8,18 +8,12 @@ import { Amount, Container, Evolution, Label, SideWrapper } from './elements';
  *
  * @return {jsx}
  */
-const Item = ({ amount, children, className, currency, evolution, locale }) => {
+const Item = ({ amount, children, className, evolution, locale }) => {
   return (
     <Container className={className}>
       <Label>{children}</Label>
       <SideWrapper>
-        <Amount>
-          {formatNumber({
-            locale,
-            currency,
-            number: amount,
-          })}
-        </Amount>
+        <Amount>{amount}</Amount>
         {evolution !== null && (
           <Evolution evolution={evolution}>
             {evolution === 0 ? '=' : evolution > 0 && '+'}
@@ -39,13 +33,10 @@ const Item = ({ amount, children, className, currency, evolution, locale }) => {
 const { node, number, string } = Proptypes;
 Item.propTypes = {
   /** First side value displayed at the right side of the container */
-  amount: number,
+  amount: node,
 
   /** Main value of the item, like a label for example, displayed at the left side of the container */
   children: node.isRequired,
-
-  /** Currency for amount value */
-  currency: string,
 
   /** Second side value displayed below the first side node. Can add extra information  */
   evolution: number,
@@ -56,7 +47,6 @@ Item.propTypes = {
 
 Item.defaultProps = {
   amount: null,
-  currency: null,
   evolution: null,
   locale: 'en',
 };

--- a/src/List/Item/index.js
+++ b/src/List/Item/index.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import Proptypes from 'prop-types';
+
+import { formatNumber } from '../../helpers/formatting';
+import { Amount, Container, Evolution, Label } from './elements';
+
+/**
+ *
+ * @return {jsx}
+ */
+const Item = ({ amount, children, className, currency, evolution, locale }) => {
+  return (
+    <Container className={className}>
+      <Label>{children}</Label>
+      <Amount>
+        {formatNumber({
+          locale,
+          currency,
+          number: amount,
+        })}
+      </Amount>
+      <Evolution evolution={evolution}>
+        {evolution === 0 ? '=' : evolution > 0 && '+'}
+        {evolution !== 0 &&
+          formatNumber({
+            locale,
+            number: evolution,
+            percent: true,
+          })}
+      </Evolution>
+    </Container>
+  );
+};
+
+const { node, number, string } = Proptypes;
+Item.propTypes = {
+  /** First side value displayed at the right side of the container */
+  amount: number,
+
+  /** Main value of the item, like a label for example, displayed at the left side of the container */
+  children: node.isRequired,
+
+  /** Currency for amount value */
+  currency: string,
+
+  /** Second side value displayed below the first side node. Can add extra information  */
+  evolution: number,
+
+  /** Locale code used to properly format numbers  */
+  locale: string,
+};
+
+Item.defaultProps = {
+  amount: null,
+  currency: null,
+  evolution: null,
+  locale: 'en',
+};
+
+export default Item;

--- a/src/List/Item/index.js
+++ b/src/List/Item/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Proptypes from 'prop-types';
 
 import { formatNumber } from '../../helpers/formatting';
-import { Amount, Container, Evolution, Label } from './elements';
+import { Amount, Container, Evolution, Label, SideWrapper } from './elements';
 
 /**
  *
@@ -12,22 +12,26 @@ const Item = ({ amount, children, className, currency, evolution, locale }) => {
   return (
     <Container className={className}>
       <Label>{children}</Label>
-      <Amount>
-        {formatNumber({
-          locale,
-          currency,
-          number: amount,
-        })}
-      </Amount>
-      <Evolution evolution={evolution}>
-        {evolution === 0 ? '=' : evolution > 0 && '+'}
-        {evolution !== 0 &&
-          formatNumber({
+      <SideWrapper>
+        <Amount>
+          {formatNumber({
             locale,
-            number: evolution,
-            percent: true,
+            currency,
+            number: amount,
           })}
-      </Evolution>
+        </Amount>
+        {evolution !== null && (
+          <Evolution evolution={evolution}>
+            {evolution === 0 ? '=' : evolution > 0 && '+'}
+            {evolution !== 0 &&
+              formatNumber({
+                locale,
+                number: evolution,
+                percent: true,
+              })}
+          </Evolution>
+        )}
+      </SideWrapper>
     </Container>
   );
 };

--- a/src/List/README.md
+++ b/src/List/README.md
@@ -1,4 +1,4 @@
-# Message
+# List
 
 ### Usage
 
@@ -21,38 +21,39 @@ import { List } from '@tillersystems/stardust';
 const datas = [
   {
     icon: '#457b9d',
-    mainLabel: 'Tartare de boeuf',
-    secondaryLabel: '3 280 €',
-    annexe: '+ 12%',
+    label: 'Tartare de boeuf',
+    amount: 3 280,
+    evolution: 0.12,
   },
   {
     icon: '#eda3a3',
-    mainLabel: 'Avocado Toast',
-    secondaryLabel: '2 267 €',
-    annexe: '+ 6%',
+    label: 'Avocado Toast',
+    amount: 2267,
+    evolution: 0.06,
   },
   {
     icon: '#a8dadc',
-    mainLabel: 'Pavé de saumon',
-    secondaryLabel: '1 829 €',
-    annexe: '+ 4%',
+    label: 'Pavé de saumon',
+    amount: 1829,
+    evolution: 0.04,
   },
 ];
 
-const formatDatas = {
-  icon: value => (
+const formatLabel = ({ label }) => (
+  <>
     <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" role="presentation">
       <rect x="0" y="1.5" fill={value} width="10" height="10" rx="3" ry="3" />
     </svg>
-  ),
-  mainLabel: value => <Main>{value}</Main>,
-  secondaryLabel: value => <Secondary>{value}</Secondary>,
-  annexe: value => <Annexe>{value}</Annexe>,
-};
+    {label}
+  </>
+);
 
 render() {
   return (
-    <List datas={datas} formatDatas={formatDatas} />
+    <List data={data.map(row => ({
+      ...row,
+      label: formatLabel(row),
+    }))} currency="EUR" locale="fr" />
   );
 }
 ```

--- a/src/List/README.md
+++ b/src/List/README.md
@@ -1,0 +1,58 @@
+# Message
+
+### Usage
+
+List component displays a list of item through data passed props.
+You can format the data to stylise it or render the item in one line.
+
+```jsx
+import { List } from '@tillersystems/stardust';
+```
+
+<!-- STORY -->
+
+<!-- PROPS -->
+
+### Example
+
+```jsx
+import { List } from '@tillersystems/stardust';
+
+const datas = [
+  {
+    icon: '#457b9d',
+    mainLabel: 'Tartare de boeuf',
+    secondaryLabel: '3 280 €',
+    annexe: '+ 12%',
+  },
+  {
+    icon: '#eda3a3',
+    mainLabel: 'Avocado Toast',
+    secondaryLabel: '2 267 €',
+    annexe: '+ 6%',
+  },
+  {
+    icon: '#a8dadc',
+    mainLabel: 'Pavé de saumon',
+    secondaryLabel: '1 829 €',
+    annexe: '+ 4%',
+  },
+];
+
+const formatDatas = {
+  icon: value => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" role="presentation">
+      <rect x="0" y="1.5" fill={value} width="10" height="10" rx="3" ry="3" />
+    </svg>
+  ),
+  mainLabel: value => <Main>{value}</Main>,
+  secondaryLabel: value => <Secondary>{value}</Secondary>,
+  annexe: value => <Annexe>{value}</Annexe>,
+};
+
+render() {
+  return (
+    <List datas={datas} formatDatas={formatDatas} />
+  );
+}
+```

--- a/src/List/__stories__/List.stories.js
+++ b/src/List/__stories__/List.stories.js
@@ -1,0 +1,75 @@
+/* eslint-disable react/display-name */
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
+import styled from 'styled-components';
+
+import ListReadme from '../README.md';
+import Wrapper from '../../Wrapper';
+import { List } from '../..';
+
+const Main = styled.span`
+  font-size: ${({ theme: { fonts } }) => fonts.size.medium};
+  font-weight: ${({ theme: { fonts } }) => fonts.weight.thick};
+`;
+
+const Secondary = styled.span`
+  font-size: ${({ theme: { fonts } }) => fonts.size.medium};
+  font-weight: ${({ theme: { fonts } }) => fonts.weight.thick};
+  color: ${({ theme: { palette } }) => palette.primary.default};
+`;
+
+const Annexe = styled.span`
+  width: 9rem;
+  color: ${({ theme: { palette } }) => palette.success.default};
+`;
+
+storiesOf('List', module)
+  .addDecorator(withKnobs)
+  .addParameters({
+    readme: {
+      // Show readme before story
+      content: ListReadme,
+    },
+  })
+  .add('default', () => {
+    const isInline = boolean('is inline', false, 'State');
+
+    const datas = [
+      {
+        icon: '#457b9d',
+        mainLabel: 'Tartare de boeuf',
+        secondaryLabel: '3 280 €',
+        annexe: '+ 12%',
+      },
+      {
+        icon: '#eda3a3',
+        mainLabel: 'Avocado Toast',
+        secondaryLabel: '2 267 €',
+        annexe: '+ 6%',
+      },
+      {
+        icon: '#a8dadc',
+        mainLabel: 'Pavé de saumon',
+        secondaryLabel: '1 829 €',
+        annexe: '+ 4%',
+      },
+    ];
+
+    const formatDatas = {
+      icon: value => (
+        <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" role="presentation">
+          <rect x="0" y="1.5" fill={value} width="10" height="10" rx="3" ry="3" />
+        </svg>
+      ),
+      mainLabel: value => <Main>{value}</Main>,
+      secondaryLabel: value => <Secondary>{value}</Secondary>,
+      annexe: value => <Annexe>{value}</Annexe>,
+    };
+
+    return (
+      <Wrapper>
+        <List datas={datas} formatDatas={formatDatas} isInline={isInline} />
+      </Wrapper>
+    );
+  });

--- a/src/List/__stories__/List.stories.js
+++ b/src/List/__stories__/List.stories.js
@@ -1,28 +1,11 @@
 /* eslint-disable react/display-name */
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, boolean } from '@storybook/addon-knobs';
-import styled from 'styled-components';
+import { withKnobs, boolean, text } from '@storybook/addon-knobs';
 
 import ListReadme from '../README.md';
 import Wrapper from '../../Wrapper';
 import { List } from '../..';
-
-const Main = styled.span`
-  font-size: ${({ theme: { fonts } }) => fonts.size.medium};
-  font-weight: ${({ theme: { fonts } }) => fonts.weight.thick};
-`;
-
-const Secondary = styled.span`
-  font-size: ${({ theme: { fonts } }) => fonts.size.medium};
-  font-weight: ${({ theme: { fonts } }) => fonts.weight.thick};
-  color: ${({ theme: { palette } }) => palette.primary.default};
-`;
-
-const Annexe = styled.span`
-  width: 9rem;
-  color: ${({ theme: { palette } }) => palette.success.default};
-`;
 
 storiesOf('List', module)
   .addDecorator(withKnobs)
@@ -33,6 +16,9 @@ storiesOf('List', module)
     },
   })
   .add('default', () => {
+    const hasEvolution = boolean('Add evolution', false, 'Props');
+    const locale = text('Locale', 'en', 'Props');
+
     const data = [
       {
         color: '#457b9d',
@@ -56,7 +42,13 @@ storiesOf('List', module)
 
     const getLabel = ({ label, color }) => (
       <>
-        <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" role="presentation">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="12"
+          height="12"
+          role="presentation"
+          style={{ marginRight: '5px' }}
+        >
           <rect x="0" y="1.5" fill={color} width="10" height="10" rx="3" ry="3" />
         </svg>
         {label}
@@ -67,10 +59,12 @@ storiesOf('List', module)
       <Wrapper>
         <List
           currency="EUR"
-          data={data.map(row => ({
-            ...row,
-            label: getLabel(row),
+          data={data.map(({ color, label, amount, evolution }) => ({
+            label: getLabel({ label, color }),
+            amount,
+            ...(hasEvolution ? { evolution } : {}),
           }))}
+          locale={locale}
         />
       </Wrapper>
     );

--- a/src/List/__stories__/List.stories.js
+++ b/src/List/__stories__/List.stories.js
@@ -33,43 +33,45 @@ storiesOf('List', module)
     },
   })
   .add('default', () => {
-    const isInline = boolean('is inline', false, 'State');
-
-    const datas = [
+    const data = [
       {
-        icon: '#457b9d',
-        mainLabel: 'Tartare de boeuf',
-        secondaryLabel: '3 280 €',
-        annexe: '+ 12%',
+        color: '#457b9d',
+        label: 'Tartare de boeuf',
+        amount: 328050,
+        evolution: 0,
       },
       {
-        icon: '#eda3a3',
-        mainLabel: 'Avocado Toast',
-        secondaryLabel: '2 267 €',
-        annexe: '+ 6%',
+        color: '#eda3a3',
+        label: 'Avocado Toast',
+        amount: 226734,
+        evolution: -0.06,
       },
       {
-        icon: '#a8dadc',
-        mainLabel: 'Pavé de saumon',
-        secondaryLabel: '1 829 €',
-        annexe: '+ 4%',
+        color: '#a8dadc',
+        label: 'Pavé de saumon',
+        amount: 182934,
+        evolution: 0.04,
       },
     ];
 
-    const formatDatas = {
-      icon: value => (
+    const getLabel = ({ label, color }) => (
+      <>
         <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" role="presentation">
-          <rect x="0" y="1.5" fill={value} width="10" height="10" rx="3" ry="3" />
+          <rect x="0" y="1.5" fill={color} width="10" height="10" rx="3" ry="3" />
         </svg>
-      ),
-      mainLabel: value => <Main>{value}</Main>,
-      secondaryLabel: value => <Secondary>{value}</Secondary>,
-      annexe: value => <Annexe>{value}</Annexe>,
-    };
+        {label}
+      </>
+    );
 
     return (
       <Wrapper>
-        <List datas={datas} formatDatas={formatDatas} isInline={isInline} />
+        <List
+          currency="EUR"
+          data={data.map(row => ({
+            ...row,
+            label: getLabel(row),
+          }))}
+        />
       </Wrapper>
     );
   });

--- a/src/List/__tests__/List.test.js
+++ b/src/List/__tests__/List.test.js
@@ -15,11 +15,11 @@ const data = [
 
 describe('<List />', () => {
   test('should render without a problem', () => {
-    const { getByText } = render(<List currency="EUR" data={data} locale="en" />);
+    const { getByText } = render(<List data={data} locale="en" />);
 
     const labelNode = getByText('Pavé de saumon');
     expect(labelNode).toBeInTheDocument();
-    const amountNode = getByText(/€18.29/);
+    const amountNode = getByText(/1829/);
     expect(amountNode).toBeInTheDocument();
   });
 

--- a/src/List/__tests__/List.test.js
+++ b/src/List/__tests__/List.test.js
@@ -1,0 +1,78 @@
+/* eslint-disable react/display-name */
+import React from 'react';
+import styled from 'styled-components';
+
+import List from '..';
+import Theme from '../../Theme';
+
+describe('<List />', () => {
+  test('should render without a problem', () => {
+    const datas = [
+      {
+        icon: '#a8dadc',
+        mainLabel: 'Pavé de saumon',
+        secondaryLabel: '1 829 €',
+        annexe: '+ 4%',
+      },
+    ];
+
+    const { getByText } = render(<List datas={datas} />);
+
+    const mainLabelNode = getByText('Pavé de saumon');
+
+    expect(mainLabelNode).toBeInTheDocument();
+  });
+
+  test('should render without a problem with formated label', () => {
+    const Main = styled.span`
+      font-size: ${({ theme: { fonts } }) => fonts.size.medium};
+    `;
+
+    const datas = [
+      {
+        icon: '#a8dadc',
+        mainLabel: 'Pavé de saumon',
+        secondaryLabel: '1 829 €',
+        annexe: '+ 4%',
+      },
+    ];
+
+    const formatDatas = {
+      mainLabel: value => <Main>{value}</Main>,
+    };
+
+    const { getByText } = render(<List datas={datas} formatDatas={formatDatas} />);
+
+    const mainLabelNode = getByText('Pavé de saumon');
+
+    expect(mainLabelNode).toHaveStyleRule('font-size', Theme.fonts.size.medium);
+  });
+
+  test('should render without a problem in line', () => {
+    const Main = styled.span`
+      font-size: ${({ theme: { fonts } }) => fonts.size.medium};
+    `;
+
+    const datas = [
+      {
+        icon: '#a8dadc',
+        mainLabel: 'Pavé de saumon',
+        secondaryLabel: '1 829 €',
+        annexe: '+ 4%',
+      },
+    ];
+
+    const formatDatas = {
+      mainLabel: value => <Main>{value}</Main>,
+    };
+
+    const { getByTestId } = render(<List datas={datas} formatDatas={formatDatas} isInline />);
+
+    const listItemNode = getByTestId('list-item');
+
+    expect(listItemNode).toHaveStyleRule(
+      'grid-template-areas',
+      "'icon mainLabel secondaryLabel annexe'",
+    );
+  });
+});

--- a/src/List/__tests__/List.test.js
+++ b/src/List/__tests__/List.test.js
@@ -5,74 +5,58 @@ import styled from 'styled-components';
 import List from '..';
 import Theme from '../../Theme';
 
+const data = [
+  {
+    color: '#a8dadc',
+    label: 'Pavé de saumon',
+    amount: 1829,
+  },
+];
+
 describe('<List />', () => {
   test('should render without a problem', () => {
-    const datas = [
-      {
-        icon: '#a8dadc',
-        mainLabel: 'Pavé de saumon',
-        secondaryLabel: '1 829 €',
-        annexe: '+ 4%',
-      },
-    ];
+    const { getByText } = render(<List currency="EUR" data={data} locale="en" />);
 
-    const { getByText } = render(<List datas={datas} />);
-
-    const mainLabelNode = getByText('Pavé de saumon');
-
-    expect(mainLabelNode).toBeInTheDocument();
+    const labelNode = getByText('Pavé de saumon');
+    expect(labelNode).toBeInTheDocument();
+    const amountNode = getByText(/€18.29/);
+    expect(amountNode).toBeInTheDocument();
   });
 
-  test('should render without a problem with formated label', () => {
+  test('should render with formatted label', () => {
     const Main = styled.span`
       font-size: ${({ theme: { fonts } }) => fonts.size.medium};
     `;
 
-    const datas = [
-      {
-        icon: '#a8dadc',
-        mainLabel: 'Pavé de saumon',
-        secondaryLabel: '1 829 €',
-        annexe: '+ 4%',
-      },
-    ];
+    const formatLabel = ({ label }) => <Main>{label}</Main>;
 
-    const formatDatas = {
-      mainLabel: value => <Main>{value}</Main>,
-    };
-
-    const { getByText } = render(<List datas={datas} formatDatas={formatDatas} />);
-
-    const mainLabelNode = getByText('Pavé de saumon');
-
-    expect(mainLabelNode).toHaveStyleRule('font-size', Theme.fonts.size.medium);
-  });
-
-  test('should render without a problem in line', () => {
-    const Main = styled.span`
-      font-size: ${({ theme: { fonts } }) => fonts.size.medium};
-    `;
-
-    const datas = [
-      {
-        icon: '#a8dadc',
-        mainLabel: 'Pavé de saumon',
-        secondaryLabel: '1 829 €',
-        annexe: '+ 4%',
-      },
-    ];
-
-    const formatDatas = {
-      mainLabel: value => <Main>{value}</Main>,
-    };
-
-    const { getByTestId } = render(<List datas={datas} formatDatas={formatDatas} isInline />);
-
-    const listItemNode = getByTestId('list-item');
-
-    expect(listItemNode).toHaveStyleRule(
-      'grid-template-areas',
-      "'icon mainLabel secondaryLabel annexe'",
+    const { getByText } = render(
+      <List
+        data={data.map(row => ({
+          ...row,
+          label: formatLabel(row),
+        }))}
+      />,
     );
+
+    const labelNode = getByText('Pavé de saumon');
+
+    expect(labelNode).toHaveStyleRule('font-size', Theme.fonts.size.medium);
+  });
+
+  test('should render with extra information', () => {
+    const data = [
+      {
+        color: '#a8dadc',
+        label: 'Pavé de saumon',
+        amount: 1829,
+        evolution: 0.04,
+      },
+    ];
+
+    const { getByText } = render(<List data={data} />);
+
+    const evolutionNode = getByText(/4%/);
+    expect(evolutionNode).toBeInTheDocument();
   });
 });

--- a/src/List/elements.js
+++ b/src/List/elements.js
@@ -1,0 +1,60 @@
+import styled, { css } from 'styled-components';
+
+export const ListContainer = styled.ul`
+  list-style: none;
+  font-feature-settings: 'tnum';
+`;
+
+export const ListItem = styled.li`
+  height: 5.2rem;
+  padding: 0 2rem;
+
+  border-top: 1px solid hsl(210, 11%, 93%);
+  background-color: white;
+
+  display: grid;
+  align-content: center;
+  align-items: center;
+
+  ${({ isInline }) =>
+    isInline
+      ? css`
+          grid-template-columns: min-content auto max-content max-content;
+          grid-template-areas: 'icon mainLabel secondaryLabel annexe';
+        `
+      : css`
+          grid-template-columns: min-content auto max-content;
+          grid-template-rows: max-content max-content;
+          grid-template-areas:
+            'icon mainLabel secondaryLabel'
+            'icon mainLabel annexe';
+        `};
+
+  &:last-of-type {
+    border-bottom: 1px solid hsl(210, 11%, 93%);
+  }
+`;
+
+export const Icon = styled.span`
+  margin-right: 1.2rem;
+
+  grid-area: icon;
+`;
+
+export const MainLabel = styled.span`
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+
+  grid-area: mainLabel;
+`;
+
+export const SecondaryLabel = styled.span`
+  text-align: right;
+  grid-area: secondaryLabel;
+`;
+
+export const Annexe = styled.span`
+  text-align: right;
+  grid-area: annexe;
+`;

--- a/src/List/elements.js
+++ b/src/List/elements.js
@@ -1,60 +1,6 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
-export const ListContainer = styled.ul`
+export const Container = styled.ul`
   list-style: none;
   font-feature-settings: 'tnum';
-`;
-
-export const ListItem = styled.li`
-  height: 5.2rem;
-  padding: 0 2rem;
-
-  border-top: 1px solid hsl(210, 11%, 93%);
-  background-color: white;
-
-  display: grid;
-  align-content: center;
-  align-items: center;
-
-  ${({ isInline }) =>
-    isInline
-      ? css`
-          grid-template-columns: min-content auto max-content max-content;
-          grid-template-areas: 'icon mainLabel secondaryLabel annexe';
-        `
-      : css`
-          grid-template-columns: min-content auto max-content;
-          grid-template-rows: max-content max-content;
-          grid-template-areas:
-            'icon mainLabel secondaryLabel'
-            'icon mainLabel annexe';
-        `};
-
-  &:last-of-type {
-    border-bottom: 1px solid hsl(210, 11%, 93%);
-  }
-`;
-
-export const Icon = styled.span`
-  margin-right: 1.2rem;
-
-  grid-area: icon;
-`;
-
-export const MainLabel = styled.span`
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
-
-  grid-area: mainLabel;
-`;
-
-export const SecondaryLabel = styled.span`
-  text-align: right;
-  grid-area: secondaryLabel;
-`;
-
-export const Annexe = styled.span`
-  text-align: right;
-  grid-area: annexe;
 `;

--- a/src/List/index.js
+++ b/src/List/index.js
@@ -41,7 +41,7 @@ List.propTypes = {
    */
   data: arrayOf(
     shape({
-      amount: number,
+      amount: node,
       evolution: number,
       label: oneOfType([node, string]),
     }),

--- a/src/List/index.js
+++ b/src/List/index.js
@@ -1,73 +1,61 @@
 import React from 'react';
 import Proptypes from 'prop-types';
 
-import { Icon, ListContainer, ListItem, MainLabel, SecondaryLabel, Annexe } from './elements';
+import Item from './Item';
+import { Container } from './elements';
 
 /**
- * List component displays a list of item through data passed props.
+ * List component displays a list of items through a `data` prop
  * You can format the data to stylise it or render the item in one line.
  *
  * See README.md and its stories from Storybook for documentation and examples
  *
  * @return {jsx}
  */
-const List = ({ datas, formatDatas, isInline }) => {
-  const {
-    icon: formatIcon,
-    mainLabel: formatMainLabel,
-    secondaryLabel: formatSecondaryLabel,
-    annexe: formatAnnexe,
-  } = formatDatas;
-
+const List = ({ currency, data, locale }) => {
   return (
-    <ListContainer>
-      {datas.map(({ icon, mainLabel, secondaryLabel, annexe }, index) => (
-        <ListItem key={index} isInline={isInline} data-testid="list-item">
-          {icon && <Icon>{formatIcon ? formatIcon(icon) : icon}</Icon>}
-          <MainLabel>{formatMainLabel ? formatMainLabel(mainLabel) : mainLabel}</MainLabel>
-          <SecondaryLabel>
-            {formatSecondaryLabel ? formatSecondaryLabel(secondaryLabel) : secondaryLabel}
-          </SecondaryLabel>
-          <Annexe>{formatAnnexe ? formatAnnexe(annexe) : annexe}</Annexe>
-        </ListItem>
+    <Container>
+      {data.map(({ amount, evolution, label }, index) => (
+        <Item
+          key={index}
+          amount={amount}
+          currency={currency}
+          evolution={evolution}
+          locale={locale}
+          data-testid="list-item"
+        >
+          {label}
+        </Item>
       ))}
-    </ListContainer>
+    </Container>
   );
 };
 
-const { arrayOf, shape, bool, func, string } = Proptypes;
+const { arrayOf, node, number, oneOfType, shape, string } = Proptypes;
 List.propTypes = {
+  /** Currency for amount values */
+  currency: string,
+
   /**
    * Data to display in the List component
    */
-  datas: arrayOf(
+  data: arrayOf(
     shape({
-      icon: string,
-      mainLabel: string,
-      secondaryLabel: string,
-      annexe: string,
+      amount: number,
+      evolution: number,
+      label: oneOfType([node, string]),
     }),
   ).isRequired,
 
   /**
-   * Format the value for display
+   * locale code used to properly format numbers
    */
-  formatDatas: shape({
-    icon: func,
-    mainLabel: func,
-    secondaryLabel: func,
-    annexe: func,
-  }),
-
-  /**
-   * If isInline property is set the list items while be displayed in one line
-   */
-  isInline: bool,
+  locale: string,
 };
 
 List.defaultProps = {
-  formatDatas: { icon: null, mainLabel: null, secondaryLabel: null, annexe: null },
-  isInline: false,
+  currency: null,
+  locale: 'en',
 };
 
 export default List;

--- a/src/List/index.js
+++ b/src/List/index.js
@@ -20,7 +20,7 @@ const List = ({ currency, data, locale }) => {
           key={index}
           amount={amount}
           currency={currency}
-          evolution={evolution}
+          {...(typeof evolution !== 'undefined' ? { evolution } : {})}
           locale={locale}
           data-testid="list-item"
         >

--- a/src/List/index.js
+++ b/src/List/index.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import Proptypes from 'prop-types';
+
+import { Icon, ListContainer, ListItem, MainLabel, SecondaryLabel, Annexe } from './elements';
+
+/**
+ * List component displays a list of item through data passed props.
+ * You can format the data to stylise it or render the item in one line.
+ *
+ * See README.md and its stories from Storybook for documentation and examples
+ *
+ * @return {jsx}
+ */
+const List = ({ datas, formatDatas, isInline }) => {
+  const {
+    icon: formatIcon,
+    mainLabel: formatMainLabel,
+    secondaryLabel: formatSecondaryLabel,
+    annexe: formatAnnexe,
+  } = formatDatas;
+
+  return (
+    <ListContainer>
+      {datas.map(({ icon, mainLabel, secondaryLabel, annexe }, index) => (
+        <ListItem key={index} isInline={isInline} data-testid="list-item">
+          {icon && <Icon>{formatIcon ? formatIcon(icon) : icon}</Icon>}
+          <MainLabel>{formatMainLabel ? formatMainLabel(mainLabel) : mainLabel}</MainLabel>
+          <SecondaryLabel>
+            {formatSecondaryLabel ? formatSecondaryLabel(secondaryLabel) : secondaryLabel}
+          </SecondaryLabel>
+          <Annexe>{formatAnnexe ? formatAnnexe(annexe) : annexe}</Annexe>
+        </ListItem>
+      ))}
+    </ListContainer>
+  );
+};
+
+const { arrayOf, shape, bool, func, string } = Proptypes;
+List.propTypes = {
+  /**
+   * Data to display in the List component
+   */
+  datas: arrayOf(
+    shape({
+      icon: string,
+      mainLabel: string,
+      secondaryLabel: string,
+      annexe: string,
+    }),
+  ).isRequired,
+
+  /**
+   * Format the value for display
+   */
+  formatDatas: shape({
+    icon: func,
+    mainLabel: func,
+    secondaryLabel: func,
+    annexe: func,
+  }),
+
+  /**
+   * If isInline property is set the list items while be displayed in one line
+   */
+  isInline: bool,
+};
+
+List.defaultProps = {
+  formatDatas: { icon: null, mainLabel: null, secondaryLabel: null, annexe: null },
+  isInline: false,
+};
+
+export default List;

--- a/src/helpers/__tests__/formatting.test.js
+++ b/src/helpers/__tests__/formatting.test.js
@@ -33,4 +33,15 @@ describe('formatNumber', () => {
 
     expect(formattedNumber).toBe('$21.14');
   });
+
+  test('should return price in dollars as a whole number', () => {
+    const formattedNumber = formatNumber({
+      locale: 'en-US',
+      number: 2114.34,
+      digits: 0,
+      currency: 'USD',
+    });
+
+    expect(formattedNumber).toBe('$21');
+  });
 });

--- a/src/helpers/__tests__/formatting.test.js
+++ b/src/helpers/__tests__/formatting.test.js
@@ -1,0 +1,36 @@
+import { formatNumber } from '../formatting';
+
+describe('formatNumber', () => {
+  test('should return percentage without digits', () => {
+    const formattedNumber = formatNumber({
+      locale: 'en-US',
+      number: -0.2114,
+      percent: true,
+      digits: 0,
+    });
+
+    expect(formattedNumber).toBe('-21%');
+  });
+
+  test('should return percentage with 2 digits', () => {
+    const formattedNumber = formatNumber({
+      locale: 'en-US',
+      number: -0.2114,
+      percent: true,
+      digits: 2,
+    });
+
+    expect(formattedNumber).toBe('-21.14%');
+  });
+
+  test('should return price in dollars with 2 digits', () => {
+    const formattedNumber = formatNumber({
+      locale: 'en-US',
+      number: 2114.34,
+      digits: 2,
+      currency: 'USD',
+    });
+
+    expect(formattedNumber).toBe('$21.14');
+  });
+});

--- a/src/helpers/formatting.js
+++ b/src/helpers/formatting.js
@@ -59,6 +59,8 @@ export const formatNumber = ({ currency, locale, number, percent, digits = 2 }) 
       ? !Number.isInteger(Math.round(value * 10000) / 100) && {
           minimumFractionDigits: digits,
         }
-      : Number.isInteger(value) && { minimumFractionDigits: 0, maximumFractionDigits: 0 }),
+      : Number.isInteger(value)
+      ? { minimumFractionDigits: 0, maximumFractionDigits: 0 }
+      : { minimumFractionDigits: digits, maximumFractionDigits: digits }),
   }).format(value);
 };

--- a/src/helpers/formatting.js
+++ b/src/helpers/formatting.js
@@ -1,0 +1,64 @@
+/**
+ * Format number according to its currency, locale and number of digits
+ *
+ * @param {string} locale - locale to format the currency in the correct way (symbol position, thousands separators, etc)
+ * @param {number} number - number to be formatted
+ * @param {string} currency - currency to display next to the value (optional)
+ *
+ * @return {string} formatted number
+ */
+export const formatCompactedNumber = (locale, number, currency) => {
+  const value = ['USD', 'EUR'].includes(currency) ? number / 100 : number;
+
+  const compactedNumber =
+    value >= 1000000
+      ? `${Math.round((value / 1000000) * 100) / 100}m`
+      : value >= 1000
+      ? `${Math.round((value / 1000) * 100) / 100}k`
+      : value;
+
+  // TODO: Waiting for a proposal from tc39 to unify the API for number formatting,
+  // meanwhile if we want a compact version of big numbers we have separate parts
+  // that we concatenate. This is not perfect as for now it only handles if this is
+  // an english locale or not, thus we put the currency symbol before, otherwise we put it after
+  // with a space
+  // see https://github.com/tc39/ecma402/issues/215
+  if (currency) {
+    const currencySymbol = formatNumber({ currency, locale, number: 0 })
+      .replace(/\d/g, '')
+      .trim();
+
+    return locale === 'en'
+      ? `${currencySymbol}${compactedNumber}`
+      : `${compactedNumber}\xa0${currencySymbol}`;
+  } else {
+    return compactedNumber.toString();
+  }
+};
+
+/**
+ * Format number depending on the locale and if it is a currency or not
+ *
+ * @param {string} object.currency - currency to display next to the value
+ * @param {string} object.locale - locale to format the currency in the correct way (symbol position, thousands separators, etc)
+ * @param {number} object.number - number to be formatted
+ * @param {boolean} object.percent - if the number should be percent formatted
+ * @param {number} [object.digits=2]  - _optional_ set the number of digits
+ *
+ * We avoid displaying trailing zeros (by default the percent style do not display decimals)
+ * Otherwise, we display two decimal digits
+ *
+ * @return {string} number formatted with spaces and currency/percent symbol if required
+ */
+export const formatNumber = ({ currency, locale, number, percent, digits = 2 }) => {
+  const value = ['USD', 'EUR'].includes(currency) ? number / 100 : number;
+
+  return new Intl.NumberFormat(locale, {
+    ...(currency ? { style: 'currency', currency } : percent ? { style: 'percent' } : {}),
+    ...(percent
+      ? !Number.isInteger(Math.round(value * 10000) / 100) && {
+          minimumFractionDigits: digits,
+        }
+      : Number.isInteger(value) && { minimumFractionDigits: 0, maximumFractionDigits: 0 }),
+  }).format(value);
+};

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,0 +1,2 @@
+export { dark, light, getLightness, setColorDark, whiteOpacity } from './colors';
+export { formatCompactedNumber, formatNumber } from './formatting';

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,15 @@ export { default as Dropdown } from './Dropdown';
 export { default as EventListener } from './EventListener';
 export { default as Flag } from './Flag';
 export { default as Form } from './Form';
+export {
+  dark,
+  light,
+  getLightness,
+  setColorDark,
+  whiteOpacity,
+  formatCompactedNumber,
+  formatNumber,
+} from './helpers';
 export { default as Icon } from './Icon';
 export { DatePickerInput, NumberInput, TextInput } from './Input';
 export { default as KpiBlock } from './KpiBlock';

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ export { default as Icon } from './Icon';
 export { DatePickerInput, NumberInput, TextInput } from './Input';
 export { default as KpiBlock } from './KpiBlock';
 export { default as KpiChart } from './KpiChart';
+export { default as List } from './List';
 export { default as Loader } from './Loader';
 export { default as Logo } from './Logo';
 export { default as Message } from './Message';


### PR DESCRIPTION
- [x] Feature
- [ ] Fix
- [ ] Enhancement

## Description
[EDITED BY @sun-tea:]
Add list component that will be used in Sonar to replace the current table for "list" view of the "product type" pie chart and the "top products" list. 
I've reused the helpers to format numbers initially created in Sonar, in the long run I think we could remove them from Sonar to only use the ones from Stardust.

As discussed with Arthur, the amounts on the right side of the labels will be pilep up so no need to handle an inlined view.

## Related / Associated Jira Cards :
>  [BP-490](https://tillersystems.atlassian.net/browse/BP-490)

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
