### PR TITLE
feat(Table): Change column width to match style guidelines

### DIFF
--- a/src/Table/elements.js
+++ b/src/Table/elements.js
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { transparentize } from 'polished';
 
 const borderRight = height => css`
   &:after {
@@ -18,10 +19,8 @@ const borderRight = height => css`
 
 // Table
 export const TableElement = styled.table`
-  min-width: 100%;
-
-  border-collapse: collapse;
-  table-layout: fixed;
+  width: 100%;
+  border-spacing: 0;
   position: relative;
 `;
 
@@ -61,20 +60,11 @@ export const TableHeaderCell = styled.th`
   height: 4.4rem;
   padding: 0 1.2rem;
   box-sizing: border-box;
-
+  vertical-align: middle;
+  border-bottom: 1px solid ${({ theme: { palette } }) => palette.veryLightBlue};
   background-color: ${({ theme: { palette } }) => palette.white};
-
   white-space: nowrap;
   text-align: ${({ align }) => align || 'left'};
-
-  &:before {
-    content: '';
-    position: absolute;
-    right: 0;
-    bottom: 0;
-    width: 100%;
-    border-bottom: 1px solid ${({ theme: { palette } }) => palette.veryLightBlue};
-  }
 
   &:first-child {
     padding-left: 2rem;
@@ -111,10 +101,19 @@ export const HeaderLabel = styled.span`
 
 // Table Body
 export const Body = styled.tbody`
+  tr:not(:last-child) {
+    td {
+      border-bottom: 1px solid ${({ theme: { palette } }) => palette.veryLightBlue};
+    }
+    th {
+      border-bottom: 1px solid ${({ theme: { palette } }) => palette.veryLightBlue};
+    }
+  }
   td {
     height: 5.2rem;
     padding: 0 1.2rem;
     white-space: nowrap;
+    vertical-align: middle;
 
     font-feature-settings: 'tnum';
 
@@ -296,5 +295,34 @@ export const Container = styled.div`
     css`
       overflow: scroll;
     `}
+  position: relative;
+`;
+
+// Shadow Container
+export const ShadowContainer = styled.div`
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: ${({ firstCellWidth }) => firstCellWidth && `${firstCellWidth}px`};
+  z-index: 10;
+  box-shadow: ${({ side, theme: { palette } }) => {
+    const shadowColor = transparentize(0.9, palette.black);
+    if (side === 'left') {
+      return `inset -8px 0 6px -6px ${shadowColor};`;
+    } else if (side === 'right') {
+      return `inset 8px 0 6px -6px ${shadowColor};`;
+    } else if (side === 'both') {
+      return `inset -8px 0 6px -6px ${shadowColor}, inset 8px 0 6px -6px ${shadowColor};`;
+    }
+    return null;
+  }}
+  background-repeat: no-repeat;
+  background-size: 10px 100%;
+`;
+
+// Shadow Container
+export const ShadowWrapped = styled.div`
   position: relative;
 `;

--- a/src/Table/elements.js
+++ b/src/Table/elements.js
@@ -1,5 +1,6 @@
 import styled, { css } from 'styled-components';
 import { transparentize } from 'polished';
+import breakpoint from 'styled-components-breakpoint';
 
 const borderRight = height => css`
   &:after {
@@ -117,10 +118,10 @@ export const Body = styled.tbody`
 
     font-feature-settings: 'tnum';
 
-    ${({ colsLenght }) =>
-      colsLenght &&
+    ${({ colsLength }) =>
+      colsLength &&
       css`
-        width: calc(100% / ${colsLenght});
+        width: calc(100% / ${colsLength});
       `};
     box-sizing: border-box;
 
@@ -181,9 +182,12 @@ export const RowHeader = styled.th`
   height: 5.2rem;
 
   /* Avoid cell to grow when the cell's text overflow */
-  max-width: 1px;
-
+  max-width: 30rem;
   min-width: 20rem;
+  ${breakpoint('xs', 'sm')`
+    max-width: 50vw;
+    min-width: 0;
+  `};
   white-space: nowrap;
   box-sizing: border-box;
 

--- a/src/Table/elements.js
+++ b/src/Table/elements.js
@@ -59,10 +59,12 @@ export const TableHeader = styled.thead`
 export const TableHeaderCell = styled.th`
   position: relative;
   height: 4.4rem;
-  padding: 0 0.5rem;
+  padding: 0 1.2rem;
+  box-sizing: border-box;
 
   background-color: ${({ theme: { palette } }) => palette.white};
 
+  white-space: nowrap;
   text-align: ${({ align }) => align || 'left'};
 
   &:before {
@@ -76,15 +78,15 @@ export const TableHeaderCell = styled.th`
 
   &:first-child {
     padding-left: 2rem;
-    padding-right: 0.5rem;
+    padding-right: 1.2rem;
     z-index: 2;
     left: 0;
     ${({ isScrollable }) => isScrollable && borderRight('4.4rem')}
   }
 
   &:last-child {
-    padding-right: 2.2rem;
-    padding-left: 0.5rem;
+    padding-right: 2rem;
+    padding-left: 1.2rem;
   }
 
   ${({ isScrollable }) =>
@@ -111,12 +113,17 @@ export const HeaderLabel = styled.span`
 export const Body = styled.tbody`
   td {
     height: 5.2rem;
-
-    padding: 0 0.5rem;
+    padding: 0 1.2rem;
+    white-space: nowrap;
 
     font-feature-settings: 'tnum';
 
-    min-width: 10rem;
+    ${({ colsLenght }) =>
+      colsLenght &&
+      css`
+        width: calc(100% / ${colsLenght});
+      `};
+    box-sizing: border-box;
 
     &:first-child {
       padding-left: 2rem;
@@ -134,7 +141,6 @@ export const ChildRow = styled(Row)`
     (hasChildren || selectable) &&
     css`
       cursor: pointer;
-      }
     `};
 
   ${({ striped }) =>
@@ -174,8 +180,13 @@ export const BodyRow = styled(ChildRow)`
 
 export const RowHeader = styled.th`
   height: 5.2rem;
-  display: flex;
-  align-items: center;
+
+  /* Avoid cell to grow when the cell's text overflow */
+  max-width: 1px;
+
+  min-width: 20rem;
+  white-space: nowrap;
+  box-sizing: border-box;
 
   ${({ isScrollable }) =>
     isScrollable &&
@@ -190,7 +201,7 @@ export const RowHeader = styled.th`
   white-space: nowrap;
   overflow: hidden;
 
-  padding: 0 0.5rem 0 2rem;
+  padding: 0 1.2rem 0 2rem;
 
   ${({ isChild }) =>
     isChild &&
@@ -198,9 +209,15 @@ export const RowHeader = styled.th`
       padding-left: 4rem;
     `}
 
-  max-width: 30rem;
-  min-width: 15rem;
   background-color: ${({ theme: { palette } }) => palette.white};
+`;
+
+export const TextEllipsis = styled.div`
+  display: inline-block;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  max-width: 100%;
 `;
 
 // Table Footer
@@ -212,6 +229,7 @@ export const Footer = styled.tfoot`
 
   td {
     font-feature-settings: 'tnum';
+    box-sizing: border-box;
   }
 
   th,
@@ -235,7 +253,7 @@ export const Footer = styled.tfoot`
 
     height: 5.2rem;
 
-    padding: 0 0.5rem;
+    padding: 0 1.2rem;
     background-color: ${({ theme: { palette } }) => palette.white};
 
     color: ${({ theme: { palette } }) => palette.primary.default};
@@ -251,11 +269,11 @@ export const Footer = styled.tfoot`
         ${borderRight('5.2rem')}
       `}
 
-    padding: 0 0.5rem 0 2rem;
+    padding: 0 1.2rem 0 2rem;
   }
 
   td:last-of-type {
-    padding: 0 3rem 0 0.5rem;
+    padding: 0 2rem 0 1.2rem;
   }
 
   ${({ isHoverable }) =>

--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -15,6 +15,7 @@ import {
   RowHeader,
   Footer,
   ChildRow,
+  TextEllipsis,
 } from './elements';
 
 /** Lookup object for next sorting direction. */
@@ -193,8 +194,14 @@ class Table extends PureComponent {
       return sortedData;
     };
 
+    // Rule:
+    // first cell count 2 fractions of the table
+    // normal cell count 1 fractions of the table
+    // To calculate the cell width we need to know the column's number and add it one to take care of the first cell which take 2 fractions.
+    const colsLenght = colsDef.length + 1;
+
     return (
-      <Body>
+      <Body colsLenght={colsLenght}>
         {sortData(data).map(({ key, item }, index) => (
           <Fragment key={key}>
             <BodyRow
@@ -218,7 +225,7 @@ class Table extends PureComponent {
                         height="20px"
                       />
                     )}
-                    {value(item, index)}
+                    <TextEllipsis>{value(item, index)}</TextEllipsis>
                   </RowHeader>
                 ) : (
                   <td key={`row-${index}-column-${columnIndex}`} align={align}>
@@ -248,7 +255,7 @@ class Table extends PureComponent {
                             key={`row-header-${key}-${index}`}
                             isChild
                           >
-                            {value(childrenItem, index)}
+                            <TextEllipsis>{value(childrenItem, index)}</TextEllipsis>
                           </RowHeader>
                         ) : (
                           <td key={`row-${index}-column-${key}-${columnIndex}`} align={align}>

--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -253,10 +253,10 @@ class Table extends PureComponent {
     // first cell count 2 fractions of the table
     // normal cell count 1 fractions of the table
     // To calculate the cell width we need to know the column's number and add it one to take care of the first cell which take 2 fractions.
-    const colsLenght = colsDef.length + 1;
+    const colsLength = colsDef.length + 1;
 
     return (
-      <Body colsLenght={colsLenght} ref={this.bodyRef}>
+      <Body colsLength={colsLength} ref={this.bodyRef}>
         {sortData(data).map(({ key, item }, index) => (
           <Fragment key={key}>
             <BodyRow


### PR DESCRIPTION
- [x] Feature
- [ ] Fix
- [ ] Enhancement

## Description
What is already done in that PR :
- changed column width to respect the style guidelines
How that works :
- I check the column's number on the table.
- Add one to the result (because first column take two column width)
- Set column width except first one to `100% / column's number + 1`
- All cell gonna have the same width except the first one which take remaining space (2 columns width)
- First column : To crop text and avoid text overflowing on the other cell I remove `display: flex` attribut which lead to an issue on safari :
<img width="136" alt="Screen Shot 2019-10-31 at 16 02 15" src="https://user-images.githubusercontent.com/16764987/67967186-6e797380-fc05-11e9-8d07-8bcaedd666cf.png">
icon is not aligned anymore

What is need to be done :
- Fix icon alignement issue
- Check on mobile (Sonar) if the preview implementation works
- Remove freshchat logo 
- Don't fill height when table is not long enough
![Screenshot 2019-10-31 at 10 37 13 (1)](https://user-images.githubusercontent.com/16764987/67967615-358dce80-fc06-11e9-8363-aa83c7420eac.png)
- Fix/Add tests
- Add shadows to the table
I already started that point. The way I think the solution :
- To add shadow effect I display a transparent element on to of table content which fit to cells body
- In that element need to add 2 more elements (div or pseudo element) on each side width shadow in it 
- When table content is **scrollY > 0** display **left** shadow
- When table content is **scrollY < max content width** display **right** shadow

## Related / Associated Jira Cards :
>  [BP-434](https://tillersystems.atlassian.net/browse/BP-434?focusedCommentId=14433&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14433)

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
