### PR TITLE
fix(Modal): added className and zIndex to container

### DIFF
--- a/src/Modal/elements.js
+++ b/src/Modal/elements.js
@@ -11,7 +11,7 @@ export const Container = styled(motion.div)`
   bottom: 0;
   left: 0;
   right: 0;
-
+  z-index: 100;
   width: 100%;
 
   /* For small mobile devices */

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -33,12 +33,13 @@ class Modal extends PureComponent {
    * Render function
    */
   render() {
-    const { active, width, height, padding, onOverlayClick, children } = this.props;
+    const { className, active, width, height, padding, onOverlayClick, children } = this.props;
     return (
       <Portal>
         <AnimatePresence>
           {active && (
             <Container
+              className={className}
               key="Container"
               initial="hidden"
               animate="visible"
@@ -83,6 +84,11 @@ Modal.propTypes = {
   children: node,
 
   /**
+   * Classname of Modal container
+   */
+  className: string,
+
+  /**
    * Modal height
    */
   height: string,
@@ -109,6 +115,7 @@ Modal.propTypes = {
 Modal.defaultProps = {
   active: false,
   children: null,
+  className: null,
   height: '39rem',
   onOverlayClick: () => {},
   padding: Theme.dimensions.medium,


### PR DESCRIPTION
- [x] Fix

## Description
Modal container had no z-index, and did not allow passing a className to override container's style, making some absolute/sticky elements to be above the overlay or modal container.

Added a default z-index of 100 (position: fixed  defines the base z-index of all children), and accept className Props if needed.

## How Has This Been Tested?
No changes in tests
## Requirements :
<!--- Eventually remove the following. -->
:warning: Requires running `yarn` command.

## Todo - Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
