### PR TITLE
feat(Select): reintroduce displayValue props to customize Header

### DIFF
--- a/src/Select/Header.js
+++ b/src/Select/Header.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Children } from 'react';
 import PropTypes from 'prop-types';
 
 import { HeaderButton, HeaderContent } from './elements';
@@ -9,17 +9,17 @@ import { HeaderButton, HeaderContent } from './elements';
  * This component is in charge of displaying
  * a search bar
  *
- * @param {array} values // The currently selected values
- * @param {function} onClick // Callback function called when button is clicked
- * @param {bool} isOpen // When popover is open
- * @param {string} placeholder // Placeholder of button when no value is selected
+ * @param {bool} disabled - If button is disabled
+ * @param {function} onClick - Callback function called when button is clicked
+ * @param {bool} isOpen - When popover is open
+ * @param {string} placeholder - Placeholder of button when no value is selected
+ * @param {node} children - The content of Header
  *
  * @return {jsx}
  */
-const Header = ({ disabled, options, displayValue, values, onClick, isOpen, placeholder }) => {
-  const selectedOptions = values
-    .map(value => options.find(option => option.value === value))
-    .filter(Boolean);
+const Header = ({ disabled, onClick, isOpen, placeholder, children }) => {
+  // Remove empty children to ensure placeholder is display if empty
+  const filteredChildren = Children.toArray(children).filter(Boolean);
 
   return (
     <HeaderButton
@@ -29,42 +29,27 @@ const Header = ({ disabled, options, displayValue, values, onClick, isOpen, plac
       aria-expanded={isOpen}
       data-testid="select-button"
     >
-      <HeaderContent>
-        {displayValue}
-        {!displayValue &&
-          (values.length
-            ? selectedOptions.map(({ value, label }, index) => (
-                <Fragment key={value}>
-                  {index > 0 && ', '}
-                  {label}
-                </Fragment>
-              ))
-            : placeholder)}
-      </HeaderContent>
+      <HeaderContent>{filteredChildren.length ? filteredChildren : placeholder}</HeaderContent>
     </HeaderButton>
   );
 };
 
-const { array, bool, func, node, oneOfType, string } = PropTypes;
+const { bool, func, node, string } = PropTypes;
 
 /** Prop types. */
 Header.propTypes = {
+  children: node,
   disabled: bool,
-  options: array,
   isOpen: bool,
-  values: array,
-  displayValue: oneOfType([node, string]),
   onClick: func.isRequired,
   placeholder: string,
 };
 
 /** Default props. */
 Header.defaultProps = {
+  children: null,
   disabled: false,
   isOpen: false,
-  options: [],
-  values: [],
-  displayValue: null,
   placeholder: '',
 };
 

--- a/src/Select/__stories__/Select.stories.js
+++ b/src/Select/__stories__/Select.stories.js
@@ -141,13 +141,20 @@ storiesOf('Select', module)
     const onToggle = action('onToggle');
     const onChangeAction = action('onChange');
 
-    const HeaderComponent = ({ values, ...rest }) => (
-      <Select.Header
-        displayValue={values.length > 1 ? `${values.length} selected` : null}
-        values={values}
-        {...rest}
-      />
-    );
+    const displayValue = (selected, values, options) =>
+      values.length === options.length ? (
+        <span
+          css={`
+            color: blue;
+          `}
+        >
+          All selected
+        </span>
+      ) : values.length > 1 ? (
+        `${values.length} selected`
+      ) : values.length === 1 ? (
+        selected[0].label
+      ) : null;
 
     const searchMethod = ({ options, term }) => {
       return options.filter(option => option.label.toLowerCase().includes(term.toLowerCase()));
@@ -169,7 +176,7 @@ storiesOf('Select', module)
                 onChangeAction(values);
                 store.set({ values });
               }}
-              HeaderComponent={HeaderComponent}
+              displayValue={displayValue}
               values={state.values}
               placeholder="Select some values"
             >

--- a/src/Select/__tests__/Select.test.js
+++ b/src/Select/__tests__/Select.test.js
@@ -242,13 +242,12 @@ describe('<Select />', () => {
   });
 
   test('should display displayedValue prop', () => {
-    const HeaderComponent = props => (
-      <Select.Header displayValue="The current value is 3" {...props} />
-    );
+    const displayValue = selected =>
+      selected.length ? `The current value is ${selected[0].value}` : 'No value';
 
     const props = {
       values: ['3'],
-      HeaderComponent,
+      displayValue,
     };
 
     const { getByText } = render(


### PR DESCRIPTION
- [x] Feature

## Description
Add a display Value prop to Select (being a function or a node) that can be used to customize the value displayed in Header without overriding the whole header.
Could also enable customizing HeaderComponent without touching the display logic.

## How Has This Been Tested?
Tests and Storybook updated

## Requirements :
<!--- Eventually remove the following. -->
:warning: Requires running `yarn` command.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
