### PR TITLE
fix(CI): Adding apt update to avoid apk break

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ references:
   install_pip: &install_pip
     run:
       name: Installing pip
-      command: sudo apt-get install python-pip
+      command: sudo apt-get update && sudo apt-get install python-pip
 
   install_awscli: &install_awscli
     run:


### PR DESCRIPTION
- [x] Fix

## Brief
Trying to fix CD deploy step by adding `apt-get update` process to avoid 404 errors 

