### PR TITLE
refactor(Table): replace selectable by onClick callback

### DIFF
--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -11,6 +11,8 @@ const TableBody = ({
   data,
   direction,
   handleRowClick,
+  hasClickCallback,
+  hasFoldedRows,
   index,
   isHoverable,
   isScrollable,
@@ -61,7 +63,7 @@ const TableBody = ({
           <BodyRow
             key={key}
             data-testid="body-row"
-            hasChildren={item.children}
+            hasPointerCursor={item.children || (!hasFoldedRows && hasClickCallback)}
             isHoverable={isHoverable}
             isUnfolded={unfoldedRows.includes(key)}
             name={unfoldedRows.includes(key) ? 'chevron-down' : 'chevron-right'}
@@ -95,9 +97,10 @@ const TableBody = ({
                   <ChildRow
                     key={`${key}-${childrenKey}`}
                     data-testid="body-row"
-                    striped={striped}
-                    onClick={() => handleRowClick(childrenItem, `${key}-${childrenKey}`)}
+                    hasPointerCursor={hasClickCallback}
                     isHoverable={isHoverable}
+                    onClick={() => handleRowClick(childrenItem, `${key}-${childrenKey}`)}
+                    striped={striped}
                   >
                     {colsDef.map(({ isRowHeader, value, format, align }, columnIndex) =>
                       isRowHeader ? (
@@ -160,6 +163,8 @@ TableBody.propTypes = {
   data: array.isRequired,
   direction: string,
   handleRowClick: func.isRequired,
+  hasClickCallback: bool.isRequired,
+  hasFoldedRows: bool.isRequired,
   index: number,
   isHoverable: bool,
   isScrollable: bool,

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -10,18 +10,13 @@ const TableBody = ({
   colsDef,
   data,
   direction,
-  handleRowSelect,
+  handleRowClick,
   index,
   isHoverable,
   isScrollable,
-  selectable,
-  selected,
-  selectedRows,
   striped,
+  unfoldedRows,
 }) => {
-  // We actually need to keep track of the original key for sorting purposes
-  // and selection purposes (i.e. when the column is sorted, the selected row
-  // should still be the same).
   const sortData = dataToSort => {
     let sortedData = dataToSort.map((item, key) => {
       return {
@@ -66,19 +61,19 @@ const TableBody = ({
           <BodyRow
             key={key}
             data-testid="body-row"
-            selectable={selectable}
-            selected={selectedRows.includes(key)}
-            striped={striped}
-            onClick={() => handleRowSelect(item, key)}
-            isHoverable={isHoverable}
             hasChildren={item.children}
+            isHoverable={isHoverable}
+            isUnfolded={unfoldedRows.includes(key)}
+            name={unfoldedRows.includes(key) ? 'chevron-down' : 'chevron-right'}
+            onClick={() => handleRowClick(item, key)}
+            striped={striped}
           >
             {colsDef.map(({ isRowHeader, value, format, align }, columnIndex) =>
               isRowHeader ? (
                 <RowHeader align={align} isScrollable={isScrollable} key={`row-header-${index}`}>
                   {item.children && (
                     <Icon
-                      name={selectedRows.includes(key) ? 'chevron-down' : 'chevron-right'}
+                      name={unfoldedRows.includes(key) ? 'chevron-down' : 'chevron-right'}
                       color={Theme.palette.darkBlue}
                       width="20px"
                       height="20px"
@@ -93,17 +88,15 @@ const TableBody = ({
               ),
             )}
           </BodyRow>
-          {selectedRows.includes(key) && (
+          {unfoldedRows.includes(key) && (
             <>
               {item.children &&
                 sortData(item.children).map(({ key: childrenKey, item: childrenItem }, index) => (
                   <ChildRow
                     key={`${key}-${childrenKey}`}
                     data-testid="body-row"
-                    selected={selected === `${key}-${childrenKey}`}
-                    selectable={selectable}
                     striped={striped}
-                    onClick={() => handleRowSelect(item, `${key}-${childrenKey}`)}
+                    onClick={() => handleRowClick(childrenItem, `${key}-${childrenKey}`)}
                     isHoverable={isHoverable}
                   >
                     {colsDef.map(({ isRowHeader, value, format, align }, columnIndex) =>
@@ -166,14 +159,12 @@ TableBody.propTypes = {
   ).isRequired,
   data: array.isRequired,
   direction: string,
-  handleRowSelect: func.isRequired,
+  handleRowClick: func.isRequired,
   index: number,
   isHoverable: bool,
   isScrollable: bool,
-  selectable: bool,
-  selected: number.isRequired,
-  selectedRows: array.isRequired,
   striped: bool,
+  unfoldedRows: array.isRequired,
 };
 
 /** Default props. */
@@ -182,7 +173,6 @@ TableBody.defaultProps = {
   index: -1,
   isHoverable: false,
   isScrollable: false,
-  selectable: false,
   striped: false,
 };
 

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -58,10 +58,10 @@ const TableBody = ({
   // To calculate the cell width we need to know the column's number and add it one to take care of the first cell which take 2 fractions.
   return (
     <Body colsLength={colsDef.length + 1} ref={bodyRef}>
-      {sortData(data).map(({ key, item }, index) => (
-        <Fragment key={key}>
+      {sortData(data).map(({ key, item }, rowIndex) => (
+        <Fragment key={rowIndex}>
           <BodyRow
-            key={key}
+            key={rowIndex}
             data-testid="body-row"
             hasPointerCursor={item.children || (!hasFoldedRows && hasClickCallback)}
             isHoverable={isHoverable}
@@ -72,7 +72,7 @@ const TableBody = ({
           >
             {colsDef.map(({ isRowHeader, value, format, align }, columnIndex) =>
               isRowHeader ? (
-                <RowHeader align={align} isScrollable={isScrollable} key={`row-header-${index}`}>
+                <RowHeader align={align} isScrollable={isScrollable} key={`row-header-${rowIndex}`}>
                   {item.children && (
                     <Icon
                       name={unfoldedRows.includes(key) ? 'chevron-down' : 'chevron-right'}
@@ -81,11 +81,11 @@ const TableBody = ({
                       height="20px"
                     />
                   )}
-                  <TextEllipsis>{value(item, index)}</TextEllipsis>
+                  <TextEllipsis>{value(item, key)}</TextEllipsis>
                 </RowHeader>
               ) : (
-                <td key={`row-${index}-column-${columnIndex}`} align={align}>
-                  {format ? format(value(item, index), index) : value(item, index)}
+                <td key={`row-${rowIndex}-column-${columnIndex}`} align={align}>
+                  {format ? format(value(item, key), key) : value(item, key)}
                 </td>
               ),
             )}
@@ -93,35 +93,45 @@ const TableBody = ({
           {unfoldedRows.includes(key) && (
             <>
               {item.children &&
-                sortData(item.children).map(({ key: childrenKey, item: childrenItem }, index) => (
-                  <ChildRow
-                    key={`${key}-${childrenKey}`}
-                    data-testid="body-row"
-                    hasPointerCursor={hasClickCallback}
-                    isHoverable={isHoverable}
-                    onClick={() => handleRowClick(childrenItem, `${key}-${childrenKey}`)}
-                    striped={striped}
-                  >
-                    {colsDef.map(({ isRowHeader, value, format, align }, columnIndex) =>
-                      isRowHeader ? (
-                        <RowHeader
-                          align={align}
-                          isScrollable={isScrollable}
-                          key={`row-header-${key}-${index}`}
-                          isChild
-                        >
-                          <TextEllipsis>{value(childrenItem, index)}</TextEllipsis>
-                        </RowHeader>
-                      ) : (
-                        <td key={`row-${index}-column-${key}-${columnIndex}`} align={align}>
-                          {format
-                            ? format(value(childrenItem, index), index)
-                            : value(childrenItem, index)}
-                        </td>
-                      ),
-                    )}
-                  </ChildRow>
-                ))}
+                sortData(item.children).map(
+                  ({ key: childrenKey, item: childrenItem }, childRowIndex) => (
+                    <ChildRow
+                      key={`${rowIndex}-${childRowIndex}`}
+                      data-testid="body-row"
+                      hasPointerCursor={hasClickCallback}
+                      isHoverable={isHoverable}
+                      onClick={() => handleRowClick(childrenItem, `${key}-${childrenKey}`)}
+                      striped={striped}
+                    >
+                      {colsDef.map(({ isRowHeader, value, format, align }, columnIndex) =>
+                        isRowHeader ? (
+                          <RowHeader
+                            align={align}
+                            isScrollable={isScrollable}
+                            key={`row-header-${rowIndex}-${childRowIndex}`}
+                            isChild
+                          >
+                            <TextEllipsis>
+                              {value(childrenItem, `${key}-${childrenKey}`)}
+                            </TextEllipsis>
+                          </RowHeader>
+                        ) : (
+                          <td
+                            key={`row-${rowIndex}-${childRowIndex}-column-${columnIndex}`}
+                            align={align}
+                          >
+                            {format
+                              ? format(
+                                  value(childrenItem, `${key}-${childrenKey}`),
+                                  `${key}-${childrenKey}`,
+                                )
+                              : value(childrenItem, `${key}-${childrenKey}`)}
+                          </td>
+                        ),
+                      )}
+                    </ChildRow>
+                  ),
+                )}
             </>
           )}
         </Fragment>

--- a/src/Table/__stories__/Table.stories.js
+++ b/src/Table/__stories__/Table.stories.js
@@ -18,7 +18,7 @@ storiesOf('Table', module)
   .add('default', () => {
     const striped = boolean('Striped', false, 'State');
     const isHoverable = boolean('Hoverable', false, 'State');
-    const selectableRow = boolean('Selectable row', false, 'State');
+    const clickableRow = boolean('Clickable row', false, 'State');
     const dishRowSortable = boolean('Dish row is sortable', true, 'State');
     const priceRowSortable = boolean('Price row is sortable', true, 'State');
     const taxRowSortable = boolean('Tax row is sortable', true, 'State');
@@ -57,8 +57,7 @@ storiesOf('Table', module)
     const onClickAction = action('onClick');
 
     const rowsDef = {
-      selectable: selectableRow,
-      onSelect: (item, key) => onClickAction(JSON.stringify(item), key),
+      ...(clickableRow ? { onClick: (item, key) => onClickAction(JSON.stringify(item), key) } : {}),
     };
 
     const data = [
@@ -163,7 +162,7 @@ storiesOf('Table', module)
 
     const striped = boolean('Striped', false, 'State');
     const isHoverable = boolean('Hoverable', false, 'State');
-    const selectableRow = boolean('Selectable row', false, 'State');
+    const clickableRow = boolean('Clickable row', false, 'State');
 
     const dishRowSortable = boolean('Dish row is sortable', true, 'State');
     const priceRowSortable = boolean('Price row is sortable', true, 'State');
@@ -197,8 +196,7 @@ storiesOf('Table', module)
     const onClickAction = action('onClick');
 
     const rowsDef = {
-      selectable: selectableRow,
-      onSelect: (item, key) => onClickAction(JSON.stringify(item), key),
+      ...(clickableRow ? { onClick: (item, key) => onClickAction(JSON.stringify(item), key) } : {}),
     };
 
     const data = [

--- a/src/Table/__tests__/Table.test.js
+++ b/src/Table/__tests__/Table.test.js
@@ -121,24 +121,10 @@ describe('<Table />', () => {
     expect(bodyRows[2]).not.toHaveStyleRule('background', { modifier: ':nth-child(even)' });
   });
 
-  test('should not have selectable row', () => {
-    const { getAllByTestId } = render(<Table colsDef={getColsDef()} data={data} />);
-
-    const bodyRows = getAllByTestId('body-row');
-
-    expect(bodyRows[0]).not.toHaveStyleRule('cursor');
-
-    // Click on the first body row
-    fireEvent.click(bodyRows[0]);
-
-    expect(bodyRows[0]).not.toHaveStyleRule('box-shadow');
-  });
-
-  test('should have selectable row', () => {
+  test('should have clickable row', () => {
     const spy = jest.fn();
     const rowsDef = {
-      selectable: true,
-      onSelect: spy,
+      onClick: spy,
     };
     const { getAllByTestId } = render(
       <Table colsDef={getColsDef()} rowsDef={rowsDef} data={data} />,
@@ -150,14 +136,6 @@ describe('<Table />', () => {
 
     // Click on the first body row
     fireEvent.click(bodyRows[0]);
-
-    expect(bodyRows[0]).toHaveStyleRule(
-      'box-shadow',
-      `inset 3px 0px 0 0px ${Theme.palette.primary.default}`,
-      {
-        modifier: ':nth-child(1n)',
-      },
-    );
 
     expect(spy).toHaveBeenCalledTimes(1);
   });
@@ -251,7 +229,7 @@ describe('<Table />', () => {
     expect(tableContainer).toHaveStyleRule('overflow', 'scroll');
   });
 
-  test('should table be hoverable', () => {
+  test('should be hoverable', () => {
     const { getByText, getAllByTestId } = render(
       <Table isHoverable height="10rem" colsDef={getColsDef()} data={data} />,
     );
@@ -315,6 +293,14 @@ describe('<Table />', () => {
 
     const children = queryAllByText(/child/i);
     expect(children).toHaveLength(2);
+
+    expect(row).toHaveStyleRule(
+      'box-shadow',
+      `inset 3px 0px 0 0px ${Theme.palette.primary.default}`,
+      {
+        modifier: ':nth-child(1n)',
+      },
+    );
 
     fireEvent.click(row);
 

--- a/src/Table/__tests__/Table.test.js
+++ b/src/Table/__tests__/Table.test.js
@@ -130,12 +130,11 @@ describe('<Table />', () => {
       <Table colsDef={getColsDef()} rowsDef={rowsDef} data={data} />,
     );
 
-    const bodyRows = getAllByTestId('body-row');
+    const [bodyRow] = getAllByTestId('body-row');
 
-    expect(bodyRows[0]).toHaveStyleRule('cursor', 'pointer');
+    expect(bodyRow).toHaveStyleRule('cursor', 'pointer');
 
-    // Click on the first body row
-    fireEvent.click(bodyRows[0]);
+    fireEvent.click(bodyRow);
 
     expect(spy).toHaveBeenCalledTimes(1);
   });
@@ -283,11 +282,11 @@ describe('<Table />', () => {
       },
     ];
 
-    const { getByText, queryAllByText } = render(
+    const { getAllByTestId, queryAllByText } = render(
       <Table height="10rem" colsDef={getColsDef()} data={data} />,
     );
 
-    const row = getByText(/tartare/i);
+    const [row] = getAllByTestId('body-row');
 
     fireEvent.click(row);
 

--- a/src/Table/elements.js
+++ b/src/Table/elements.js
@@ -115,7 +115,7 @@ export const TableHeaderCell = styled.th`
     width: 33%;
     overflow:hidden;
     text-overflow: ellipsis;
-    
+
     ${({ isRowHeader }) =>
       isRowHeader &&
       css`
@@ -172,8 +172,8 @@ export const Body = styled.tbody`
 export const ChildRow = styled(Row)`
   position: relative;
 
-  ${({ hasChildren, selectable }) =>
-    (hasChildren || selectable) &&
+  ${({ areRowsClickable, hasChildren }) =>
+    (areRowsClickable || hasChildren) &&
     css`
       cursor: pointer;
     `};
@@ -184,16 +184,6 @@ export const ChildRow = styled(Row)`
       &:nth-child(even) > th,
       &:nth-child(even) {
         background: ${({ theme: { palette } }) => palette.paleGrey};
-      }
-    `};
-
-  ${({ selected }) =>
-    selected &&
-    css`
-      &:nth-child(1n) > th,
-      &:nth-child(1n) {
-        background: ${({ theme: { palette } }) => palette.veryLightGrey};
-        box-shadow: inset 3px 0px 0 0px ${({ theme: { palette } }) => palette.primary.default};
       }
     `};
 
@@ -211,6 +201,16 @@ export const ChildRow = styled(Row)`
 
 export const BodyRow = styled(ChildRow)`
   font-weight: ${({ theme: { fonts } }) => fonts.weight.thick};
+
+  ${({ isUnfolded }) =>
+    isUnfolded &&
+    css`
+      &:nth-child(1n) > th,
+      &:nth-child(1n) {
+        background: ${({ theme: { palette } }) => palette.veryLightGrey};
+        box-shadow: inset 3px 0px 0 0px ${({ theme: { palette } }) => palette.primary.default};
+      }
+    `};
 `;
 
 export const RowHeader = styled.th`

--- a/src/Table/elements.js
+++ b/src/Table/elements.js
@@ -172,8 +172,8 @@ export const Body = styled.tbody`
 export const ChildRow = styled(Row)`
   position: relative;
 
-  ${({ areRowsClickable, hasChildren }) =>
-    (areRowsClickable || hasChildren) &&
+  ${({ hasPointerCursor }) =>
+    hasPointerCursor &&
     css`
       cursor: pointer;
     `};

--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -29,15 +29,13 @@ const initialSort = {
 class Table extends PureComponent {
   /** Internal state. */
   state = {
+    firstCellWidth: 0,
+    /** Checks if any object from data has a non-empty children value */
+    hasFoldedRows: false,
+    shadowSide: null,
     // Stores which column should be sorted.
     sort: initialSort,
-
-    // Stores selected row.
-    // Use `-1` for no row selected.
-    selected: -1,
-    selectedRows: [],
-    firstCellWidth: 0,
-    shadowSide: null,
+    unfoldedRows: [],
   };
 
   rowHeaderRef = createRef();
@@ -46,6 +44,8 @@ class Table extends PureComponent {
 
   componentDidMount() {
     const { isScrollable } = this.props;
+    this.checkDataDepth();
+
     if (isScrollable) {
       this.setFirstCellWidth();
       addEventListener('resize', this.onResize);
@@ -53,10 +53,14 @@ class Table extends PureComponent {
     }
   }
 
-  componentDidUpdate({ colsDef: prevColsDef }) {
-    const { colsDef } = this.props;
+  componentDidUpdate({ colsDef: prevColsDef, data: prevData }) {
+    const { colsDef, data } = this.props;
+
     if (prevColsDef !== colsDef) {
       this.setState({ sort: initialSort });
+    }
+    if (prevData !== data) {
+      this.checkDataDepth();
     }
     this.onResize();
   }
@@ -115,31 +119,40 @@ class Table extends PureComponent {
   };
 
   /**
-   * Handles click on a row.
+   * Handles click on a row
    *
    * @param {Object} item - The item of the row that was clicked.
    * @param {Number} key - The key of the row that was clicked.
    */
-  handleRowSelect = (item, key) => {
+  handleRowClick = (item, key) => {
+    const { hasFoldedRows, unfoldedRows } = this.state;
     const {
-      rowsDef: { selectable, onSelect },
+      rowsDef: { onClick },
     } = this.props;
-    const { selectedRows } = this.state;
 
-    if (selectable) {
-      this.setState({ selected: key }, () => {
-        if (onSelect) onSelect(item, key);
-      });
-    }
-
-    if (selectable || item.children) {
-      if (selectedRows.includes(key)) {
-        const selectedRowsState = selectedRows.filter(keyItem => keyItem !== key);
-        this.setState({ selectedRows: selectedRowsState });
+    if (hasFoldedRows && item.children) {
+      // row needs to be folded back
+      if (unfoldedRows.includes(key)) {
+        const unfoldedRowsNewState = unfoldedRows.filter(keyItem => keyItem !== key);
+        this.setState({ unfoldedRows: unfoldedRowsNewState });
       } else {
-        this.setState({ selectedRows: [...selectedRows, key] });
+        this.setState({ unfoldedRows: [...unfoldedRows, key] });
       }
+    } else if (onClick && (!hasFoldedRows || typeof key === 'string')) {
+      // row is a "leaf", i.e. at the latest level in the data
+      onClick(item, key);
     }
+  };
+
+  /**
+   * Checks if data has children and needs folding rows.
+   * Helps us getting the proper callback for any row in handleRowClick
+   *
+   */
+  checkDataDepth = () => {
+    const { data } = this.props;
+    const hasFoldedRows = data.find(d => d.children && d.children.length) !== undefined;
+    this.setState({ hasFoldedRows });
   };
 
   /**
@@ -155,16 +168,15 @@ class Table extends PureComponent {
       height,
       isHoverable,
       isScrollable,
-      rowsDef: { selectable },
+      rowsDef: { onClick },
       striped,
       width,
     } = this.props;
     const {
-      selected,
-      selectedRows,
       shadowSide,
       firstCellWidth,
       sort: { index, direction },
+      unfoldedRows,
     } = this.state;
 
     const tableHeaderProps = {
@@ -181,14 +193,13 @@ class Table extends PureComponent {
       colsDef,
       data,
       direction,
-      handleRowSelect: this.handleRowSelect,
+      handleRowClick: this.handleRowClick,
       index,
       isHoverable,
       isScrollable,
-      selectable,
-      selected,
-      selectedRows,
+      onClick,
       striped,
+      unfoldedRows,
     };
 
     const tableFooterProps = {
@@ -270,14 +281,13 @@ Table.propTypes = {
 
   /**
    * Define if the table is isHoverable or not.
-   * When the table is isHoverable if a user hover a row it background change increasing contrast with others improving readability.
+   * On hover of a row, its background color changes, increasing contrast with others and improving readability.
    **/
   isHoverable: bool,
 
   /** Rows definition */
   rowsDef: shape({
-    onSelect: func,
-    selectable: bool,
+    onClick: func,
   }),
 
   /** Whether rows should alternate color or not */
@@ -294,8 +304,7 @@ Table.defaultProps = {
   isScrollable: false,
   isHoverable: false,
   rowsDef: {
-    onSelect: () => {},
-    selectable: false,
+    onClick: null,
   },
   striped: false,
   width: '100%',

--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -173,8 +173,9 @@ class Table extends PureComponent {
       width,
     } = this.props;
     const {
-      shadowSide,
       firstCellWidth,
+      hasFoldedRows,
+      shadowSide,
       sort: { index, direction },
       unfoldedRows,
     } = this.state;
@@ -194,10 +195,11 @@ class Table extends PureComponent {
       data,
       direction,
       handleRowClick: this.handleRowClick,
+      hasClickCallback: !!onClick,
+      hasFoldedRows,
       index,
       isHoverable,
       isScrollable,
-      onClick,
       striped,
       unfoldedRows,
     };


### PR DESCRIPTION
- [ ] Feature
- [ ] Fix
- [x] Enhancement

## Brief
To handle product detail view, the rows need to handle a callback that will allows us to change page. Since selecting a row is not actually used on the Table rn, I've cleaned the code and replace that by what we actually need, i.e. handling click on rows.

## Related / Associated Jira Cards :
>  <!--- [BP-538](https://tillersystems.atlassian.net/browse/BP-538) -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
