### PR TITLE
fix(Select): multiple fixes

### DIFF
--- a/src/Select/__tests__/__snapshots__/Select.test.js.snap
+++ b/src/Select/__tests__/__snapshots__/Select.test.js.snap
@@ -19,7 +19,7 @@ exports[`<Select /> should render without a problem 1`] = `
   height: 100%;
   width: 100%;
   position: relative;
-  padding: 0 2rem 0 1.6rem;
+  padding: 0 2.4rem 0 1.6rem;
   cursor: pointer;
   text-align: left;
   font-size: 1.4rem;
@@ -120,7 +120,7 @@ exports[`<Select /> should render without a problem when disabled 1`] = `
   height: 100%;
   width: 100%;
   position: relative;
-  padding: 0 2rem 0 1.6rem;
+  padding: 0 2.4rem 0 1.6rem;
   cursor: pointer;
   text-align: left;
   font-size: 1.4rem;

--- a/src/Select/elements.js
+++ b/src/Select/elements.js
@@ -6,7 +6,7 @@ export const HeaderButton = styled.button`
   height: 100%;
   width: 100%;
   position: relative;
-  padding: 0 2rem 0 1.6rem;
+  padding: 0 2.4rem 0 1.6rem;
   cursor: pointer;
   text-align: left;
   font-size: ${({ theme: { fonts } }) => fonts.size.medium};

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -203,7 +203,7 @@ class Select extends PureComponent {
     const { contentWidth } = this.state;
 
     const isOpen = this.getControllableValue('isOpen');
-    const values = this.getControllableValue('values');
+    const values = this.getControllableValue('values') || [];
 
     const Header = HeaderComponent || DefaultHeader;
     const selectOptions = options || transformChildrenToOptions(children);


### PR DESCRIPTION
- [x] Fix

## Description
After reducing padding, text occurs to sometimes "touch" the arrows.
* Increase padding a bit to avoid that behaviour
* Also, give a default values if not provided to avoid TypeError when values is not an array