### PR TITLE
fix(Table): fix text/icon alignment

### DIFF
--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import compare from '../helpers/compare';
 import { Icon, Theme } from '..';
-import { Body, BodyRow, RowHeader, ChildRow, TextEllipsis } from './elements';
+import { Body, BodyRow, RowHeader, RowHeaderContent, ChildRow, TextEllipsis } from './elements';
 
 const TableBody = ({
   bodyRef,
@@ -73,15 +73,17 @@ const TableBody = ({
             {colsDef.map(({ isRowHeader, value, format, align }, columnIndex) =>
               isRowHeader ? (
                 <RowHeader align={align} isScrollable={isScrollable} key={`row-header-${rowIndex}`}>
-                  {item.children && (
-                    <Icon
-                      name={unfoldedRows.includes(key) ? 'chevron-down' : 'chevron-right'}
-                      color={Theme.palette.darkBlue}
-                      width="20px"
-                      height="20px"
-                    />
-                  )}
-                  <TextEllipsis>{value(item, key)}</TextEllipsis>
+                  <RowHeaderContent>
+                    {item.children && (
+                      <Icon
+                        name={unfoldedRows.includes(key) ? 'chevron-down' : 'chevron-right'}
+                        color={Theme.palette.darkBlue}
+                        width="20px"
+                        height="20px"
+                      />
+                    )}
+                    <TextEllipsis>{value(item, key)}</TextEllipsis>
+                  </RowHeaderContent>
                 </RowHeader>
               ) : (
                 <td key={`row-${rowIndex}-column-${columnIndex}`} align={align}>
@@ -111,9 +113,11 @@ const TableBody = ({
                             key={`row-header-${rowIndex}-${childRowIndex}`}
                             isChild
                           >
-                            <TextEllipsis>
-                              {value(childrenItem, `${key}-${childrenKey}`)}
-                            </TextEllipsis>
+                            <RowHeaderContent>
+                              <TextEllipsis>
+                                {value(childrenItem, `${key}-${childrenKey}`)}
+                              </TextEllipsis>
+                            </RowHeaderContent>
                           </RowHeader>
                         ) : (
                           <td

--- a/src/Table/elements.js
+++ b/src/Table/elements.js
@@ -73,7 +73,7 @@ export const THeader = styled.thead`
 export const TableHeaderCell = styled.th`
   position: relative;
   height: 4.4rem;
-  padding: 0 1.2rem;
+  padding: 0 1.2rem 0 2rem;
   box-sizing: border-box;
   vertical-align: middle;
   border-bottom: 1px solid ${({ theme: { palette } }) => palette.veryLightBlue};
@@ -250,6 +250,11 @@ export const RowHeader = styled.th`
     `}
 
   background-color: ${({ theme: { palette } }) => palette.white};
+`;
+
+export const RowHeaderContent = styled.div`
+  display: flex;
+  align-items: center;
 `;
 
 export const TextEllipsis = styled.div`


### PR DESCRIPTION
- [ ] Feature
- [x] Fix
- [ ] Enhancement

## Description
Fix alignment on table between Icon and text in RowHeader.

I try to find a solution for the iPad scroll issue... I don't reproduce the problem all the time. Weird shit...

Basically, Arthur wanted to reduce the size of the table to avoid that the Freshchat button goes over it. He now prefers to wait until we put it in the TopBar.

## Related / Associated Jira Cards :
>  <!--- [BP-569](https://tillersystems.atlassian.net/browse/BP-569) -->

## How Has This Been Tested?
On Safari iPad (iPad Pro 11 13.3) and Chrome/Safari on desktop

## Todo - Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
