### PR TITLE
fix(Checkbox|Radio|OptionsList): allow value as proptype node

### DIFF
--- a/src/CheckBox/index.js
+++ b/src/CheckBox/index.js
@@ -137,7 +137,7 @@ CheckBox.propTypes = {
   /**
    * The value to be used in the checkbox input. This is the value that will be returned on form submission.
    */
-  value: PropTypes.string,
+  value: PropTypes.node,
 };
 
 /** Default props. */

--- a/src/OptionsList/Options/CheckboxOption.js
+++ b/src/OptionsList/Options/CheckboxOption.js
@@ -19,18 +19,18 @@ const CheckboxOption = ({ className, disabled, isChecked, label, onChange, value
   );
 };
 
-const { array, bool, func, string } = PropTypes;
+const { array, bool, func, node, string } = PropTypes;
 
 /**
  *
  * PropTypes validation
  */
 CheckboxOption.propTypes = {
-  value: string.isRequired,
+  value: node.isRequired,
   className: string,
   disabled: bool,
   isChecked: bool,
-  label: string.isRequired,
+  label: node.isRequired,
   onChange: func.isRequired,
   values: array,
 };

--- a/src/OptionsList/Options/RadioOption.js
+++ b/src/OptionsList/Options/RadioOption.js
@@ -11,7 +11,7 @@ const RadioOption = ({ className, disabled, label, onChange, value, values }) =>
   </OptionElement>
 );
 
-const { array, bool, func, string } = PropTypes;
+const { array, bool, func, node, string } = PropTypes;
 
 /**
  *
@@ -20,9 +20,9 @@ const { array, bool, func, string } = PropTypes;
 RadioOption.propTypes = {
   className: string,
   disabled: bool,
-  label: string.isRequired,
+  label: node.isRequired,
   onChange: func.isRequired,
-  value: string.isRequired,
+  value: node.isRequired,
   values: array.isRequired,
 };
 

--- a/src/OptionsList/Options/SimpleOption.js
+++ b/src/OptionsList/Options/SimpleOption.js
@@ -16,18 +16,18 @@ const SimpleOption = ({ className, disabled, isChecked, label, onChange, value, 
   );
 };
 
-const { array, bool, func, node, oneOfType, string } = PropTypes;
+const { array, bool, func, node, string } = PropTypes;
 
 /**
  *
  * PropTypes validation
  */
 SimpleOption.propTypes = {
-  value: string.isRequired,
+  value: node.isRequired,
   className: string,
   disabled: bool,
   isChecked: bool,
-  label: oneOfType([node, string]).isRequired,
+  label: node.isRequired,
   onChange: func.isRequired,
   values: array,
 };

--- a/src/OptionsList/__stories__/OptionsList.stories.js
+++ b/src/OptionsList/__stories__/OptionsList.stories.js
@@ -16,14 +16,15 @@ const store = new Store({
 });
 
 const options = [
-  { value: 'street-bangkok-bastille', label: 'Street Bangkok Bastille', disabled: false },
-  { value: 'street-bangkok-marais', label: 'Street Bangkok Marais', disabled: false },
-  { value: 'street-bangkok-canal', label: 'Street Bangkok Canal', disabled: false },
-  { value: 'street-bangkok-montorgeuil', label: 'Street Bangkok Montorgeuil', disabled: false },
-  { value: 'street-bangkok-sentier', label: 'Street Bangkok Sentier', disabled: false },
-  { value: 'street-bangkok-st-louis', label: 'Street Bangkok St louis', disabled: false },
-  { value: 'street-bangkok-st-michel', label: 'Street Bangkok St Michel', disabled: false },
-  { value: 'street-bangkok-oberkampf', label: 'Street Bangkok Oberkampf', disabled: false },
+  { value: 0, label: 'Street Bangkok Bastille', disabled: false },
+  { value: 1, label: 'Street Bangkok Bastille', disabled: false },
+  { value: 2, label: 'Street Bangkok Marais', disabled: false },
+  { value: 3, label: 'Street Bangkok Canal', disabled: false },
+  { value: 4, label: 'Street Bangkok Montorgeuil', disabled: false },
+  { value: 5, label: 'Street Bangkok Sentier', disabled: false },
+  { value: 6, label: 'Street Bangkok St louis', disabled: false },
+  { value: 7, label: 'Street Bangkok St Michel', disabled: false },
+  { value: 8, label: 'Street Bangkok Oberkampf', disabled: false },
 ];
 
 storiesOf('OptionsList', module)

--- a/src/RadioGroup/index.js
+++ b/src/RadioGroup/index.js
@@ -98,7 +98,7 @@ RadioGroup.propTypes = {
   onChange: func,
 
   /** Value which pre-select the radio button */
-  selectedValue: string,
+  selectedValue: node,
 };
 
 /** Default props. */


### PR DESCRIPTION
- [x] Fix

## Description
Updated some PropTypes too restrictive.
Use node where string or number or any dom element can be rendered.

## How Has This Been Tested?
Not impacting behaviour

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
